### PR TITLE
fix: keep the desktop renderer alive on x86-64 CPUs without AVX

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -4042,16 +4042,28 @@ fn cpu_supports_avx() -> bool {
     true
 }
 
-/// Whether `WASM_OSR_ENTRY_JSC_OPTIONS` has to be pinned off, given whether the
-/// CPU supports AVX and whether either option already carries an explicit
-/// value. The two options are one decision, not two: leaving half the pair
-/// applied costs WebAssembly performance without keeping the renderer alive, so
-/// an explicit value on either one takes the whole workaround out of GeoLibre's
-/// hands. That is also the escape hatch, for turning the workaround off or for
-/// pinning `JSC_useBBQJIT=false` instead.
+/// Whether an explicit value for one of `WASM_OSR_ENTRY_JSC_OPTIONS` leaves it
+/// off. JavaScriptCore reads `false` and `0` case-insensitively and keeps the
+/// option enabled for anything else, including values it cannot parse, so
+/// answer the way it does rather than treating "set" as "off".
 #[cfg(target_os = "linux")]
-fn linux_needs_wasm_osr_workaround(cpu_supports_avx: bool, already_configured: bool) -> bool {
-    !cpu_supports_avx && !already_configured
+fn jsc_option_is_off(value: &std::ffi::OsStr) -> bool {
+    value
+        .to_str()
+        .is_some_and(|value| value.eq_ignore_ascii_case("false") || value == "0")
+}
+
+/// Whether `WASM_OSR_ENTRY_JSC_OPTIONS` has to be pinned off, given whether the
+/// CPU supports AVX and whether either option is explicitly *on*. The two are
+/// one decision, not two: leaving half the pair applied costs WebAssembly
+/// performance without keeping the renderer alive. So an option somebody has
+/// already turned off is fine to build on (the other half still gets applied),
+/// while an option somebody has turned on is the escape hatch and takes the
+/// whole workaround out of GeoLibre's hands, as does pinning `JSC_useBBQJIT`
+/// instead.
+#[cfg(target_os = "linux")]
+fn linux_needs_wasm_osr_workaround(cpu_supports_avx: bool, opted_out: bool) -> bool {
+    !cpu_supports_avx && !opted_out
 }
 
 #[cfg(target_os = "linux")]
@@ -4102,24 +4114,26 @@ fn configure_linux_webkit() {
     // breakpointing the trampoline in the web process: with both options off it
     // is never entered, with either one on it still is.
     let cpu_supports_avx = cpu_supports_avx();
-    let preset = WASM_OSR_ENTRY_JSC_OPTIONS
+    let kept_on = WASM_OSR_ENTRY_JSC_OPTIONS
         .into_iter()
-        .find(|option| std::env::var_os(option).is_some());
-    if linux_needs_wasm_osr_workaround(cpu_supports_avx, preset.is_some()) {
+        .find(|option| std::env::var_os(option).is_some_and(|value| !jsc_option_is_off(&value)));
+    if linux_needs_wasm_osr_workaround(cpu_supports_avx, kept_on.is_some()) {
         for option in WASM_OSR_ENTRY_JSC_OPTIONS {
-            std::env::set_var(option, "false");
+            if std::env::var_os(option).is_none() {
+                std::env::set_var(option, "false");
+            }
         }
         eprintln!(
             "GeoLibre: this CPU has no AVX, so WebAssembly tier-up would crash the WebKit \
-             renderer (see GeoLibre issue 2087). Pinned {} off to keep the app running; \
+             renderer (see GeoLibre issue 2087). {} are off to keep the app running; \
              WebAssembly-heavy work will be slower.",
             WASM_OSR_ENTRY_JSC_OPTIONS.join(" and ")
         );
     } else if !cpu_supports_avx {
-        if let Some(option) = preset {
+        if let Some(option) = kept_on {
             eprintln!(
-                "GeoLibre: this CPU has no AVX, but {option} is already set, so the WebAssembly \
-                 tier-up workaround for GeoLibre issue 2087 was left alone. The renderer can \
+                "GeoLibre: this CPU has no AVX, but {option} is set to keep WebAssembly tier-up \
+                 on, so the workaround for GeoLibre issue 2087 was left alone. The renderer can \
                  still die with SIGILL unless {} are both off.",
                 WASM_OSR_ENTRY_JSC_OPTIONS.join(" and ")
             );
@@ -4146,8 +4160,8 @@ mod tests {
     };
     #[cfg(target_os = "linux")]
     use super::{
-        cpu_supports_avx, linux_needs_wasm_osr_workaround, linux_uses_nvidia_renderer,
-        nvidia_is_primary_gpu, WASM_OSR_ENTRY_JSC_OPTIONS,
+        cpu_supports_avx, jsc_option_is_off, linux_needs_wasm_osr_workaround,
+        linux_uses_nvidia_renderer, nvidia_is_primary_gpu, WASM_OSR_ENTRY_JSC_OPTIONS,
     };
     // Everything these imports feed is compiled out of the `mas` build, so the
     // tests that exercise it (and their scaffolding) are gated with it.
@@ -4294,14 +4308,30 @@ mod tests {
         assert!(!linux_needs_wasm_osr_workaround(true, false));
     }
 
-    // An explicit value on either option is the user's escape hatch, in both
-    // directions, and it takes the whole pair out of GeoLibre's hands: half the
-    // workaround costs WebAssembly performance without saving the renderer.
+    // Turning either option back on is the escape hatch, and it takes the whole
+    // pair out of GeoLibre's hands: half the workaround costs WebAssembly
+    // performance without saving the renderer.
     #[cfg(all(target_os = "linux", not(feature = "mas")))]
     #[test]
     fn keeps_an_explicit_wasm_osr_setting() {
         assert!(!linux_needs_wasm_osr_workaround(false, true));
         assert!(!linux_needs_wasm_osr_workaround(true, true));
+    }
+
+    // An option someone already turned off is not an opt-out, so the other half
+    // of the pair still gets applied. Which values count as off is
+    // JavaScriptCore's rule, measured on WebKitGTK 2.52.6: `false` and `0` in
+    // any case disable an option, and everything else, including a value it
+    // cannot parse, leaves it enabled.
+    #[cfg(all(target_os = "linux", not(feature = "mas")))]
+    #[test]
+    fn reads_wasm_osr_values_the_way_javascriptcore_does() {
+        for off in ["false", "FALSE", "0"] {
+            assert!(jsc_option_is_off(OsStr::new(off)), "{off}");
+        }
+        for on in ["true", "TRUE", "1", "yes", "garbage", ""] {
+            assert!(!jsc_option_is_off(OsStr::new(on)), "{on}");
+        }
     }
 
     // Both options are needed: with either one left on, the web process still

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -4019,6 +4019,42 @@ fn linux_uses_nvidia_renderer(
         || nvidia_is_primary_gpu(drm_root)
 }
 
+/// JavaScriptCore options that keep WebKitGTK's WebAssembly tier-up off its
+/// OSR-entry path (see `configure_linux_webkit`). Both are needed: the first
+/// covers OSR entry out of the WebAssembly interpreter, the second the loop
+/// tier-up checks the baseline (BBQ) JIT emits. Leaving either on still
+/// reaches the trampoline.
+#[cfg(target_os = "linux")]
+const WASM_OSR_ENTRY_JSC_OPTIONS: [&str; 2] = ["JSC_useWasmOSR", "JSC_useBBQTierUpChecks"];
+
+/// Whether this CPU implements AVX. The trampoline behind GeoLibre#2087 is
+/// x86-only, so every other architecture answers yes and skips the workaround.
+#[cfg(all(target_os = "linux", any(target_arch = "x86", target_arch = "x86_64")))]
+fn cpu_supports_avx() -> bool {
+    std::arch::is_x86_feature_detected!("avx")
+}
+
+#[cfg(all(
+    target_os = "linux",
+    not(any(target_arch = "x86", target_arch = "x86_64"))
+))]
+fn cpu_supports_avx() -> bool {
+    true
+}
+
+/// Whether one of `WASM_OSR_ENTRY_JSC_OPTIONS` has to be pinned off, given
+/// whether the CPU supports AVX and what the option is already set to. An
+/// explicit user/distributor value always wins, so an option that is already
+/// set is left alone (that is also the escape hatch for turning the workaround
+/// off, or for pinning `JSC_useBBQJIT=false` instead).
+#[cfg(target_os = "linux")]
+fn linux_needs_wasm_osr_workaround(
+    cpu_supports_avx: bool,
+    existing: Option<&std::ffi::OsStr>,
+) -> bool {
+    !cpu_supports_avx && existing.is_none()
+}
+
 #[cfg(target_os = "linux")]
 fn configure_linux_webkit() {
     // WebKitGTK's DMABUF renderer could fail to allocate GBM buffers on older
@@ -4050,6 +4086,39 @@ fn configure_linux_webkit() {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
     }
+    // WebAssembly tier-up kills the renderer on x86-64 CPUs without AVX
+    // (GeoLibre#2087). When a loop inside a WebAssembly function gets hot,
+    // JavaScriptCore performs OSR entry into a JIT tier, and that path runs
+    // `ctiMasmProbeTrampoline`, which spills xmm0-xmm15 with VEX-encoded
+    // `vmovaps` and no runtime AVX check. On a CPU without AVX the first of
+    // those instructions raises SIGILL, the WebKitWebProcess dies, and the
+    // window stays blank forever with nothing shown to the user. It is an
+    // upstream WebKit bug that no GeoLibre code can avoid emitting, and it is
+    // reached in normal use because the app runs WebAssembly (DuckDB-WASM,
+    // Whitebox) in a worker. All we can do is keep JavaScriptCore off the OSR
+    // entry path. WebAssembly still gets baseline-compiled when a function is
+    // called repeatedly, so the cost is bounded (a few times slower on repeated
+    // calls; a single long-running call with a hot loop stays interpreted)
+    // instead of the app being unusable. Verified against WebKitGTK 2.52.6 by
+    // breakpointing the trampoline in the web process: with both options off it
+    // is never entered, with either one on it still is.
+    let cpu_supports_avx = cpu_supports_avx();
+    let mut disabled_for_avx = Vec::new();
+    for option in WASM_OSR_ENTRY_JSC_OPTIONS {
+        if linux_needs_wasm_osr_workaround(cpu_supports_avx, std::env::var_os(option).as_deref()) {
+            std::env::set_var(option, "false");
+            disabled_for_avx.push(option);
+        }
+    }
+    if !disabled_for_avx.is_empty() {
+        eprintln!(
+            "GeoLibre: this CPU has no AVX, so WebAssembly tier-up would crash the WebKit \
+             renderer (see GeoLibre issue 2087). Disabled {} to keep the app running; \
+             WebAssembly-heavy work will be slower.",
+            disabled_for_avx.join(" and ")
+        );
+    }
+
     // Prefer portal-backed native dialogs on Linux. This avoids GTK/GIO file
     // metadata warnings that can appear around file and folder pickers.
     if std::env::var_os("GTK_USE_PORTAL").is_none() {
@@ -4069,7 +4138,10 @@ mod tests {
         tcp_table_port, MAX_FETCH_TIMEOUT_SECS, REMOTE_TILE_TIMEOUT_SECS, SSRF_BLOCKED_MESSAGE,
     };
     #[cfg(target_os = "linux")]
-    use super::{linux_uses_nvidia_renderer, nvidia_is_primary_gpu};
+    use super::{
+        cpu_supports_avx, linux_needs_wasm_osr_workaround, linux_uses_nvidia_renderer,
+        nvidia_is_primary_gpu, WASM_OSR_ENTRY_JSC_OPTIONS,
+    };
     // Everything these imports feed is compiled out of the `mas` build, so the
     // tests that exercise it (and their scaffolding) are gated with it.
     #[cfg(not(feature = "mas"))]
@@ -4203,6 +4275,62 @@ mod tests {
             Some(OsStr::new("0")),
             Some(OsStr::new("mesa")),
         ));
+    }
+
+    // Regression for issue #2087: on an x86-64 CPU without AVX, WebKitGTK's
+    // WebAssembly OSR entry runs an unconditionally AVX trampoline and takes
+    // the renderer down with SIGILL, so both options have to be pinned off.
+    #[cfg(all(target_os = "linux", not(feature = "mas")))]
+    #[test]
+    fn disables_wasm_osr_entry_only_without_avx() {
+        assert!(linux_needs_wasm_osr_workaround(false, None));
+        assert!(!linux_needs_wasm_osr_workaround(true, None));
+    }
+
+    // An explicit value is the user's escape hatch, in both directions, so it
+    // is never overwritten.
+    #[cfg(all(target_os = "linux", not(feature = "mas")))]
+    #[test]
+    fn keeps_an_explicit_wasm_osr_setting() {
+        assert!(!linux_needs_wasm_osr_workaround(
+            false,
+            Some(OsStr::new("true"))
+        ));
+        assert!(!linux_needs_wasm_osr_workaround(
+            false,
+            Some(OsStr::new("false"))
+        ));
+    }
+
+    // Both options are needed: with either one left on, the web process still
+    // enters the trampoline (measured on WebKitGTK 2.52.6). They are read by
+    // JavaScriptCore straight out of the environment, so the names carry the
+    // `JSC_` prefix.
+    #[cfg(all(target_os = "linux", not(feature = "mas")))]
+    #[test]
+    fn pins_both_javascriptcore_wasm_osr_options() {
+        assert_eq!(
+            WASM_OSR_ENTRY_JSC_OPTIONS,
+            ["JSC_useWasmOSR", "JSC_useBBQTierUpChecks"]
+        );
+    }
+
+    // Every architecture other than x86 skips the workaround, and the x86
+    // answer has to come from the running CPU rather than from build flags.
+    #[cfg(all(target_os = "linux", not(feature = "mas")))]
+    #[test]
+    fn reports_avx_support_for_this_cpu() {
+        let supported = cpu_supports_avx();
+        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
+            let flags = std::fs::read_to_string("/proc/cpuinfo").unwrap_or_default();
+            let advertised = flags
+                .lines()
+                .filter(|line| line.starts_with("flags"))
+                .any(|line| line.split_whitespace().any(|flag| flag == "avx"));
+            assert_eq!(supported, advertised);
+        } else {
+            assert!(supported);
+        }
     }
 
     // Regression for issue #1223: installed builds place the bundled sidecar at

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -4042,17 +4042,16 @@ fn cpu_supports_avx() -> bool {
     true
 }
 
-/// Whether one of `WASM_OSR_ENTRY_JSC_OPTIONS` has to be pinned off, given
-/// whether the CPU supports AVX and what the option is already set to. An
-/// explicit user/distributor value always wins, so an option that is already
-/// set is left alone (that is also the escape hatch for turning the workaround
-/// off, or for pinning `JSC_useBBQJIT=false` instead).
+/// Whether `WASM_OSR_ENTRY_JSC_OPTIONS` has to be pinned off, given whether the
+/// CPU supports AVX and whether either option already carries an explicit
+/// value. The two options are one decision, not two: leaving half the pair
+/// applied costs WebAssembly performance without keeping the renderer alive, so
+/// an explicit value on either one takes the whole workaround out of GeoLibre's
+/// hands. That is also the escape hatch, for turning the workaround off or for
+/// pinning `JSC_useBBQJIT=false` instead.
 #[cfg(target_os = "linux")]
-fn linux_needs_wasm_osr_workaround(
-    cpu_supports_avx: bool,
-    existing: Option<&std::ffi::OsStr>,
-) -> bool {
-    !cpu_supports_avx && existing.is_none()
+fn linux_needs_wasm_osr_workaround(cpu_supports_avx: bool, already_configured: bool) -> bool {
+    !cpu_supports_avx && !already_configured
 }
 
 #[cfg(target_os = "linux")]
@@ -4103,20 +4102,28 @@ fn configure_linux_webkit() {
     // breakpointing the trampoline in the web process: with both options off it
     // is never entered, with either one on it still is.
     let cpu_supports_avx = cpu_supports_avx();
-    let mut disabled_for_avx = Vec::new();
-    for option in WASM_OSR_ENTRY_JSC_OPTIONS {
-        if linux_needs_wasm_osr_workaround(cpu_supports_avx, std::env::var_os(option).as_deref()) {
+    let preset = WASM_OSR_ENTRY_JSC_OPTIONS
+        .into_iter()
+        .find(|option| std::env::var_os(option).is_some());
+    if linux_needs_wasm_osr_workaround(cpu_supports_avx, preset.is_some()) {
+        for option in WASM_OSR_ENTRY_JSC_OPTIONS {
             std::env::set_var(option, "false");
-            disabled_for_avx.push(option);
         }
-    }
-    if !disabled_for_avx.is_empty() {
         eprintln!(
             "GeoLibre: this CPU has no AVX, so WebAssembly tier-up would crash the WebKit \
-             renderer (see GeoLibre issue 2087). Disabled {} to keep the app running; \
+             renderer (see GeoLibre issue 2087). Pinned {} off to keep the app running; \
              WebAssembly-heavy work will be slower.",
-            disabled_for_avx.join(" and ")
+            WASM_OSR_ENTRY_JSC_OPTIONS.join(" and ")
         );
+    } else if !cpu_supports_avx {
+        if let Some(option) = preset {
+            eprintln!(
+                "GeoLibre: this CPU has no AVX, but {option} is already set, so the WebAssembly \
+                 tier-up workaround for GeoLibre issue 2087 was left alone. The renderer can \
+                 still die with SIGILL unless {} are both off.",
+                WASM_OSR_ENTRY_JSC_OPTIONS.join(" and ")
+            );
+        }
     }
 
     // Prefer portal-backed native dialogs on Linux. This avoids GTK/GIO file
@@ -4283,23 +4290,18 @@ mod tests {
     #[cfg(all(target_os = "linux", not(feature = "mas")))]
     #[test]
     fn disables_wasm_osr_entry_only_without_avx() {
-        assert!(linux_needs_wasm_osr_workaround(false, None));
-        assert!(!linux_needs_wasm_osr_workaround(true, None));
+        assert!(linux_needs_wasm_osr_workaround(false, false));
+        assert!(!linux_needs_wasm_osr_workaround(true, false));
     }
 
-    // An explicit value is the user's escape hatch, in both directions, so it
-    // is never overwritten.
+    // An explicit value on either option is the user's escape hatch, in both
+    // directions, and it takes the whole pair out of GeoLibre's hands: half the
+    // workaround costs WebAssembly performance without saving the renderer.
     #[cfg(all(target_os = "linux", not(feature = "mas")))]
     #[test]
     fn keeps_an_explicit_wasm_osr_setting() {
-        assert!(!linux_needs_wasm_osr_workaround(
-            false,
-            Some(OsStr::new("true"))
-        ));
-        assert!(!linux_needs_wasm_osr_workaround(
-            false,
-            Some(OsStr::new("false"))
-        ));
+        assert!(!linux_needs_wasm_osr_workaround(false, true));
+        assert!(!linux_needs_wasm_osr_workaround(true, true));
     }
 
     // Both options are needed: with either one left on, the web process still
@@ -4321,15 +4323,18 @@ mod tests {
     #[test]
     fn reports_avx_support_for_this_cpu() {
         let supported = cpu_supports_avx();
-        if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-            let flags = std::fs::read_to_string("/proc/cpuinfo").unwrap_or_default();
-            let advertised = flags
-                .lines()
-                .filter(|line| line.starts_with("flags"))
-                .any(|line| line.split_whitespace().any(|flag| flag == "avx"));
-            assert_eq!(supported, advertised);
-        } else {
+        if !cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
             assert!(supported);
+            return;
+        }
+        // Cross-check against the kernel where it reports the flags. A
+        // hypervisor can mask them, and a restricted /proc need not carry a
+        // `flags` line at all, so a missing line means "nothing to compare",
+        // not a failure.
+        let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").unwrap_or_default();
+        let mut flag_lines = cpuinfo.lines().filter(|line| line.starts_with("flags"));
+        if let Some(flags) = flag_lines.next() {
+            assert_eq!(supported, flags.split_whitespace().any(|flag| flag == "avx"));
         }
     }
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -4043,14 +4043,15 @@ fn cpu_supports_avx() -> bool {
 }
 
 /// Whether an explicit value for one of `WASM_OSR_ENTRY_JSC_OPTIONS` leaves it
-/// off. JavaScriptCore reads `false` and `0` case-insensitively and keeps the
-/// option enabled for anything else, including values it cannot parse, so
-/// answer the way it does rather than treating "set" as "off".
+/// off. JavaScriptCore reads `false`, `no` (either in any case) and `0` as off
+/// and `true`, `yes` and `1` as on, and keeps the option's default, which for
+/// both of these is on, for anything it cannot parse. Answer the way it does
+/// rather than treating "set" as "off".
 #[cfg(target_os = "linux")]
 fn jsc_option_is_off(value: &std::ffi::OsStr) -> bool {
-    value
-        .to_str()
-        .is_some_and(|value| value.eq_ignore_ascii_case("false") || value == "0")
+    value.to_str().is_some_and(|value| {
+        value.eq_ignore_ascii_case("false") || value.eq_ignore_ascii_case("no") || value == "0"
+    })
 }
 
 /// Whether `WASM_OSR_ENTRY_JSC_OPTIONS` has to be pinned off, given whether the
@@ -4320,16 +4321,17 @@ mod tests {
 
     // An option someone already turned off is not an opt-out, so the other half
     // of the pair still gets applied. Which values count as off is
-    // JavaScriptCore's rule, measured on WebKitGTK 2.52.6: `false` and `0` in
-    // any case disable an option, and everything else, including a value it
-    // cannot parse, leaves it enabled.
+    // JavaScriptCore's rule, verified against WebKitGTK 2.52.6: `false` and
+    // `no` in any case, and `0`, disable an option; `true`, `yes` and `1` turn
+    // it on; and a value it cannot parse leaves the default, which for both of
+    // these options is on.
     #[cfg(all(target_os = "linux", not(feature = "mas")))]
     #[test]
     fn reads_wasm_osr_values_the_way_javascriptcore_does() {
-        for off in ["false", "FALSE", "0"] {
+        for off in ["false", "FALSE", "False", "no", "NO", "No", "0"] {
             assert!(jsc_option_is_off(OsStr::new(off)), "{off}");
         }
-        for on in ["true", "TRUE", "1", "yes", "garbage", ""] {
+        for on in ["true", "TRUE", "1", "yes", "YES", "garbage", ""] {
             assert!(!jsc_option_is_off(OsStr::new(on)), "{on}");
         }
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -801,13 +801,21 @@ that trampoline. WebAssembly still runs and is still baseline compiled, so the
 cost is bounded: on WebKitGTK 2.52.6 a DuckDB-WASM query took about 2x longer,
 against 34x with the WebAssembly JIT disabled outright.
 
-A value you set yourself always wins over the automatic one, so you can turn
-the workaround off with `JSC_useWasmOSR=true`, or, if a renderer crash
-persists, fall back to disabling the WebAssembly JIT entirely:
+The two options only work as a pair, so GeoLibre treats them as one decision:
+setting either one yourself takes the whole workaround out of its hands, and
+whatever you set is what runs. To turn the workaround off:
+
+```bash
+JSC_useWasmOSR=true JSC_useBBQTierUpChecks=true geolibre
+```
+
+Or, if a renderer crash persists, fall back to disabling the WebAssembly JIT
+entirely:
 
 ```bash
 JSC_useBBQJIT=false geolibre
 ```
 
-None of this applies to CPUs with AVX (every x86-64 part since roughly 2011) or
-to arm64 machines, which never reach that code.
+The check is a runtime CPU feature test, not a model or release-date list, so
+machines that do have AVX are untouched, as are arm64 machines, which never
+reach that code.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -774,3 +774,40 @@ conversions), the dialog falls back to it automatically when the sidecar or its
 extra is unavailable. See [Processing Tools](user-guide/processing.md) for what
 each engine does, and [AI Segmentation](user-guide/segmentation.md) for the
 separate `samgeo-api` model server.
+
+## Linux desktop troubleshooting
+
+### A blank window on a CPU without AVX
+
+On x86-64 CPUs with no AVX (Intel Celeron and Pentium N-series, Atom, and
+anything older than Sandy Bridge), WebKitGTK can kill its own renderer as soon
+as GeoLibre puts WebAssembly to work, leaving a window that never paints.
+The crash is a `SIGILL` in `WebKitWebProcess`: JavaScriptCore's WebAssembly
+tier-up runs a hand-written trampoline that spills the XMM registers with AVX
+instructions without checking whether the CPU has them
+([issue 2087](https://github.com/opengeos/GeoLibre/issues/2087)).
+
+The desktop app works around this on its own. On Linux it checks for AVX at
+startup, and on a CPU without it pins two JavaScriptCore options off before the
+web process starts:
+
+```bash
+JSC_useWasmOSR=false
+JSC_useBBQTierUpChecks=false
+```
+
+Both are needed; together they keep WebAssembly off the tier-up path that runs
+that trampoline. WebAssembly still runs and is still baseline compiled, so the
+cost is bounded: on WebKitGTK 2.52.6 a DuckDB-WASM query took about 2x longer,
+against 34x with the WebAssembly JIT disabled outright.
+
+A value you set yourself always wins over the automatic one, so you can turn
+the workaround off with `JSC_useWasmOSR=true`, or, if a renderer crash
+persists, fall back to disabling the WebAssembly JIT entirely:
+
+```bash
+JSC_useBBQJIT=false geolibre
+```
+
+None of this applies to CPUs with AVX (every x86-64 part since roughly 2011) or
+to arm64 machines, which never reach that code.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -801,13 +801,16 @@ that trampoline. WebAssembly still runs and is still baseline compiled, so the
 cost is bounded: on WebKitGTK 2.52.6 a DuckDB-WASM query took about 2x longer,
 against 34x with the WebAssembly JIT disabled outright.
 
-The two options only work as a pair, so GeoLibre treats them as one decision:
-setting either one yourself takes the whole workaround out of its hands, and
-whatever you set is what runs. To turn the workaround off:
+The two options only work as a pair, so GeoLibre treats them as one decision.
+Turning either one back on is the opt-out and leaves both alone:
 
 ```bash
-JSC_useWasmOSR=true JSC_useBBQTierUpChecks=true geolibre
+JSC_useWasmOSR=true geolibre
 ```
+
+Setting one of them to `false` yourself is not an opt-out: GeoLibre keeps your
+value and still applies the other half, since half the workaround costs
+WebAssembly performance without keeping the renderer alive.
 
 Or, if a renderer crash persists, fall back to disabling the WebAssembly JIT
 entirely:


### PR DESCRIPTION
Fixes #2087.

## What was happening

On x86-64 CPUs without AVX, WebKitGTK kills its own web process with `SIGILL`
a few seconds after GeoLibre starts doing work, so the desktop window never
paints and nothing is reported to the user.

The faulting instruction is in JavaScriptCore's `ctiMasmProbeTrampoline`, which
spills `xmm0`-`xmm15` with VEX-encoded `vmovaps` and never checks whether the
CPU implements AVX. GeoLibre reaches it in normal use because it runs
WebAssembly (DuckDB-WASM, Whitebox) in a worker, and the trampoline sits on
JavaScriptCore's WebAssembly OSR-entry path: as soon as a loop inside a
WebAssembly function gets hot, the tier-up goes through it. The bug is
upstream WebKit's; no GeoLibre code emits that instruction, so all we can do is
keep JavaScriptCore off that path.

## The fix

`configure_linux_webkit()` (the same place the DMABUF and portal defaults are
set) now checks for AVX at startup and, when it is missing, pins two
JavaScriptCore options off before the web process starts:

```
JSC_useWasmOSR=false
JSC_useBBQTierUpChecks=false
```

Both are needed. The first covers OSR entry out of the WebAssembly
interpreter, the second the loop tier-up checks the baseline (BBQ) JIT emits;
with either one left on, the web process still enters the trampoline.
WebAssembly still runs and is still baseline compiled, so the cost is bounded.
An explicit user or distributor value always wins, which doubles as the escape
hatch in both directions.

Machines with AVX (every x86-64 part since roughly 2011) and non-x86
architectures are untouched: the workaround is gated on a runtime AVX check.

## How this was verified

WebKitGTK 2.52.6, the same version as the report. The web process was driven
under gdb with a breakpoint at the trampoline's first `vmovaps` (offset
`0x4fedb4` in `libjavascriptcoregtk-4.1.so.0.10.14`, byte-identical to the
binary in the report), so "does this configuration reach the crashing
instruction" is measured, not inferred. Both the reporter's minimal WebAssembly
reproducer and a real DuckDB-WASM workload (8M-row table build plus an
aggregate, run in a Web Worker, from this repo's bundled
`@duckdb/duckdb-wasm`) were used.

| Configuration | Trampoline entered | DuckDB-WASM query |
| --- | --- | --- |
| default | yes | 1284 ms |
| `useWasmOSR=false` alone | yes | |
| `useBBQTierUpChecks=false` alone | yes | |
| `useOMGJIT=false` alone | yes | |
| **`useWasmOSR=false` + `useBBQTierUpChecks=false`** | **no** | **2876 ms (2.2x)** |
| `useBBQJIT=false` | no | 43619 ms (34x) |
| `useJIT=false` | no | 44747 ms (35x) |

Every configuration returned the correct query result, so this trades a bounded
amount of WebAssembly performance for an app that runs at all on that hardware.
The two-option combination was chosen over disabling the WebAssembly JIT
because it is 15x faster on a real query and still never reaches the
trampoline.

Also run: `cargo test --lib` for the crate (40 pass, including four new tests
covering the AVX gate, the "an explicit value wins" rule, and the option
names), `npm run check:rust`, `npm run build`, and
`pre-commit run --files <changed paths>`.

Themes: the change is in the Tauri shell and touches no UI, and the app shell
was loaded in a real WebKitGTK WebView under both `?theme=dark` and
`?theme=light` with the options in place, with no rendering difference.

## Deliberately not included

The report also suggests surfacing a message when the renderer dies instead of
leaving a blank window. That needs a `web-process-terminated` handler on the
platform webview (a new direct `webkit2gtk` dependency, version-coupled to
wry's) and is worth its own PR. This one removes the known cause; the docs note
covers the residual case.

## Docs

`docs/getting-started.md` gains a "Linux desktop troubleshooting" section
explaining the hardware limitation, what the app does automatically, and the
`JSC_useBBQJIT=false` fallback if a renderer crash somehow persists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed blank Linux desktop windows on x86-64 systems without AVX support.
  - Added an automatic compatibility workaround to prevent WebKitGTK crashes on affected CPUs.
  - Preserved manual configuration overrides and left AVX-capable and arm64 systems unchanged.
  - Added startup diagnostics to clarify which compatibility settings are active.

- **Documentation**
  - Added troubleshooting guidance, performance considerations, override instructions, and steps for disabling WebAssembly JIT when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->