### PR TITLE
feat: make annotation toolbar collapsible

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -239,6 +239,8 @@ export function TopToolbar({
     });
     setAnnotationLabels({
       toolbar: t("annotations.toolbar"),
+      collapse: t("pluginPanel.collapse"),
+      expand: t("pluginPanel.expand"),
       layerName: t("annotations.layerName"),
       elementsPanelTitle: t("annotations.elementsPanelTitle"),
       tools: {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -239,8 +239,8 @@ export function TopToolbar({
     });
     setAnnotationLabels({
       toolbar: t("annotations.toolbar"),
-      collapse: t("pluginPanel.collapse"),
-      expand: t("pluginPanel.expand"),
+      collapse: t("sharedRail.collapse", { title: t("annotations.toolbar") }),
+      expand: t("sharedRail.expand", { title: t("annotations.toolbar") }),
       layerName: t("annotations.layerName"),
       elementsPanelTitle: t("annotations.elementsPanelTitle"),
       tools: {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1173,12 +1173,6 @@ body,
   overflow: hidden;
 }
 
-.geolibre-annotations-control.is-collapsed {
-  /* MapLibre gives grouped controls a minimum height through their children;
-   * keep only the toggle's single control cell when the tools are folded. */
-  height: var(--geolibre-annotations-cell-size);
-}
-
 .geolibre-annotations-control .geolibre-annotations-tools {
   display: flex;
   flex-direction: column;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1172,6 +1172,21 @@ body,
   overflow: hidden;
 }
 
+.geolibre-annotations-control.is-collapsed {
+  /* MapLibre gives grouped controls a minimum height through their children;
+   * keep only the toggle's single control cell when the tools are folded. */
+  height: 29px;
+}
+
+.geolibre-annotations-control .geolibre-annotations-tools {
+  display: flex;
+  flex-direction: column;
+}
+
+.geolibre-annotations-control .geolibre-annotations-tools[hidden] {
+  display: none;
+}
+
 /* `display: flex !important` overrides MapLibre's `.maplibregl-ctrl button`
  * (which is `display: block`), so the icon centers in the 29px cell instead of
  * sitting at the top-left. */
@@ -1204,8 +1219,16 @@ body,
   color: hsl(var(--primary-foreground));
 }
 
+.geolibre-annotations-control .geolibre-annotations-collapse {
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.geolibre-annotations-control.is-collapsed .geolibre-annotations-collapse {
+  border-bottom: 0;
+}
+
 /* Separators between the icon buttons, tinted for the active theme. */
-.geolibre-annotations-control button + button,
+.geolibre-annotations-control .geolibre-annotations-tools button + button,
 .geolibre-annotations-control .geolibre-annotations-width,
 .geolibre-annotations-control .geolibre-annotations-color {
   border-top: 1px solid hsl(var(--border));

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1163,6 +1163,7 @@ body,
  * buttons, the active-tool highlight, and the inline color/width inputs.
  */
 .geolibre-annotations-control {
+  --geolibre-annotations-cell-size: 29px;
   background-color: hsl(var(--background)) !important;
   border: 1px solid hsl(var(--border)) !important;
   border-radius: 4px;
@@ -1175,7 +1176,7 @@ body,
 .geolibre-annotations-control.is-collapsed {
   /* MapLibre gives grouped controls a minimum height through their children;
    * keep only the toggle's single control cell when the tools are folded. */
-  height: 29px;
+  height: var(--geolibre-annotations-cell-size);
 }
 
 .geolibre-annotations-control .geolibre-annotations-tools {
@@ -1197,10 +1198,10 @@ body,
   color: hsl(var(--foreground));
   cursor: pointer;
   display: flex !important;
-  height: 29px;
+  height: var(--geolibre-annotations-cell-size);
   justify-content: center;
   padding: 0;
-  width: 29px;
+  width: var(--geolibre-annotations-cell-size);
 }
 
 .geolibre-annotations-control button > svg {

--- a/docs/user-guide/map-controls.md
+++ b/docs/user-guide/map-controls.md
@@ -115,7 +115,7 @@ The Controls menu also carries tools that move the camera, drape live data over 
 
 ## Annotations and the Elements panel
 
-The annotation tools draw on top of the map: **Text**, **Arrow**, **Rectangle highlight**, **Ellipse highlight**, **Freehand highlight**, **Pin marker**, **Sticky note**, and **Placed image**. Each has a color, and the stroked shapes (Arrow, Rectangle, Ellipse, and Freehand) also honor the line width. You can delete the last annotation or clear them all.
+The annotation tools draw on top of the map: **Text**, **Arrow**, **Rectangle highlight**, **Ellipse highlight**, **Freehand highlight**, **Pin marker**, **Sticky note**, and **Placed image**. Each has a color, and the stroked shapes (Arrow, Rectangle, Ellipse, and Freehand) also honor the line width. You can delete the last annotation or clear them all. Use the chevron at the top of the toolbar to collapse the tools when you need more room for controls beneath them.
 
 Annotations are saved with the project, and the **Elements** panel lists them so you can find and manage each one instead of hunting for it on the canvas. Most elements are anchored **At Point** — a geographic coordinate they move with. **Placed image** additionally offers **Pinned to Extent**, which stretches it across a bounding box so it scales with the view.
 

--- a/packages/plugins/src/plugins/maplibre-annotations.ts
+++ b/packages/plugins/src/plugins/maplibre-annotations.ts
@@ -33,6 +33,7 @@ const TEXT_MARKER_SHAPE = "text_marker";
 const PREVIEW_SOURCE_ID = "geolibre-annotation-preview";
 const PREVIEW_FILL_LAYER_ID = "geolibre-annotation-preview-fill";
 const PREVIEW_LINE_LAYER_ID = "geolibre-annotation-preview-line";
+const ANNOTATION_TOOLS_ID = "geolibre-annotation-tools";
 
 const DEFAULT_COLOR = "#ef4444";
 const DEFAULT_WIDTH = 3;
@@ -293,6 +294,7 @@ class AnnotationToolbarControl implements maplibregl.IControl {
     const collapseButton = document.createElement("button");
     collapseButton.type = "button";
     collapseButton.className = "geolibre-annotations-collapse";
+    collapseButton.setAttribute("aria-controls", ANNOTATION_TOOLS_ID);
     collapseButton.addEventListener("click", () => {
       this.collapsed = !this.collapsed;
       if (this.collapsed) setActiveTool(null);
@@ -303,6 +305,7 @@ class AnnotationToolbarControl implements maplibregl.IControl {
     container.appendChild(collapseButton);
 
     const toolsContainer = document.createElement("div");
+    toolsContainer.id = ANNOTATION_TOOLS_ID;
     toolsContainer.className = "geolibre-annotations-tools";
     container.appendChild(toolsContainer);
 

--- a/packages/plugins/src/plugins/maplibre-annotations.ts
+++ b/packages/plugins/src/plugins/maplibre-annotations.ts
@@ -198,6 +198,8 @@ const WIDTH_VALUES = [2, 3, 5] as const;
  */
 export interface AnnotationLabels {
   toolbar: string;
+  collapse: string;
+  expand: string;
   /** Name of the layer the annotations are stored in (shown in the Layers panel). */
   layerName: string;
   elementsPanelTitle: string;
@@ -220,6 +222,8 @@ export interface AnnotationLabels {
 
 let labels: AnnotationLabels = {
   toolbar: "Annotation tools",
+  collapse: "Collapse annotation tools",
+  expand: "Expand annotation tools",
   layerName: ANNOTATIONS_LAYER_NAME,
   elementsPanelTitle: "Elements",
   tools: {
@@ -273,7 +277,10 @@ function widthOptionLabel(value: number): string {
 /** A plain-DOM MapLibre control hosting the annotation tools and style inputs. */
 class AnnotationToolbarControl implements maplibregl.IControl {
   private container: HTMLElement | null = null;
+  private toolsContainer: HTMLElement | null = null;
+  private collapseButton: HTMLButtonElement | null = null;
   private toolButtons = new Map<AnnotationTool, HTMLButtonElement>();
+  private collapsed = false;
   // Closures that re-apply each element's translated text from `labels`, run on
   // mount and again whenever the active language changes (see relabel()).
   private relabelers: (() => void)[] = [];
@@ -282,6 +289,22 @@ class AnnotationToolbarControl implements maplibregl.IControl {
     const container = document.createElement("div");
     container.className = "maplibregl-ctrl maplibregl-ctrl-group geolibre-annotations-control";
     this.relabelers = [() => container.setAttribute("aria-label", labels.toolbar)];
+
+    const collapseButton = document.createElement("button");
+    collapseButton.type = "button";
+    collapseButton.className = "geolibre-annotations-collapse";
+    collapseButton.addEventListener("click", () => {
+      this.collapsed = !this.collapsed;
+      if (this.collapsed) setActiveTool(null);
+      this.syncCollapsedState();
+      this.relabel();
+    });
+    this.applyLabel(collapseButton, () => (this.collapsed ? labels.expand : labels.collapse));
+    container.appendChild(collapseButton);
+
+    const toolsContainer = document.createElement("div");
+    toolsContainer.className = "geolibre-annotations-tools";
+    container.appendChild(toolsContainer);
 
     for (const tool of TOOL_ORDER) {
       const button = document.createElement("button");
@@ -293,7 +316,7 @@ class AnnotationToolbarControl implements maplibregl.IControl {
       });
       this.applyLabel(button, () => labels.tools[tool] || tool);
       this.toolButtons.set(tool, button);
-      container.appendChild(button);
+      toolsContainer.appendChild(button);
     }
 
     const color = document.createElement("input");
@@ -304,7 +327,7 @@ class AnnotationToolbarControl implements maplibregl.IControl {
       strokeColor = color.value;
     });
     this.applyLabel(color, () => labels.color);
-    container.appendChild(color);
+    toolsContainer.appendChild(color);
 
     // A cycling button (thin → medium → thick) rather than a native <select>:
     // the icon uses currentColor so it themes with the other tools, and there is
@@ -326,23 +349,26 @@ class AnnotationToolbarControl implements maplibregl.IControl {
     });
     renderWidth();
     this.applyLabel(width, () => `${labels.width}: ${widthOptionLabel(strokeWidth)}`);
-    container.appendChild(width);
+    toolsContainer.appendChild(width);
 
     const deleteLast = this.makeActionButton(
       () => labels.deleteLast,
       '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h11a5 5 0 0 1 0 10h-1"/></svg>',
       () => deleteLastAnnotation(),
     );
-    container.appendChild(deleteLast);
+    toolsContainer.appendChild(deleteLast);
 
     const clearAll = this.makeActionButton(
       () => labels.clearAll,
       '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M6 6l1 14h10l1-14"/></svg>',
       () => clearAllAnnotations(),
     );
-    container.appendChild(clearAll);
+    toolsContainer.appendChild(clearAll);
 
     this.container = container;
+    this.toolsContainer = toolsContainer;
+    this.collapseButton = collapseButton;
+    this.syncCollapsedState();
     this.relabel();
     return container;
   }
@@ -350,6 +376,8 @@ class AnnotationToolbarControl implements maplibregl.IControl {
   onRemove(): void {
     this.container?.remove();
     this.container = null;
+    this.toolsContainer = null;
+    this.collapseButton = null;
     this.toolButtons.clear();
     this.relabelers = [];
   }
@@ -387,6 +415,17 @@ class AnnotationToolbarControl implements maplibregl.IControl {
     for (const [tool, button] of this.toolButtons) {
       button.classList.toggle("is-active", activeTool === tool);
     }
+  }
+
+  /** Reduce the tall toolbar to its toggle while keeping it discoverable. */
+  private syncCollapsedState(): void {
+    if (!this.container || !this.toolsContainer || !this.collapseButton) return;
+    this.container.classList.toggle("is-collapsed", this.collapsed);
+    this.toolsContainer.hidden = this.collapsed;
+    this.collapseButton.setAttribute("aria-expanded", String(!this.collapsed));
+    this.collapseButton.innerHTML = this.collapsed
+      ? '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>'
+      : '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>';
   }
 }
 

--- a/tests/annotation-toolbar.test.ts
+++ b/tests/annotation-toolbar.test.ts
@@ -53,6 +53,7 @@ describe("annotation toolbar collapse toggle", () => {
 
     assert.equal(toggle.getAttribute("aria-expanded"), "true");
     assert.equal(toggle.getAttribute("aria-label"), "Collapse toolbar");
+    assert.equal(toggle.getAttribute("aria-controls"), tools.id);
     assert.equal(tools.hidden, false);
 
     textTool.click();
@@ -68,6 +69,7 @@ describe("annotation toolbar collapse toggle", () => {
     toggle.click();
     assert.equal(container.classList.contains("is-collapsed"), false);
     assert.equal(toggle.getAttribute("aria-expanded"), "true");
+    assert.equal(toggle.getAttribute("aria-label"), "Collapse toolbar");
     assert.equal(tools.hidden, false);
   });
 });

--- a/tests/annotation-toolbar.test.ts
+++ b/tests/annotation-toolbar.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { parseHTML } from "linkedom";
+import type { IControl } from "maplibre-gl";
+import {
+  maplibreAnnotationsPlugin,
+  setAnnotationLabels,
+} from "../packages/plugins/src/plugins/maplibre-annotations";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
+
+describe("annotation toolbar collapse toggle", () => {
+  let restoreGlobals: () => void;
+  let control: IControl | null;
+  let app: GeoLibreAppAPI;
+
+  beforeEach(() => {
+    const { document, window } = parseHTML("<html><body></body></html>");
+    const previousDocument = globalThis.document;
+    const previousWindow = globalThis.window;
+    Object.assign(globalThis, { document, window });
+    restoreGlobals = () => {
+      Object.assign(globalThis, { document: previousDocument, window: previousWindow });
+    };
+
+    control = null;
+    app = {
+      addMapControl: (nextControl) => {
+        control = nextControl;
+        return true;
+      },
+      removeMapControl: (removedControl) => removedControl.onRemove(),
+      getMap: () => null,
+    } as GeoLibreAppAPI;
+
+    setAnnotationLabels({ collapse: "Collapse toolbar", expand: "Expand toolbar" });
+    maplibreAnnotationsPlugin.activate(app);
+  });
+
+  afterEach(() => {
+    maplibreAnnotationsPlugin.deactivate(app);
+    restoreGlobals();
+  });
+
+  it("folds to one accessible button and expands again", () => {
+    assert.ok(control);
+    const container = control.onAdd(null as never);
+    const toggle = container.querySelector<HTMLButtonElement>(".geolibre-annotations-collapse");
+    const tools = container.querySelector<HTMLElement>(".geolibre-annotations-tools");
+    const textTool = container.querySelector<HTMLButtonElement>(".geolibre-annotations-tool");
+    assert.ok(toggle);
+    assert.ok(tools);
+    assert.ok(textTool);
+
+    assert.equal(toggle.getAttribute("aria-expanded"), "true");
+    assert.equal(toggle.getAttribute("aria-label"), "Collapse toolbar");
+    assert.equal(tools.hidden, false);
+
+    textTool.click();
+    assert.equal(textTool.classList.contains("is-active"), true);
+    toggle.click();
+
+    assert.equal(container.classList.contains("is-collapsed"), true);
+    assert.equal(toggle.getAttribute("aria-expanded"), "false");
+    assert.equal(toggle.getAttribute("aria-label"), "Expand toolbar");
+    assert.equal(tools.hidden, true);
+    assert.equal(textTool.classList.contains("is-active"), false);
+
+    toggle.click();
+    assert.equal(container.classList.contains("is-collapsed"), false);
+    assert.equal(toggle.getAttribute("aria-expanded"), "true");
+    assert.equal(tools.hidden, false);
+  });
+});

--- a/tests/annotation-toolbar.test.ts
+++ b/tests/annotation-toolbar.test.ts
@@ -53,6 +53,7 @@ describe("annotation toolbar collapse toggle", () => {
 
     assert.equal(toggle.getAttribute("aria-expanded"), "true");
     assert.equal(toggle.getAttribute("aria-label"), "Collapse toolbar");
+    assert.ok(tools.id, "Tools region must have an id");
     assert.equal(toggle.getAttribute("aria-controls"), tools.id);
     assert.equal(tools.hidden, false);
 


### PR DESCRIPTION
## Summary

- add a chevron button that collapses the Annotation toolbar to a single control cell
- deactivate any selected annotation tool when collapsing and expose accessible expanded state
- reuse translated panel labels, document the control, and cover the interaction with a DOM regression test

## Verification

- `npm run build -w geolibre-desktop`
- `npm run test:frontend` (6,908 passed, 1 skipped)
- `node --import tsx --test tests/i18n-catalogs.test.ts`
- ESLint on the changed TypeScript files (no errors; two pre-existing hook warnings in TopToolbar)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chevron toggle to collapse and expand the annotation toolbar.
  * Collapsing the toolbar hides its tools while retaining quick access to the toggle.
  * Added localized labels and accessibility state updates for the collapse control.
  * Active annotation tools are reset when the toolbar is collapsed.

* **Documentation**
  * Updated the map controls guide to describe the annotation toolbar toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->