### PR TITLE
fix: keep MCP tool errors readable under the mcp 2.1 SDK

### DIFF
--- a/python/src/geolibre/mcp/server.py
+++ b/python/src/geolibre/mcp/server.py
@@ -175,12 +175,25 @@ def _reports_its_errors(fn: Callable[..., Any]) -> Callable[..., Any]:
     ``ValueError`` is translated, and the original stays attached as ``__cause__``
     for the server log.
 
+    Every tool is synchronous. An ``async def`` one would return an unawaited
+    coroutine from the wrapper and raise its ``ValueError`` after the ``try``
+    below has exited, so its messages would be withheld again with nothing to
+    show for the wrapper -- it is refused here rather than registered that way.
+
     Args:
         fn: The tool function to wrap.
 
     Returns:
         The same function, with anticipated failures restated as ``ToolError``.
+
+    Raises:
+        TypeError: If *fn* is a coroutine function.
     """
+    if inspect.iscoroutinefunction(fn):
+        raise TypeError(
+            f"{fn.__name__} is async, which this wrapper cannot report errors for; "
+            "give it an async wrapper before registering it as a tool."
+        )
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/python/src/geolibre/mcp/server.py
+++ b/python/src/geolibre/mcp/server.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import functools
 import inspect
 import os
 import sys
@@ -22,6 +23,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator
 
 from mcp.server import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 
 from .. import __version__, authoring
 from .. import project as _project
@@ -154,6 +156,42 @@ def _build_layer(
         ) from exc
 
 
+def _reports_its_errors(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a tool so a rejected call tells the caller why it was rejected.
+
+    Every validation failure in this package is a ``ValueError`` (``WorkspaceError``
+    subclasses it), raised where the rule lives -- in :mod:`geolibre.authoring`,
+    :mod:`geolibre.project`, :mod:`geolibre.mcp.workspace`, or a tool body here --
+    so none of those modules has to import the MCP SDK. But the SDK reserves
+    ``ToolError`` for a failure the tool *anticipated* and treats anything else as
+    a crash, withholding its message: from mcp 2.1 the caller of, say,
+    ``add_ogc_layer`` without ``layers`` sees only "Error executing tool
+    add_ogc_layer" instead of the sentence naming the missing argument. An agent
+    that cannot read why a call was rejected cannot correct it, so it retries the
+    same call or gives up.
+
+    Restating each failure as a ``ToolError`` at the tool boundary keeps the rules
+    SDK-free and the messages intact. A crash still surfaces as a crash: only
+    ``ValueError`` is translated, and the original stays attached as ``__cause__``
+    for the server log.
+
+    Args:
+        fn: The tool function to wrap.
+
+    Returns:
+        The same function, with anticipated failures restated as ``ToolError``.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except ValueError as exc:
+            raise ToolError(str(exc)) from exc
+
+    return wrapper
+
+
 def _summarize(path: Path, project: dict[str, Any], **extra: Any) -> dict[str, Any]:
     """Build a tool result: what changed, plus where the project now stands."""
     return {
@@ -179,6 +217,22 @@ def build_server(workspace: Workspace) -> MCPServer:
         instructions=INSTRUCTIONS,
         version=__version__,
     )
+
+    def tool(**kwargs: Any) -> Callable[[Callable[..., Any]], Any]:
+        """Register a tool, restating its anticipated failures for the caller.
+
+        Stands in for ``@server.tool()`` on every tool below, so none of them can
+        be registered without :func:`_reports_its_errors`; a bare
+        ``@server.tool()`` would silently mask that tool's validation messages.
+
+        Args:
+            **kwargs: Forwarded to :meth:`MCPServer.tool` unchanged.
+
+        Returns:
+            The decorator to apply to the tool function.
+        """
+        register = server.tool(**kwargs)
+        return lambda fn: register(_reports_its_errors(fn))
 
     @contextlib.contextmanager
     def edit(path: str) -> Iterator[tuple[Path, dict[str, Any]]]:
@@ -222,7 +276,7 @@ def build_server(workspace: Workspace) -> MCPServer:
 
     # -- project lifecycle ----------------------------------------------------
 
-    @server.tool()
+    @tool()
     def create_project(
         path: str,
         name: str = "Untitled Project",
@@ -281,7 +335,7 @@ def build_server(workspace: Workspace) -> MCPServer:
         authoring.save_project(file, project)
         return _summarize(file, project, mapView=project["mapView"])
 
-    @server.tool()
+    @tool()
     def describe_project(path: str) -> dict[str, Any]:
         """Summarize a project: its camera, basemap, layers, and map controls.
 
@@ -298,7 +352,7 @@ def build_server(workspace: Workspace) -> MCPServer:
         project = authoring.load_project(file)
         return {"path": str(file), **authoring.describe_project(project)}
 
-    @server.tool()
+    @tool()
     def list_catalog() -> dict[str, Any]:
         """List the named basemaps, color ramps, and legend presets available.
 
@@ -318,7 +372,7 @@ def build_server(workspace: Workspace) -> MCPServer:
 
     # -- adding layers --------------------------------------------------------
 
-    @server.tool()
+    @tool()
     def add_geojson_layer(
         path: str,
         name: str,
@@ -362,7 +416,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             layer_id = authoring.add_layer(project, layer, index=index)
         return _summarize(file, project, layerId=layer_id, layerName=layer.get("name"))
 
-    @server.tool()
+    @tool()
     def add_vector_layer(
         path: str,
         name: str,
@@ -404,7 +458,7 @@ def build_server(workspace: Workspace) -> MCPServer:
         )
         return add(path, layer, index)
 
-    @server.tool()
+    @tool()
     def add_raster_layer(
         path: str,
         name: str,
@@ -445,7 +499,7 @@ def build_server(workspace: Workspace) -> MCPServer:
         )
         return add(path, layer, index)
 
-    @server.tool()
+    @tool()
     def add_tile_layer(
         path: str,
         name: str,
@@ -474,7 +528,7 @@ def build_server(workspace: Workspace) -> MCPServer:
         layer = _project.tile_layer(name, url, tile_size=tile_size, attribution=attribution)
         return add(path, layer, index)
 
-    @server.tool()
+    @tool()
     def add_ogc_layer(
         path: str,
         name: str,
@@ -526,7 +580,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             raise ValueError(f"service must be 'wms' or 'wmts', got {service!r}")
         return add(path, layer, index)
 
-    @server.tool()
+    @tool()
     def add_tiles_layer(
         path: str,
         name: str,
@@ -575,7 +629,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             raise ValueError(f"kind must be 'pmtiles' or 'vector-tiles', got {kind!r}")
         return add(path, layer, index)
 
-    @server.tool()
+    @tool()
     def add_3d_tiles_layer(
         path: str,
         name: str,
@@ -601,7 +655,7 @@ def build_server(workspace: Workspace) -> MCPServer:
 
     # -- editing layers -------------------------------------------------------
 
-    @server.tool()
+    @tool()
     def update_layer(
         path: str,
         layer: str,
@@ -631,7 +685,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             )
         return _summarize(file, project, layer=summary)
 
-    @server.tool()
+    @tool()
     def remove_layer(path: str, layer: str) -> dict[str, Any]:
         """Remove a layer from the project.
 
@@ -646,7 +700,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             layer_id = authoring.remove_layer(project, layer)
         return _summarize(file, project, removedLayerId=layer_id)
 
-    @server.tool()
+    @tool()
     def style_layer(path: str, layer: str, style: dict[str, Any]) -> dict[str, Any]:
         """Set style properties on a layer, merging with what is already there.
 
@@ -667,7 +721,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             merged = authoring.apply_style(project, layer, style)
         return _summarize(file, project, style=merged)
 
-    @server.tool()
+    @tool()
     def classify_layer(
         path: str,
         layer: str,
@@ -710,7 +764,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             )
         return _summarize(file, project, symbology=fragment)
 
-    @server.tool()
+    @tool()
     def list_layer_properties(path: str, layer: str) -> dict[str, Any]:
         """List the feature properties of a layer, with sample values.
 
@@ -736,7 +790,7 @@ def build_server(workspace: Workspace) -> MCPServer:
 
     # -- camera, basemap, and controls ---------------------------------------
 
-    @server.tool()
+    @tool()
     def set_view(
         path: str,
         center: list[float] | None = None,
@@ -773,7 +827,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             )
         return _summarize(file, project, mapView=view)
 
-    @server.tool()
+    @tool()
     def set_basemap(path: str, basemap: str) -> dict[str, Any]:
         """Set the project's background basemap.
 
@@ -789,7 +843,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             url = authoring.set_basemap(project, basemap)
         return _summarize(file, project, basemapStyleUrl=url)
 
-    @server.tool()
+    @tool()
     def add_legend(
         path: str,
         title: str | None = None,
@@ -835,7 +889,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             )
         return _summarize(file, project, legend=entry)
 
-    @server.tool()
+    @tool()
     def add_colorbar(
         path: str,
         colormap: str = "viridis",
@@ -879,7 +933,7 @@ def build_server(workspace: Workspace) -> MCPServer:
             )
         return _summarize(file, project, colorbar=entry)
 
-    @server.tool()
+    @tool()
     def add_swipe(
         path: str,
         left_layers: list[str],
@@ -915,7 +969,7 @@ def build_server(workspace: Workspace) -> MCPServer:
 
     # -- export ---------------------------------------------------------------
 
-    @server.tool()
+    @tool()
     def export_html(
         path: str,
         out_path: str,

--- a/python/src/geolibre/mcp/server.py
+++ b/python/src/geolibre/mcp/server.py
@@ -192,7 +192,8 @@ def _reports_its_errors(fn: Callable[..., Any]) -> Callable[..., Any]:
     if inspect.iscoroutinefunction(fn):
         raise TypeError(
             f"{fn.__name__} is async, which this wrapper cannot report errors for; "
-            "give it an async wrapper before registering it as a tool."
+            "give _reports_its_errors a coroutine branch that awaits fn inside the "
+            "same try, and register the tool through that."
         )
 
     @functools.wraps(fn)

--- a/python/tests/test_agent_skill.py
+++ b/python/tests/test_agent_skill.py
@@ -142,6 +142,28 @@ def parameters(node: ast.FunctionDef) -> list[tuple[str, str | None]]:
     return collected
 
 
+def registers_a_tool(node: ast.FunctionDef) -> bool:
+    """Whether a function is decorated as an MCP tool.
+
+    Both spellings count: the server's own ``@server.tool()``, and the
+    ``@tool()`` wrapper ``build_server`` defines around it (which restates an
+    anticipated ``ValueError`` as the SDK's ``ToolError`` so the caller still
+    reads why a call was rejected). Matching only one of the two would silently
+    empty this scan and pass every check that reads from it.
+
+    Args:
+        node: The function definition to test.
+
+    Returns:
+        True when one of its decorators registers it as a tool.
+    """
+    for decorator in node.decorator_list:
+        text = ast.unparse(decorator)
+        if "server.tool" in text or text == "tool()" or text.startswith("tool("):
+            return True
+    return False
+
+
 def mcp_tool_signatures() -> dict[str, list[tuple[str, str | None]]]:
     """Return every tool the MCP server registers, with its parameters.
 
@@ -149,14 +171,13 @@ def mcp_tool_signatures() -> dict[str, list[tuple[str, str | None]]]:
     optional ``mcp`` SDK installed.
 
     Returns:
-        A mapping of ``@server.tool()`` function name to its parameters.
+        A mapping of tool function name to its parameters.
     """
     source = (Path(mcp_package.__file__).parent / "server.py").read_text(encoding="utf-8")
     return {
         node.name: parameters(node)
         for node in ast.walk(ast.parse(source))
-        if isinstance(node, ast.FunctionDef)
-        and any("server.tool" in ast.unparse(d) for d in node.decorator_list)
+        if isinstance(node, ast.FunctionDef) and registers_a_tool(node)
     }
 
 
@@ -164,7 +185,7 @@ def mcp_tool_names() -> set[str]:
     """Return the names of every tool the MCP server registers.
 
     Returns:
-        The set of ``@server.tool()`` function names.
+        The set of tool function names.
     """
     return set(mcp_tool_signatures())
 

--- a/python/tests/test_agent_skill.py
+++ b/python/tests/test_agent_skill.py
@@ -159,7 +159,7 @@ def registers_a_tool(node: ast.FunctionDef) -> bool:
     """
     for decorator in node.decorator_list:
         text = ast.unparse(decorator)
-        if "server.tool" in text or text == "tool()" or text.startswith("tool("):
+        if "server.tool" in text or text.startswith("tool("):
             return True
     return False
 

--- a/python/tests/test_mcp_server.py
+++ b/python/tests/test_mcp_server.py
@@ -24,7 +24,10 @@ mcp = pytest.importorskip("mcp", reason="the mcp SDK is an optional extra")
 
 from mcp.server.mcpserver.exceptions import ToolError  # noqa: E402 - after the skip guard
 
-from geolibre.mcp.server import build_server  # noqa: E402 - after the skip guard
+from geolibre.mcp.server import (  # noqa: E402 - after the skip guard
+    _reports_its_errors,
+    build_server,
+)
 
 POINT_FC = {
     "type": "FeatureCollection",
@@ -211,6 +214,23 @@ def test_every_tool_reports_its_own_validation_errors(server):
     # And the wrapper is really in force: a rejected call carries its reason.
     message = call_error(server, "create_project", path="map.txt")
     assert "map.txt" in message or "suffix" in message.lower()
+
+
+def test_an_async_tool_is_refused_rather_than_registered_unreported():
+    """A coroutine tool cannot be wrapped, so it is rejected where it is wrapped.
+
+    The wrapper is synchronous: an ``async def`` tool would hand the SDK an
+    unawaited coroutine, and the ``ValueError`` inside it would be raised after
+    the wrapper's ``try`` had exited, putting the tool right back to answering
+    with "Error executing tool <name>". Failing at registration keeps that from
+    reaching a caller unnoticed.
+    """
+
+    async def make_map():
+        raise ValueError("never reached: the wrapper refuses this function")
+
+    with pytest.raises(TypeError, match="async"):
+        _reports_its_errors(make_map)
 
 
 def test_create_project_writes_a_file(server, tmp_path):

--- a/python/tests/test_mcp_server.py
+++ b/python/tests/test_mcp_server.py
@@ -7,11 +7,13 @@ not pull the SDK) stays green rather than silently losing coverage it never had.
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import builtins
 import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -184,6 +186,31 @@ def test_every_tool_is_registered_with_a_description(server):
     assert {"create_project", "add_geojson_layer", "classify_layer", "export_html"} <= names
     # An undescribed tool is invisible to a model choosing between them.
     assert all(tool.description for tool in tools)
+
+
+def test_every_tool_reports_its_own_validation_errors(server):
+    """No tool may be registered with a bare ``@server.tool()``.
+
+    The SDK reserves ``ToolError`` for an anticipated failure and treats every
+    other exception as a crash whose message is withheld, so from mcp 2.1 a tool
+    registered straight on the server answers a rejected call with only "Error
+    executing tool <name>" -- the caller cannot see which argument was wrong.
+    ``build_server``'s ``@tool()`` wrapper restates the ``ValueError`` that every
+    validation rule in this package raises, and this is what keeps a later tool
+    from being added without it.
+    """
+    source = (Path(mcp_package.__file__).parent / "server.py").read_text(encoding="utf-8")
+    bare = [
+        node.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.FunctionDef)
+        and any("server.tool" in ast.unparse(d) for d in node.decorator_list)
+    ]
+    assert not bare, f"tools registered without the error-reporting wrapper: {bare}"
+
+    # And the wrapper is really in force: a rejected call carries its reason.
+    message = call_error(server, "create_project", path="map.txt")
+    assert "map.txt" in message or "suffix" in message.lower()
 
 
 def test_create_project_writes_a_file(server, tmp_path):


### PR DESCRIPTION
## What broke

`mcp` 2.1.0 was published a few hours ago and turned CI red on every PR (21 failures in `python/tests/test_mcp_server.py`, on all four Python versions). Nothing in the repo changed; the SDK did.

The SDK reserves `ToolError` for a failure a tool *anticipated*, and treats every other exception as a crash whose message is withheld from the client. Every validation rule in this package raises `ValueError` (and `WorkspaceError` subclasses it), deliberately: the rules live in `authoring.py`, `project.py`, `workspace.py` and the tool bodies, none of which should import the MCP SDK — `server.py` is the only module that does.

Under mcp 2.1 that means the rules still fire, but their reasons no longer reach the caller:

```
add_ogc_layer(name="WMS", service="wms", endpoint="https://example.com/wms")
before:  add_ogc_layer: 'layers' is required when service='wms'
after:   Error executing tool add_ogc_layer
```

Same for the inverted colorbar range, the unknown tile kind, the 50 MB inline-GeoJSON cap, the non-HTML `export_html` destination, and every workspace confinement error. An agent that cannot read why a call was rejected cannot fix the call: it retries the same one or gives up. The failing tests were doing their job — they assert the sentences a caller is supposed to read.

## Fix

`build_server` registers every tool through a local `@tool()` that restates an anticipated `ValueError` as `ToolError`:

- The rules stay where they are and stay SDK-free; only the boundary knows about `ToolError`.
- Only `ValueError` is translated, and the original is kept as `__cause__`, so a genuine crash is still reported as a crash and still logged with its traceback.
- A new test fails if a later tool is added with a bare `@server.tool()`, since that tool would silently lose its messages again.
- `test_agent_skill.py` finds the tool surface by parsing `server.py` for that decorator, so its scanner now recognizes both spellings. Without that it would have quietly scanned zero tools and passed every drift check that reads from it.

## Verification

- `pytest python/tests` under **mcp 2.0.0** (the current floor, `mcp>=2.0`) and under **mcp 2.1.0** in a clean venv: 373 passing on both, so this is not a swap of one version's breakage for another's.
- `pre-commit run --files python/src/geolibre/mcp/server.py python/tests/test_mcp_server.py python/tests/test_agent_skill.py`.

Found while working #2086; it is unrelated to that issue, so it is here on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for tool validation failures, including workspace-related errors.
  * Tool errors now preserve the original message and provide clearer details when a request is rejected.
  * Unexpected failures continue to be handled without altering their original behavior.
  * Asynchronous tools are now rejected during registration instead of being registered without error reporting.

* **Tests**
  * Added coverage to verify consistent error reporting and tool registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->