### PR TITLE
fix: improve dark theme destructive contrast

### DIFF
--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -82,8 +82,12 @@
     --muted-foreground: 215 20.2% 65.1%;
     --accent: 220 18% 22%;
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    /* Destructive is also the app-wide error-text and invalid-control colour.
+       Keep it light enough to clear WCAG AA on every dark surface, including
+       accent (4.70:1). Its foreground is correspondingly dark so destructive
+       buttons retain strong contrast (6.78:1). */
+    --destructive: 0 84.2% 72%;
+    --destructive-foreground: 222.2 47.4% 11.2%;
     --border: 220 14% 26%;
     --input: 220 12% 38%;
     /* Tailwind's built-in shadow scale bakes in a 10%-black colour, which is


### PR DESCRIPTION
## Summary
- increase the dark theme destructive color contrast across error text and invalid controls
- switch destructive foreground text to a dark tone for readable destructive buttons
- document the WCAG contrast ratios behind the paired colors

## Test plan
- [x] Run pre-commit hooks for `packages/ui/src/globals.css`
- [x] Run the production npm build through the pre-commit gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark-theme destructive states with a lighter red background and darker foreground text for better visual contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->