### PR TITLE
fix: read the source CRS of a GeoParquet from its `geo` metadata

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -94,7 +94,7 @@
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.5",
-    "maplibre-gl-vector": "^0.10.12",
+    "maplibre-gl-vector": "^0.10.13",
     "openai": "^7.3.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/apps/geolibre-desktop/src/lib/crs-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/crs-catalog.ts
@@ -125,6 +125,7 @@ const GEOGRAPHIC_CRS: CrsEntry[] = (
     [4123, "KKJ"],
     [4207, "Lisbon"],
     [4265, "Monte Mario"],
+    [4121, "GGRS87"],
     [4237, "HD72"],
     [4284, "Pulkovo 1942"],
     [4200, "Pulkovo 1995"],

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -14,6 +14,11 @@ import {
   stripAutoFidColumn,
   wkbRowsToFeatureCollection,
 } from "./duckdb-geometry";
+import {
+  GEOPARQUET_METADATA_COLUMN,
+  geoParquetMetadataSql,
+  geoParquetSourceCrs,
+} from "./geoparquet-crs";
 import { confirmLargeDataset, type DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
 import { readDxfCodepage, recodeCadFeatureCollection } from "./cad-encoding";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
@@ -439,6 +444,28 @@ function crsSql(fileName: string, includeWkt: boolean): string {
 }
 
 /**
+ * The CRS a GeoParquet file declares in its `geo` file metadata, or null when it
+ * carries none, declares WGS84, or the metadata cannot be read.
+ *
+ * A failure is swallowed the way the `ST_Read_Meta` path below swallows one: the
+ * overwhelmingly common case is a plain Parquet with no `geo` key at all, and a
+ * file whose coordinates are already lon/lat must still load.
+ */
+async function readGeoParquetCrs(
+  connection: duckdb.AsyncDuckDBConnection,
+  fileName: string,
+): Promise<string | null> {
+  try {
+    const row = rowsFromResult(await connection.query(geoParquetMetadataSql(fileName)))[0];
+    const metadata = row?.[GEOPARQUET_METADATA_COLUMN];
+    return geoParquetSourceCrs(typeof metadata === "string" ? metadata : null);
+  } catch (err) {
+    console.warn("[GeoLibre] Could not read GeoParquet CRS metadata; reprojection skipped.", err);
+    return null;
+  }
+}
+
+/**
  * Resolve the source CRS of a vector file as a string ST_Transform accepts —
  * `AUTHORITY:CODE` when GDAL identified one, otherwise the raw WKT definition,
  * else a shapefile's `.prj` sidecar text, or null when the file carries no
@@ -453,11 +480,12 @@ async function readSourceCrs(
   file: DuckDbVectorFile,
   prjCrs: string | null,
 ): Promise<string | null> {
-  // GeoParquet CRS is not read via ST_Read_Meta, so reprojection is skipped.
-  // A spec-valid GeoParquet file not stored in WGS84 will render with wrong
-  // coordinates; revisit if/when DuckDB exposes its CRS metadata here.
+  // GeoParquet is read with `read_parquet`, not GDAL, so `ST_Read_Meta` reports
+  // nothing about it. Its CRS is read from the file's own `geo` metadata
+  // instead, without which a file in a projected CRS loads in raw metres and
+  // draws nothing (issue #2086).
   if (isParquetExtension(file.extension)) {
-    return null;
+    return await readGeoParquetCrs(connection, file.name);
   }
 
   let row: Record<string, unknown> | undefined;

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -450,15 +450,20 @@ function crsSql(fileName: string, includeWkt: boolean): string {
  * A failure is swallowed the way the `ST_Read_Meta` path below swallows one: the
  * overwhelmingly common case is a plain Parquet with no `geo` key at all, and a
  * file whose coordinates are already lon/lat must still load.
+ *
+ * `geometryColumn` is the column the loader detected, so a file carrying several
+ * geometry columns in different CRSs resolves the one actually being read rather
+ * than whichever the document calls primary.
  */
 async function readGeoParquetCrs(
   connection: duckdb.AsyncDuckDBConnection,
   fileName: string,
+  geometryColumn?: string,
 ): Promise<string | null> {
   try {
     const row = rowsFromResult(await connection.query(geoParquetMetadataSql(fileName)))[0];
     const metadata = row?.[GEOPARQUET_METADATA_COLUMN];
-    return geoParquetSourceCrs(typeof metadata === "string" ? metadata : null);
+    return geoParquetSourceCrs(typeof metadata === "string" ? metadata : null, geometryColumn);
   } catch (err) {
     console.warn("[GeoLibre] Could not read GeoParquet CRS metadata; reprojection skipped.", err);
     return null;
@@ -479,13 +484,14 @@ async function readSourceCrs(
   connection: duckdb.AsyncDuckDBConnection,
   file: DuckDbVectorFile,
   prjCrs: string | null,
+  geometryColumn?: string,
 ): Promise<string | null> {
   // GeoParquet is read with `read_parquet`, not GDAL, so `ST_Read_Meta` reports
   // nothing about it. Its CRS is read from the file's own `geo` metadata
   // instead, without which a file in a projected CRS loads in raw metres and
   // draws nothing (issue #2086).
   if (isParquetExtension(file.extension)) {
-    return await readGeoParquetCrs(connection, file.name);
+    return await readGeoParquetCrs(connection, file.name, geometryColumn);
   }
 
   let row: Record<string, unknown> | undefined;
@@ -705,7 +711,8 @@ export async function loadDuckDbVectorFile(
     // Resolved up front (ST_Read_Meta does not materialize geometry) so the
     // surface-WKB fallback below can reuse it.
     const sourceCrs =
-      options.overrideSourceCrs?.trim() || (await readSourceCrs(connection, file, prjCrs));
+      options.overrideSourceCrs?.trim() ||
+      (await readSourceCrs(connection, file, prjCrs, detected.column));
 
     // Tracks whether the large-dataset guard already confirmed, so the
     // surface-WKB fallback does not prompt a second time (or skip it entirely

--- a/apps/geolibre-desktop/src/lib/geoparquet-crs.ts
+++ b/apps/geolibre-desktop/src/lib/geoparquet-crs.ts
@@ -1,0 +1,132 @@
+/**
+ * Reading a GeoParquet file's declared CRS out of its `geo` file metadata.
+ *
+ * Every other vector format GeoLibre loads goes through GDAL's `ST_Read`, whose
+ * `ST_Read_Meta` reports the layer CRS, so the loader can reproject it to WGS84.
+ * GeoParquet is read with `read_parquet` instead, and DuckDB does not surface
+ * that file's CRS anywhere in the scan — so a file stored in a projected CRS used
+ * to load with raw metre coordinates and draw nothing (issue #2086, reported for
+ * EPSG:2100 / the Greek Grid).
+ *
+ * The CRS is not lost, though: the GeoParquet specification puts it in the
+ * Parquet file-level key/value metadata under the key `geo`, which DuckDB does
+ * expose via `parquet_kv_metadata`. This module is the parsing half of that read
+ * — kept free of DuckDB imports so it can be tested on its own.
+ */
+
+import { isGeographicCrs } from "./crs-utils";
+import { quoteSqlString } from "./duckdb-geometry";
+
+/** The Parquet file-metadata key the GeoParquet specification writes to. */
+export const GEOPARQUET_METADATA_KEY = "geo";
+
+/** The column the {@link geoParquetMetadataSql} query returns the document in. */
+export const GEOPARQUET_METADATA_COLUMN = "geo_metadata";
+
+/**
+ * SQL that yields the `geo` metadata document of a registered Parquet file as
+ * text, or no rows when the file carries none (a plain, non-spatial Parquet).
+ *
+ * The key is matched as a BLOB via `encode` rather than by decoding every key,
+ * so a file carrying a non-UTF-8 metadata key cannot fail the whole read; only
+ * the matched row's value is decoded.
+ *
+ * @param fileName The registered DuckDB file name to read metadata from.
+ * @returns A SELECT returning at most one row, holding the JSON text.
+ */
+export function geoParquetMetadataSql(fileName: string): string {
+  return (
+    `SELECT decode(value) AS ${GEOPARQUET_METADATA_COLUMN} ` +
+    `FROM parquet_kv_metadata(${quoteSqlString(fileName)}) ` +
+    `WHERE key = encode(${quoteSqlString(GEOPARQUET_METADATA_KEY)})`
+  );
+}
+
+/**
+ * The CRS to reproject a GeoParquet file from, parsed from its `geo` metadata
+ * document, or null when it needs no reprojection.
+ *
+ * Null is returned for every "already in GeoJSON's coordinate convention" case,
+ * which the specification spells three ways: an absent `crs` member (GeoParquet
+ * defaults to OGC:CRS84), an explicit WGS84/CRS84 identifier, and `"crs": null`,
+ * which declares that the coordinates are in no known CRS at all — reprojecting
+ * those would invent an answer, so they are passed through as-is.
+ *
+ * A CRS that is present and not WGS84 is returned in the most specific form the
+ * document supports, in this order:
+ *
+ * 1. `AUTHORITY:CODE` from the PROJJSON `id` member (`EPSG:2100`), which is what
+ *    every writer that round-trips an EPSG code emits and what `ST_Transform`
+ *    resolves most reliably.
+ * 2. The PROJJSON document itself, for a CRS with no authority code (a custom
+ *    projection); PROJ parses PROJJSON wherever it parses WKT.
+ * 3. The raw string, for the pre-1.0 GeoParquet drafts that wrote the CRS as a
+ *    WKT2 string rather than as PROJJSON.
+ *
+ * @param metadataJson The `geo` metadata document as text, or null/blank when
+ *   the file has none.
+ * @returns A CRS string `ST_Transform` accepts, or null to skip reprojection.
+ */
+export function geoParquetSourceCrs(metadataJson: string | null | undefined): string | null {
+  if (!metadataJson) return null;
+
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(metadataJson);
+  } catch {
+    // A `geo` key that is not JSON is not a GeoParquet document; treat the file
+    // as carrying no CRS rather than failing the load.
+    return null;
+  }
+
+  const column = primaryGeometryColumn(metadata);
+  if (!column || !("crs" in column)) return null;
+
+  const crs = (column as { crs?: unknown }).crs;
+  // An explicit null declares "no CRS", distinct from an absent member (CRS84).
+  if (crs === null || crs === undefined) return null;
+
+  const resolved = crsString(crs);
+  if (!resolved || isGeographicCrs(resolved)) return null;
+  return resolved;
+}
+
+/**
+ * The metadata entry for the file's primary geometry column, falling back to the
+ * first column listed when `primary_column` names one that is absent (or is
+ * missing itself), so a hand-written document with a single geometry column
+ * still resolves.
+ */
+function primaryGeometryColumn(metadata: unknown): object | null {
+  const columns = (metadata as { columns?: unknown })?.columns;
+  if (!columns || typeof columns !== "object") return null;
+  const entries = Object.entries(columns as Record<string, unknown>).filter(
+    (entry): entry is [string, object] => typeof entry[1] === "object" && entry[1] !== null,
+  );
+  if (entries.length === 0) return null;
+
+  const primary = (metadata as { primary_column?: unknown }).primary_column;
+  if (typeof primary === "string") {
+    const named = entries.find(([name]) => name === primary);
+    if (named) return named[1];
+  }
+  return entries[0][1];
+}
+
+/** One column's `crs` value rendered as a string `ST_Transform` accepts. */
+function crsString(crs: unknown): string | null {
+  if (typeof crs === "string") return crs.trim() || null;
+  if (typeof crs !== "object") return null;
+
+  const id = (crs as { id?: unknown }).id;
+  const authority = (id as { authority?: unknown })?.authority;
+  const code = (id as { code?: unknown })?.code;
+  if (typeof authority === "string" && (typeof code === "string" || typeof code === "number")) {
+    return `${authority.trim().toUpperCase()}:${String(code).trim()}`;
+  }
+
+  // No authority code: hand PROJ the whole PROJJSON definition instead, so a
+  // custom projection still reprojects rather than silently rendering in raw
+  // projected coordinates.
+  return JSON.stringify(crs);
+}

--- a/apps/geolibre-desktop/src/lib/geoparquet-crs.ts
+++ b/apps/geolibre-desktop/src/lib/geoparquet-crs.ts
@@ -65,9 +65,16 @@ export function geoParquetMetadataSql(fileName: string): string {
  *
  * @param metadataJson The `geo` metadata document as text, or null/blank when
  *   the file has none.
+ * @param geometryColumn The column actually being read, when known. A
+ *   GeoParquet may carry several geometry columns in different CRSs, and the
+ *   loader reads whichever one it detected rather than necessarily the primary
+ *   one, so that column's CRS is the one to transform from.
  * @returns A CRS string `ST_Transform` accepts, or null to skip reprojection.
  */
-export function geoParquetSourceCrs(metadataJson: string | null | undefined): string | null {
+export function geoParquetSourceCrs(
+  metadataJson: string | null | undefined,
+  geometryColumn?: string,
+): string | null {
   if (!metadataJson) return null;
 
   let metadata: unknown;
@@ -79,7 +86,7 @@ export function geoParquetSourceCrs(metadataJson: string | null | undefined): st
     return null;
   }
 
-  const column = primaryGeometryColumn(metadata);
+  const column = geometryColumnMetadata(metadata, geometryColumn);
   if (!column || !("crs" in column)) return null;
 
   const crs = (column as { crs?: unknown }).crs;
@@ -92,12 +99,16 @@ export function geoParquetSourceCrs(metadataJson: string | null | undefined): st
 }
 
 /**
- * The metadata entry for the file's primary geometry column, falling back to the
- * first column listed when `primary_column` names one that is absent (or is
- * missing itself), so a hand-written document with a single geometry column
- * still resolves.
+ * The metadata entry for the geometry column being read: the named column when
+ * the document describes it, else the one `primary_column` names, else the first
+ * column listed (so a hand-written document with a single geometry column still
+ * resolves).
+ *
+ * The named column comes first because a GeoParquet may hold several geometry
+ * columns in different CRSs; transforming the column the loader read with the
+ * primary column's CRS would place the layer somewhere else entirely.
  */
-function primaryGeometryColumn(metadata: unknown): object | null {
+function geometryColumnMetadata(metadata: unknown, geometryColumn?: string): object | null {
   const columns = (metadata as { columns?: unknown })?.columns;
   if (!columns || typeof columns !== "object") return null;
   const entries = Object.entries(columns as Record<string, unknown>).filter(
@@ -106,8 +117,9 @@ function primaryGeometryColumn(metadata: unknown): object | null {
   if (entries.length === 0) return null;
 
   const primary = (metadata as { primary_column?: unknown }).primary_column;
-  if (typeof primary === "string") {
-    const named = entries.find(([name]) => name === primary);
+  for (const wanted of [geometryColumn, primary]) {
+    if (typeof wanted !== "string") continue;
+    const named = entries.find(([name]) => name === wanted);
     if (named) return named[1];
   }
   return entries[0][1];

--- a/docs/user-guide/adding-data.md
+++ b/docs/user-guide/adding-data.md
@@ -17,7 +17,7 @@ To collect supported dataset links from a catalog or other webpage and open seve
 | **GPX Layer** | Loads a GPX file or URL and splits it into separate waypoint, track, and route layers. |
 | **MBTiles Layer** | Loads a local MBTiles tile archive (desktop app). |
 
-Vector files are reprojected to EPSG:4326 on load. In the browser, vector import relies on DuckDB-WASM Spatial, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives.
+Vector files are reprojected to EPSG:4326 on load. In the browser, vector import relies on DuckDB-WASM Spatial, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. The source CRS is read from the file itself — the layer metadata for the GDAL-read formats, a Shapefile's `.prj` sidecar, or a GeoParquet's `geo` metadata — so a national grid such as EPSG:2100 (GGRS87 / Greek Grid) lands in the right place with nothing to configure.
 
 !!! warning "Large vector files"
     There is no fixed size limit. Files **under 100 MB** are read by the

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.5",
-        "maplibre-gl-vector": "^0.10.12",
+        "maplibre-gl-vector": "^0.10.13",
         "openai": "^7.3.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -18896,9 +18896,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.12",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.12.tgz",
-      "integrity": "sha512-ukA9NVm3/fju0CDn7UfyEUU8iWWnolA3n0uNp3L/Q4Wp5O/sa5ekJE5f+7GsMEhou0W+lbRsbhkEp8caR/AMNA==",
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.13.tgz",
+      "integrity": "sha512-gRizrMNVDgncNBWU9830GDI5NvoDcYbpjZ5UPkQfNY4BeAz/pyQFxCdjt+3ubGYdS3YNaeL82vjenVzJsmfdew==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -24448,7 +24448,7 @@
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.5",
-        "maplibre-gl-vector": "^0.10.12",
+        "maplibre-gl-vector": "^0.10.13",
         "netcdfjs": "^4.0.0",
         "ngeohash": "^0.6.4",
         "open-location-code-typescript": "^1.5.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -69,7 +69,7 @@
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.5",
-    "maplibre-gl-vector": "^0.10.12",
+    "maplibre-gl-vector": "^0.10.13",
     "netcdfjs": "^4.0.0",
     "ngeohash": "^0.6.4",
     "open-location-code-typescript": "^1.5.0",

--- a/tests/geoparquet-crs.test.ts
+++ b/tests/geoparquet-crs.test.ts
@@ -85,6 +85,32 @@ describe("geoParquetSourceCrs", () => {
     assert.equal(geoParquetSourceCrs(geoMetadata("EPSG:4326")), null);
   });
 
+  it("reads the column being loaded, not the primary one, when they differ", () => {
+    // A GeoParquet may carry several geometry columns in different CRSs, and the
+    // loader reads whichever column it detected. Resolving `primary_column`'s
+    // CRS instead would transform the loaded geometry with another column's
+    // projection and land the layer somewhere else entirely. The physical order
+    // here also differs from `primary_column`, so a first-entry fallback would
+    // be wrong too.
+    const metadata = JSON.stringify({
+      primary_column: "geom_4326",
+      columns: {
+        geom_2100: { crs: GREEK_GRID_PROJJSON },
+        geom_4326: { crs: { id: { authority: "EPSG", code: 4326 } } },
+      },
+    });
+    assert.equal(geoParquetSourceCrs(metadata, "geom_2100"), "EPSG:2100");
+    assert.equal(geoParquetSourceCrs(metadata, "geom_4326"), null);
+  });
+
+  it("falls back to primary_column when the loaded column is not described", () => {
+    const metadata = JSON.stringify({
+      primary_column: "geometry",
+      columns: { geometry: { crs: GREEK_GRID_PROJJSON } },
+    });
+    assert.equal(geoParquetSourceCrs(metadata, "wkb_blob"), "EPSG:2100");
+  });
+
   it("reads the column named by primary_column, not the first one listed", () => {
     const metadata = JSON.stringify({
       primary_column: "geom_2100",

--- a/tests/geoparquet-crs.test.ts
+++ b/tests/geoparquet-crs.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  GEOPARQUET_METADATA_COLUMN,
+  GEOPARQUET_METADATA_KEY,
+  geoParquetMetadataSql,
+  geoParquetSourceCrs,
+} from "../apps/geolibre-desktop/src/lib/geoparquet-crs";
+
+/** A `geo` document shaped the way GeoPandas/GDAL write one. */
+function geoMetadata(crs: unknown, options: { column?: string; omitCrs?: boolean } = {}) {
+  const column = options.column ?? "geometry";
+  const entry: Record<string, unknown> = { encoding: "WKB" };
+  if (!options.omitCrs) entry.crs = crs;
+  return JSON.stringify({
+    version: "1.0.0",
+    primary_column: column,
+    columns: { [column]: entry },
+  });
+}
+
+/** The PROJJSON GeoPandas writes for GGRS87 / Greek Grid, trimmed to what is read. */
+const GREEK_GRID_PROJJSON = {
+  $schema: "https://proj.org/schemas/v0.7/projjson.schema.json",
+  type: "ProjectedCRS",
+  name: "GGRS87 / Greek Grid",
+  base_crs: { name: "GGRS87", id: { authority: "EPSG", code: 4121 } },
+  id: { authority: "EPSG", code: 2100 },
+};
+
+describe("geoParquetMetadataSql", () => {
+  it("reads the `geo` key of the named file as text", () => {
+    const sql = geoParquetMetadataSql("greece.parquet");
+    assert.match(sql, /parquet_kv_metadata\('greece\.parquet'\)/);
+    assert.match(sql, new RegExp(`decode\\(value\\) AS ${GEOPARQUET_METADATA_COLUMN}`));
+    // The key is compared as a BLOB rather than decoded, so a file carrying a
+    // non-UTF-8 metadata key cannot fail the read.
+    assert.match(sql, new RegExp(`key = encode\\('${GEOPARQUET_METADATA_KEY}'\\)`));
+    assert.doesNotMatch(sql, /decode\(key\)/);
+  });
+
+  it("escapes a quote in the file name", () => {
+    assert.match(
+      geoParquetMetadataSql("o'brien.parquet"),
+      /parquet_kv_metadata\('o''brien\.parquet'\)/,
+    );
+  });
+});
+
+describe("geoParquetSourceCrs", () => {
+  it("returns the EPSG identity of a projected CRS", () => {
+    assert.equal(geoParquetSourceCrs(geoMetadata(GREEK_GRID_PROJJSON)), "EPSG:2100");
+  });
+
+  it("prefers the CRS's own id over its base CRS", () => {
+    // The base_crs of EPSG:2100 is EPSG:4121, a geographic system: reading that
+    // one instead would leave the metre coordinates untransformed.
+    assert.notEqual(geoParquetSourceCrs(geoMetadata(GREEK_GRID_PROJJSON)), "EPSG:4121");
+  });
+
+  it("skips reprojection for WGS84 and CRS84 identities", () => {
+    assert.equal(geoParquetSourceCrs(geoMetadata({ id: { authority: "EPSG", code: 4326 } })), null);
+    assert.equal(
+      geoParquetSourceCrs(geoMetadata({ id: { authority: "OGC", code: "CRS84" } })),
+      null,
+    );
+  });
+
+  it("skips reprojection for an absent crs member (the spec default is CRS84)", () => {
+    assert.equal(geoParquetSourceCrs(geoMetadata(null, { omitCrs: true })), null);
+  });
+
+  it("skips reprojection for an explicit null crs (no known CRS)", () => {
+    assert.equal(geoParquetSourceCrs(geoMetadata(null)), null);
+  });
+
+  it("hands PROJ the whole PROJJSON when the CRS has no authority code", () => {
+    const custom = { type: "ProjectedCRS", name: "Custom Site Grid" };
+    assert.equal(geoParquetSourceCrs(geoMetadata(custom)), JSON.stringify(custom));
+  });
+
+  it("accepts the WKT string the pre-1.0 drafts wrote", () => {
+    const wkt = 'PROJCS["Greek_Grid",GEOGCS["GCS_GGRS_1987"]]';
+    assert.equal(geoParquetSourceCrs(geoMetadata(wkt)), wkt);
+    assert.equal(geoParquetSourceCrs(geoMetadata("EPSG:4326")), null);
+  });
+
+  it("reads the column named by primary_column, not the first one listed", () => {
+    const metadata = JSON.stringify({
+      primary_column: "geom_2100",
+      columns: {
+        geom_4326: { crs: { id: { authority: "EPSG", code: 4326 } } },
+        geom_2100: { crs: GREEK_GRID_PROJJSON },
+      },
+    });
+    assert.equal(geoParquetSourceCrs(metadata), "EPSG:2100");
+  });
+
+  it("falls back to the only column when primary_column names none", () => {
+    const metadata = JSON.stringify({
+      primary_column: "missing",
+      columns: { geometry: { crs: GREEK_GRID_PROJJSON } },
+    });
+    assert.equal(geoParquetSourceCrs(metadata), "EPSG:2100");
+  });
+
+  it("returns null for a plain Parquet with no metadata, or an unreadable one", () => {
+    assert.equal(geoParquetSourceCrs(null), null);
+    assert.equal(geoParquetSourceCrs(undefined), null);
+    assert.equal(geoParquetSourceCrs(""), null);
+    assert.equal(geoParquetSourceCrs("not json"), null);
+    assert.equal(geoParquetSourceCrs("{}"), null);
+    assert.equal(geoParquetSourceCrs(JSON.stringify({ columns: {} })), null);
+  });
+});


### PR DESCRIPTION
Fixes #2086.

## What the issue asked for

Support for EPSG:2100 (GGRS87 / Greek Grid), the coordinate system Greek public administration and cadastral mapping run on, for both vector and raster.

## What was actually broken

I built the sample datasets the issue was missing — 30 Natural Earth Greek cities and the Greek boundary written by GeoPandas in EPSG:2100 as GeoJSON, zipped Shapefile, GeoPackage and GeoParquet, plus a Copernicus DEM over Athens as an EPSG:2100 COG — and drove every load path in the running app. Most of them already worked:

| Path | EPSG:2100 before this PR |
| --- | --- |
| GeoJSON with a legacy `crs` member (drop) | reprojected correctly |
| Zipped Shapefile with an EPSG:2100 `.prj` (drop) | reprojected correctly |
| GeoPackage (drop) | reprojected correctly |
| COG raster, Add Data > Raster Layer | rendered in place over Athens |
| **GeoParquet (drop)** | **"Coordinates in \<layer\> are not longitude/latitude", nothing drawn** |
| **GeoParquet, Add Data > GeoParquet Layer** | **hung at "Converting ... to GeoJSON..." forever** |

So this is not really about Greece: **no** GeoParquet in **any** projected CRS was ever reprojected. Everything else goes through GDAL's `ST_Read`, whose `ST_Read_Meta` reports the layer CRS; GeoParquet is read with `read_parquet`, DuckDB surfaces nothing about its CRS in the scan, and `readSourceCrs` returned null for it outright with a comment to "revisit if/when DuckDB exposes its CRS metadata here".

## Fix

DuckDB does expose it, just not through `ST_Read_Meta`. The GeoParquet specification writes the CRS into the Parquet file-level key/value metadata under the key `geo`, and `parquet_kv_metadata` reads that. The loader now resolves the geometry column's `crs` from that document, preferring the PROJJSON `id` (`EPSG:2100`), falling back to the PROJJSON itself for a CRS with no authority code, and to the raw string for the pre-1.0 drafts that wrote WKT2.

Reprojection is still skipped for every "already lon/lat" case the spec spells out, so the common path costs one extra metadata query and nothing else: an absent `crs` member (the spec default is OGC:CRS84), an explicit `"crs": null` (no known CRS — reprojecting would invent an answer), and a WGS84/CRS84 identity. A file with several geometry columns in different CRSs resolves the column the loader actually detected, not whichever the document calls primary, since transforming with a sibling column's projection would land the layer somewhere else entirely.

The parsing lives in its own leaf module (`geoparquet-crs.ts`) so it is unit-tested without pulling `duckdb-wasm` into the coverage denominator.

Two smaller pieces:

- **`maplibre-gl-vector` 0.10.12 -> 0.10.13.** Add Data > GeoParquet Layer routes to that package's own panel, which had the identical gap — hence the hang. Fixed upstream in opengeos/maplibre-gl-vector#69 and released as [v0.10.13](https://github.com/opengeos/maplibre-gl-vector/releases/tag/v0.10.13); typing `EPSG:2100` into the panel's Source CRS override box was the workaround, and is no longer needed.
- **GGRS87 (EPSG:4121) added to the Processing CRS picker.** Its projected list already carried EPSG:2100 but not the geographic system that one is based on.

## Verification

- `npm run typecheck`, `npm run test:frontend` (6899 passing), `npm run test:frontend:coverage` (87.06% lines / 84.78% branches / 75.43% functions, all above the floors), `pre-commit run --files ...`.
- Driven in the real app against the datasets above, in **both light and dark themes**, after installing the published 0.10.13:
  - GeoParquet by drop and via Add Data > GeoParquet Layer (URL, and "Stream GeoParquet (no copy)"): loads with the override box empty, every point on its city.
  - Quantitatively: the rendered Athens point reads **23.73130, 37.98526** against the source's own untouched WGS84 attributes of **23.731375, 37.985272** — under one pixel at that zoom, so the GGRS87 datum shift is being applied, not just the map projection.
  - A WGS84 GeoParquet (Natural Earth countries) loads unchanged by both paths, so the non-reprojecting path is untouched.
  - The COG raster and the GeoJSON/Shapefile/GeoPackage paths re-checked for regressions; all still correct.

## Note for the issue

The reporter never supplied test data, so the sample datasets above were built from open sources (Natural Earth, Copernicus DEM) and reprojected to EPSG:2100. They are not committed here — the repo carries no data fixtures of that kind — but they are reproducible from those two public sources if anyone wants to re-check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting GeoParquet coordinate reference systems directly from file metadata.
  * Projected GeoParquet layers, including Greek Grid data, now reproject correctly for display.
  * Added GGRS87 to the available coordinate reference system catalog.

* **Documentation**
  * Clarified how source coordinate reference systems are detected for supported vector file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->