### PR TITLE
feat: support xarray raster layers in Python API

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -26,13 +26,11 @@ Or with conda from [conda-forge](https://anaconda.org/conda-forge/geolibre):
 conda install -c conda-forge geolibre
 ```
 
-Optional extras for `add_geojson()` from a GeoDataFrame and for reading **local**
-vector files with `add_vector()` / `add_geoparquet()` / `add_flatgeobuf()` /
-`add_shp()` / `add_kml()` / `add_gpkg()` (remote URLs for those formats need no
-extras):
+Optional extras provide GeoPandas/Shapely support for GeoDataFrames and local
+vector files, plus xarray/rioxarray/rasterio support for in-memory rasters:
 
 ```bash
-pip install "geolibre[all]"   # adds GeoPandas and Shapely
+pip install "geolibre[all]"
 ```
 
 The optional `[all]` extra is pip-only. If you installed via conda, add it with

--- a/docs/python.md
+++ b/docs/python.md
@@ -30,8 +30,13 @@ Optional extras provide GeoPandas/Shapely support for GeoDataFrames and local
 vector files, plus xarray/rioxarray/rasterio support for in-memory rasters:
 
 ```bash
-pip install "geolibre[all]"
+pip install "geolibre[all]"      # both
+pip install "geolibre[vector]"   # GeoPandas/Shapely only
+pip install "geolibre[raster]"   # xarray/rioxarray/rasterio only
 ```
+
+`[all]` is the union of the two, so it now installs rasterio (and GDAL with it);
+use `[vector]` to keep an existing vector-only environment as light as before.
 
 The optional `[all]` extra is pip-only. If you installed via conda, add it with
 `pip install "geolibre[all]"` inside the same environment.
@@ -103,6 +108,9 @@ m.add_raster(
 
 The temporary Cloud-Optimized GeoTIFF backing an xarray layer is removed when the widget is
 closed, so xarray layers have the same session-only limitation as local files.
+Call `m.close()` when you are done to remove it promptly; otherwise it is removed
+when the `Map` is garbage collected or when the kernel exits normally. A kernel
+that is killed outright leaves the file behind in the system temp directory.
 
 Add markers and data-driven symbology without precomputing styles:
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -89,6 +89,23 @@ the localhost route is unreachable, so pass a hosted URL there. The served URL i
 also session-scoped, so a project saved with a local raster will not restore it
 when reopened later — pass a hosted URL for durable projects.
 
+Install `geolibre[raster]` to visualize an in-memory xarray object. Spatial
+dimensions named `lon`/`lat` or `longitude`/`latitude` default to EPSG:4326;
+otherwise provide CRS and dimension names explicitly. Dataset variables become
+bands unless one is selected:
+
+```python
+m.add_raster(data_array, name="Temperature", colormap="viridis")
+m.add_raster(
+    dataset,
+    name="Temperature",
+    array_args={"variable": "temperature", "isel": {"time": 0}},
+)
+```
+
+The temporary Cloud-Optimized GeoTIFF backing an xarray layer is removed when the widget is
+closed, so xarray layers have the same session-only limitation as local files.
+
 Add markers and data-driven symbology without precomputing styles:
 
 ```python
@@ -265,7 +282,7 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | `add_wmts(url, name=, tile_size=, **style)` | Add a WMTS layer from a tile URL template. |
 | `add_wfs(endpoint, type_name, name=, version=, output_format=, srs_name=, max_features=, **style)` | Add a WFS layer (GetFeature GeoJSON, fetched and inlined). |
 | `add_cog(url, name=, bands=, colormap=, rescale=, **style)` | Add a Cloud Optimized GeoTIFF (URL or a kernel-side local GeoTIFF path). |
-| `add_raster(url, name=, bands=, colormap=, rescale=, **style)` | Add a raster (COG/GeoTIFF), URL or local path; alias of `add_cog`. |
+| `add_raster(source, name=, bands=, colormap=, rescale=, array_args=, **style)` | Add a COG/GeoTIFF URL or path, or an xarray DataArray/Dataset (xarray needs `geolibre[raster]`). |
 | `add_3d_tiles(url, name=, altitude_offset=, request_headers=, **style)` | Add a 3D Tiles `tileset.json`. |
 | `add_video(urls, coordinates, name=, **style)` | Add a georeferenced video (four `[lng, lat]` corners). |
 | `add_basemap(basemap)` | Set the background basemap. |

--- a/python/README.md
+++ b/python/README.md
@@ -90,7 +90,7 @@ m.to_project()["mapView"]["center"]
 | `add_wmts(url, name=, tile_size=, **style)` | Add a WMTS tile URL template. |
 | `add_wfs(endpoint, type_name, name=, version=, output_format=, srs_name=, max_features=, **style)` | Add a WFS layer (GeoJSON, fetched and inlined). |
 | `add_cog(url, name=, bands=, colormap=, rescale=)` | Add a Cloud Optimized GeoTIFF. |
-| `add_raster(url, name=, bands=, colormap=, rescale=)` | Add a raster (alias of `add_cog`). |
+| `add_raster(source, name=, bands=, colormap=, rescale=, array_args=)` | Add a COG/GeoTIFF or an xarray DataArray/Dataset (xarray needs `geolibre[raster]`). |
 | `add_3d_tiles(url, name=, altitude_offset=, request_headers=, **style)` | Add a 3D Tiles `tileset.json`. |
 | `add_video(urls, coordinates, name=, **style)` | Add a georeferenced video (four `[lng, lat]` corners). |
 | `add_basemap(basemap)` | Set the background basemap. |

--- a/python/README.md
+++ b/python/README.md
@@ -203,8 +203,9 @@ anywhere untrusted, or use `Map.save_project`, which redacts by default.
 - Optional extras: `pip install "geolibre[all]"` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)` and for reading **local** vector files
   (`add_vector`/`add_geoparquet`/`add_flatgeobuf`/`add_shp`/`add_kml`/`add_gpkg`),
-  which the kernel reads and inlines as GeoJSON. Remote URLs for the same formats stream through
-  the in-browser vector control and need no extras.
+  plus xarray/rioxarray/rasterio support for in-memory rasters. The kernel reads
+  local vectors and inlines them as GeoJSON; remote URLs for those formats
+  stream through the in-browser vector control and need no extras.
 - `add_geojson` inlines file/URL data into the project (up to 50 MB), so a large
   dataset is held in memory and re-synced on every project update. For very large
   layers, prefer a tile or COG source (`add_tile_layer`/`add_cog`) the app fetches

--- a/python/README.md
+++ b/python/README.md
@@ -203,9 +203,10 @@ anywhere untrusted, or use `Map.save_project`, which redacts by default.
 - Optional extras: `pip install "geolibre[all]"` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)` and for reading **local** vector files
   (`add_vector`/`add_geoparquet`/`add_flatgeobuf`/`add_shp`/`add_kml`/`add_gpkg`),
-  plus xarray/rioxarray/rasterio support for in-memory rasters. The kernel reads
-  local vectors and inlines them as GeoJSON; remote URLs for those formats
-  stream through the in-browser vector control and need no extras.
+  plus xarray/rioxarray/rasterio support for in-memory rasters. `[vector]` and
+  `[raster]` install just one half each -- `[all]` pulls in rasterio (and GDAL).
+  The kernel reads local vectors and inlines them as GeoJSON; remote URLs for
+  those formats stream through the in-browser vector control and need no extras.
 - `add_geojson` inlines file/URL data into the project (up to 50 MB), so a large
   dataset is held in memory and re-synced on every project update. For very large
   layers, prefer a tile or COG source (`add_tile_layer`/`add_cog`) the app fetches

--- a/python/examples/xarray-raster.ipynb
+++ b/python/examples/xarray-raster.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Visualize xarray rasters with GeoLibre\n",
+    "\n",
+    "This notebook exercises `Map.add_raster` with both an `xarray.DataArray` and an `xarray.Dataset`. It creates synthetic geographic data, so no download is required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "install",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run once if the raster dependencies are not installed.\n",
+    "# %pip install \"geolibre[raster]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "imports",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "\n",
+    "from geolibre import Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dataarray-heading",
+   "metadata": {},
+   "source": [
+    "## DataArray\n",
+    "\n",
+    "Coordinate dimensions named `lon` and `lat` are recognized automatically and default to EPSG:4326."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "create-dataarray",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lon = np.linspace(-125, -65, 240)\n",
+    "lat = np.linspace(50, 24, 140)\n",
+    "xx, yy = np.meshgrid(lon, lat)\n",
+    "\n",
+    "temperature = xr.DataArray(\n",
+    "    28 - 0.45 * (yy - 24) + 5 * np.sin((xx + 100) / 8),\n",
+    "    coords={\"lat\": lat, \"lon\": lon},\n",
+    "    dims=(\"lat\", \"lon\"),\n",
+    "    name=\"temperature\",\n",
+    "    attrs={\"long_name\": \"Synthetic air temperature\", \"units\": \"°C\"},\n",
+    ")\n",
+    "temperature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "show-dataarray",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(center=(-96, 37), zoom=3.5, height=\"700px\")\n",
+    "m.add_raster(\n",
+    "    temperature,\n",
+    "    name=\"Temperature DataArray\",\n",
+    "    colormap=\"turbo\",\n",
+    "    rescale=[[-5, 35]],\n",
+    "    array_args={\"nodata\": -9999, \"compress\": \"LZW\"},\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dataset-heading",
+   "metadata": {},
+   "source": [
+    "## Dataset variable and dimension selection\n",
+    "\n",
+    "Use `array_args[\"variable\"]` to select a data variable and `array_args[\"isel\"]` to select an index from non-spatial dimensions such as time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "show-dataset-variable",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "climate = xr.Dataset(\n",
+    "    {\n",
+    "        \"temperature\": xr.concat([temperature, temperature + 3], dim=\"time\"),\n",
+    "        \"precipitation\": ((\"time\", \"lat\", \"lon\"), np.stack([\n",
+    "            80 + 60 * np.cos((xx + 95) / 10) ** 2,\n",
+    "            110 + 70 * np.cos((xx + 90) / 10) ** 2,\n",
+    "        ])),\n",
+    "    },\n",
+    "    coords={\"time\": [\"2026-01-01\", \"2026-07-01\"], \"lat\": lat, \"lon\": lon},\n",
+    ")\n",
+    "\n",
+    "m.add_raster(\n",
+    "    climate,\n",
+    "    name=\"Precipitation Dataset\",\n",
+    "    colormap=\"viridis\",\n",
+    "    rescale=[[0, 180]],\n",
+    "    array_args={\"variable\": \"precipitation\", \"isel\": {\"time\": 1}},\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rgb-heading",
+   "metadata": {},
+   "source": [
+    "## Multivariable Dataset as RGB\n",
+    "\n",
+    "Compatible two-dimensional Dataset variables are written as separate bands. Here the three variables are displayed as red, green, and blue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "show-rgb-dataset",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "red = np.clip(255 * (xx - lon.min()) / np.ptp(lon), 0, 255).astype(\"uint8\")\n",
+    "green = np.clip(255 * (lat.max() - yy) / np.ptp(lat), 0, 255).astype(\"uint8\")\n",
+    "blue = np.full_like(red, 140)\n",
+    "rgb = xr.Dataset(\n",
+    "    {\n",
+    "        \"red\": ((\"lat\", \"lon\"), red),\n",
+    "        \"green\": ((\"lat\", \"lon\"), green),\n",
+    "        \"blue\": ((\"lat\", \"lon\"), blue),\n",
+    "    },\n",
+    "    coords={\"lat\": lat, \"lon\": lon},\n",
+    ")\n",
+    "\n",
+    "m.add_raster(\n",
+    "    rgb,\n",
+    "    name=\"RGB Dataset\",\n",
+    "    bands=[1, 2, 3],\n",
+    "    rescale=[[0, 255], [0, 255], [0, 255]],\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cleanup-heading",
+   "metadata": {},
+   "source": [
+    "The xarray objects are converted to session-scoped temporary Cloud-Optimized GeoTIFFs. Close the widget when finished to remove them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cleanup",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (geo)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/examples/xarray-raster.ipynb
+++ b/python/examples/xarray-raster.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "intro",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Visualize xarray rasters with GeoLibre\n",
@@ -12,8 +12,8 @@
   },
   {
    "cell_type": "code",
-   "id": "install",
    "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,8 +23,8 @@
   },
   {
    "cell_type": "code",
-   "id": "imports",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dataarray-heading",
+   "id": "3",
    "metadata": {},
    "source": [
     "## DataArray\n",
@@ -46,8 +46,8 @@
   },
   {
    "cell_type": "code",
-   "id": "create-dataarray",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,8 +67,8 @@
   },
   {
    "cell_type": "code",
-   "id": "show-dataarray",
    "execution_count": null,
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dataset-heading",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Dataset variable and dimension selection\n",
@@ -95,18 +95,23 @@
   },
   {
    "cell_type": "code",
-   "id": "show-dataset-variable",
    "execution_count": null,
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
     "climate = xr.Dataset(\n",
     "    {\n",
     "        \"temperature\": xr.concat([temperature, temperature + 3], dim=\"time\"),\n",
-    "        \"precipitation\": ((\"time\", \"lat\", \"lon\"), np.stack([\n",
-    "            80 + 60 * np.cos((xx + 95) / 10) ** 2,\n",
-    "            110 + 70 * np.cos((xx + 90) / 10) ** 2,\n",
-    "        ])),\n",
+    "        \"precipitation\": (\n",
+    "            (\"time\", \"lat\", \"lon\"),\n",
+    "            np.stack(\n",
+    "                [\n",
+    "                    80 + 60 * np.cos((xx + 95) / 10) ** 2,\n",
+    "                    110 + 70 * np.cos((xx + 90) / 10) ** 2,\n",
+    "                ]\n",
+    "            ),\n",
+    "        ),\n",
     "    },\n",
     "    coords={\"time\": [\"2026-01-01\", \"2026-07-01\"], \"lat\": lat, \"lon\": lon},\n",
     ")\n",
@@ -123,7 +128,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "rgb-heading",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Multivariable Dataset as RGB\n",
@@ -133,8 +138,8 @@
   },
   {
    "cell_type": "code",
-   "id": "show-rgb-dataset",
    "execution_count": null,
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cleanup-heading",
+   "id": "10",
    "metadata": {},
    "source": [
     "The xarray objects are converted to session-scoped temporary Cloud-Optimized GeoTIFFs. Close the widget when finished to remove them."
@@ -169,8 +174,8 @@
   },
   {
    "cell_type": "code",
-   "id": "cleanup",
    "execution_count": null,
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,11 @@ classifiers = [
 dependencies = ["anywidget>=0.9", "traitlets>=5", "jupyter-ui-poll>=0.2"]
 
 [project.optional-dependencies]
+# `all` is the union of the data extras. It now pulls in the raster stack
+# (rasterio ships GDAL), so installs that only need GeoDataFrames and local
+# vector files can ask for `vector` instead.
 all = ["geopandas", "shapely", "xarray", "rioxarray", "rasterio"]
+vector = ["geopandas", "shapely"]
 raster = ["xarray", "rioxarray", "rasterio"]
 # The MCP server (geolibre.mcp) is the only thing that imports the SDK, so it
 # stays optional: the widget and the project builders work without it.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 dependencies = ["anywidget>=0.9", "traitlets>=5", "jupyter-ui-poll>=0.2"]
 
 [project.optional-dependencies]
-all = ["geopandas", "shapely"]
+all = ["geopandas", "shapely", "xarray", "rioxarray", "rasterio"]
+raster = ["xarray", "rioxarray", "rasterio"]
 # The MCP server (geolibre.mcp) is the only thing that imports the SDK, so it
 # stays optional: the widget and the project builders work without it.
 mcp = ["mcp>=2.0"]

--- a/python/src/geolibre/_server.py
+++ b/python/src/geolibre/_server.py
@@ -294,6 +294,31 @@ def register_local_file(path: str | os.PathLike[str]) -> str:
     return f"{base}{_LOCAL_FILE_PREFIX.lstrip('/')}{token}/{quote(file_path.name)}"
 
 
+def unregister_local_file(path: str | os.PathLike[str]) -> None:
+    """Drop the registration for ``path``, if it has one.
+
+    The counterpart of :func:`register_local_file`, so a caller that owns the
+    file's lifetime (``Map`` deleting a GeoTIFF it materialized from an xarray
+    object) can also drop the token instead of leaving a dead entry behind. Each
+    materialization writes to a fresh temporary path, so without this the
+    registry — which ``register_local_file`` scans linearly to dedup — would grow
+    for the life of the kernel.
+
+    Args:
+        path: A path previously passed to :func:`register_local_file`. It is
+            resolved the same way, so the caller can pass what it handed in.
+            A path that is not registered is ignored.
+    """
+    try:
+        file_path = Path(path).expanduser().resolve()
+    except OSError:  # pragma: no cover - best-effort during interpreter exit
+        return
+    with _lock:
+        for token, registered in list(_local_files.items()):
+            if registered == file_path:
+                del _local_files[token]
+
+
 def app_port() -> int | None:
     """Return the port the static app server is listening on, if started.
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1905,9 +1905,10 @@ class Map(anywidget.AnyWidget):
 
     def add_raster(
         self,
-        source: Any,
+        source: Any = None,
         name: str = "Raster",
         *,
+        url: str | os.PathLike[str] | None = None,
         bands: list[int] | None = None,
         colormap: str | None = None,
         rescale: list[list[float]] | None = None,
@@ -1930,6 +1931,9 @@ class Map(anywidget.AnyWidget):
             source: URL or path of a COG / GeoTIFF, or an
                 ``xarray.DataArray`` / ``xarray.Dataset``.
             name: Layer display name.
+            url: Deprecated alias of ``source``, kept because this method used
+                to name its first parameter ``url`` (as :meth:`add_cog` still
+                does). Passing it emits a ``DeprecationWarning``.
             bands: Optional 1-based band indices to render.
             colormap: Optional colormap name (single-band rendering).
             rescale: Optional ``[[min, max], ...]`` ranges per band.
@@ -1943,6 +1947,19 @@ class Map(anywidget.AnyWidget):
         Returns:
             The id of the added layer.
         """
+        if url is not None:
+            if source is not None:
+                raise TypeError("add_raster() got both 'source' and its deprecated alias 'url'")
+            warnings.warn(
+                "add_raster(url=...) is deprecated; pass the raster as the first "
+                "positional argument or as source=...",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            source = url
+        if source is None:
+            raise TypeError("add_raster() missing required argument: 'source'")
+
         raster_source = source
         if not isinstance(source, (str, os.PathLike)):
             raster_source = self._materialize_xarray(source, array_args)

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -17,6 +17,7 @@ import time
 import urllib.parse
 import uuid
 import warnings
+import weakref
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 from urllib.error import URLError
@@ -64,6 +65,21 @@ _EE_VECTOR_STYLE_KEYS = frozenset(
 # restkey is ``None``, which would put a non-string key in the feature
 # properties and break JSON serialization on the way to the widget.
 _CSV_RESTKEY = "_extra"
+
+
+def _remove_temporary_rasters(paths: list[pathlib.Path]) -> None:
+    """Delete GeoTIFFs materialized from in-memory xarray objects.
+
+    Args:
+        paths: Paths to remove. The list is cleared in place so the same
+            object can be shared with a ``weakref.finalize`` safety net.
+    """
+    for path in paths:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:  # pragma: no cover - best-effort cleanup at exit
+            pass
+    paths.clear()
 
 
 def _read_local_vector(
@@ -388,6 +404,14 @@ class Map(anywidget.AnyWidget):
         # disk while the widget is alive because the app reads them lazily via
         # HTTP Range requests.
         self._temporary_rasters: list[pathlib.Path] = []
+        # ``close()`` is easy to forget, so the same list is handed to a
+        # finalizer, which weakref runs when the Map is collected and, because
+        # ipywidgets keeps widgets referenced until then, at interpreter exit.
+        # ``close()`` clears the list in place rather than rebinding it, so this
+        # finalizer stays valid for anything materialized afterwards.
+        self._raster_cleanup = weakref.finalize(
+            self, _remove_temporary_rasters, self._temporary_rasters
+        )
         self.on_msg(self._on_custom_msg)
 
     def close(self) -> None:
@@ -395,9 +419,7 @@ class Map(anywidget.AnyWidget):
         try:
             super().close()
         finally:
-            for path in getattr(self, "_temporary_rasters", []):
-                path.unlink(missing_ok=True)
-            self._temporary_rasters = []
+            _remove_temporary_rasters(getattr(self, "_temporary_rasters", []))
 
     @staticmethod
     def _running_on_colab() -> bool:
@@ -1900,6 +1922,10 @@ class Map(anywidget.AnyWidget):
         EPSG:4326; other dimension names require georeferencing through the
         object's ``.rio`` accessor or ``array_args``.
 
+        The temporary GeoTIFF is removed by :meth:`close`, and, if that is never
+        called, when the ``Map`` is garbage collected or the interpreter exits
+        normally. A killed kernel leaves the file in the system temp directory.
+
         Args:
             source: URL or path of a COG / GeoTIFF, or an
                 ``xarray.DataArray`` / ``xarray.Dataset``.
@@ -1921,7 +1947,11 @@ class Map(anywidget.AnyWidget):
         if not isinstance(source, (str, os.PathLike)):
             raster_source = self._materialize_xarray(source, array_args)
         elif array_args:
-            warnings.warn("array_args is ignored unless source is an xarray object", UserWarning)
+            warnings.warn(
+                "array_args is ignored unless source is an xarray object",
+                UserWarning,
+                stacklevel=2,
+            )
         return self.add_cog(
             raster_source,
             name,

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -12,6 +12,7 @@ import math
 import os
 import pathlib
 import re
+import tempfile
 import time
 import urllib.parse
 import uuid
@@ -383,7 +384,20 @@ class Map(anywidget.AnyWidget):
         # name to its registered callbacks.
         self._pending: dict[str, dict[str, Any]] = {}
         self._event_handlers: dict[str, list[Callable[[Any], None]]] = {}
+        # GeoTIFFs materialized from in-memory xarray objects must remain on
+        # disk while the widget is alive because the app reads them lazily via
+        # HTTP Range requests.
+        self._temporary_rasters: list[pathlib.Path] = []
         self.on_msg(self._on_custom_msg)
+
+    def close(self) -> None:
+        """Close the widget and remove rasters materialized from xarray data."""
+        try:
+            super().close()
+        finally:
+            for path in getattr(self, "_temporary_rasters", []):
+                path.unlink(missing_ok=True)
+            self._temporary_rasters = []
 
     @staticmethod
     def _running_on_colab() -> bool:
@@ -1869,32 +1883,136 @@ class Map(anywidget.AnyWidget):
 
     def add_raster(
         self,
-        url: str,
+        source: Any,
         name: str = "Raster",
         *,
         bands: list[int] | None = None,
         colormap: str | None = None,
         rescale: list[list[float]] | None = None,
+        array_args: dict[str, Any] | None = None,
         **style: Any,
     ) -> str:
-        """Add a raster (COG / GeoTIFF) layer.
+        """Add a raster from a COG, GeoTIFF, or xarray object.
 
-        Alias of :meth:`add_cog` with a generic default name. Accepts a URL or a
-        kernel-side local GeoTIFF path (see :meth:`add_cog` for the local-file
-        caveats).
+        URLs and paths are passed to :meth:`add_cog`. An
+        ``xarray.DataArray`` or ``xarray.Dataset`` is first materialized as a
+        temporary GeoTIFF using rioxarray. Longitude/latitude dimensions imply
+        EPSG:4326; other dimension names require georeferencing through the
+        object's ``.rio`` accessor or ``array_args``.
 
         Args:
-            url: URL of the COG / GeoTIFF, or a local GeoTIFF path.
+            source: URL or path of a COG / GeoTIFF, or an
+                ``xarray.DataArray`` / ``xarray.Dataset``.
             name: Layer display name.
             bands: Optional 1-based band indices to render.
             colormap: Optional colormap name (single-band rendering).
             rescale: Optional ``[[min, max], ...]`` ranges per band.
+            array_args: Options used only for xarray inputs. ``variable``
+                selects one Dataset variable, ``isel`` slices extra dimensions,
+                and ``x_dim``, ``y_dim``, ``crs``, and ``nodata`` override the
+                corresponding spatial metadata. Remaining options are passed to
+                ``rio.to_raster``.
             **style: Style overrides.
 
         Returns:
             The id of the added layer.
         """
-        return self.add_cog(url, name, bands=bands, colormap=colormap, rescale=rescale, **style)
+        raster_source = source
+        if not isinstance(source, (str, os.PathLike)):
+            raster_source = self._materialize_xarray(source, array_args)
+        elif array_args:
+            warnings.warn("array_args is ignored unless source is an xarray object", UserWarning)
+        return self.add_cog(
+            raster_source,
+            name,
+            bands=bands,
+            colormap=colormap,
+            rescale=rescale,
+            **style,
+        )
+
+    def _materialize_xarray(
+        self, source: Any, array_args: dict[str, Any] | None = None
+    ) -> pathlib.Path:
+        """Write an xarray DataArray or Dataset to a session-scoped COG."""
+        try:
+            import xarray as xr
+        except ImportError as exc:  # pragma: no cover - object normally implies install
+            raise ImportError(
+                "xarray support requires the 'raster' extra: pip install geolibre[raster]"
+            ) from exc
+
+        if not isinstance(source, (xr.DataArray, xr.Dataset)):
+            raise TypeError(
+                "source must be a COG/GeoTIFF URL or path, or an xarray DataArray/Dataset"
+            )
+        try:
+            import rioxarray  # noqa: F401 -- registers the .rio accessor
+        except ImportError as exc:
+            raise ImportError(
+                "xarray raster support requires rioxarray and rasterio; "
+                "install them with: pip install geolibre[raster]"
+            ) from exc
+
+        options = dict(array_args or {})
+        variable = options.pop("variable", None)
+        indexers = options.pop("isel", None)
+        x_dim = options.pop("x_dim", None)
+        y_dim = options.pop("y_dim", None)
+        crs = options.pop("crs", None)
+        nodata = options.pop("nodata", None)
+
+        data = source
+        if variable is not None:
+            if not isinstance(data, xr.Dataset):
+                raise ValueError("array_args['variable'] is only valid for an xarray Dataset")
+            if variable not in data.data_vars:
+                raise ValueError(f"Dataset has no data variable named {variable!r}")
+            data = data[variable]
+        elif isinstance(data, xr.Dataset) and not data.data_vars:
+            raise ValueError("Cannot visualize an xarray Dataset with no data variables")
+        if indexers is not None:
+            if not isinstance(indexers, Mapping):
+                raise TypeError(
+                    "array_args['isel'] must be a mapping of dimension names to indices"
+                )
+            data = data.isel(dict(indexers))
+
+        dims = set(data.dims)
+        x_dim = x_dim or next((d for d in ("x", "lon", "longitude") if d in dims), None)
+        y_dim = y_dim or next((d for d in ("y", "lat", "latitude") if d in dims), None)
+        if x_dim is None or y_dim is None:
+            raise ValueError(
+                "Could not identify x/y dimensions. Set array_args={'x_dim': ..., 'y_dim': ...}."
+            )
+        data = data.rio.set_spatial_dims(x_dim=x_dim, y_dim=y_dim, inplace=False)
+        if crs is not None:
+            data = data.rio.write_crs(crs, inplace=False)
+        elif data.rio.crs is None:
+            if x_dim in {"lon", "longitude"} and y_dim in {"lat", "latitude"}:
+                data = data.rio.write_crs("EPSG:4326", inplace=False)
+            else:
+                raise ValueError(
+                    "The xarray object has no CRS. Set it with .rio.write_crs() or "
+                    "array_args={'crs': 'EPSG:...'} ."
+                )
+        if nodata is not None:
+            data = data.rio.write_nodata(nodata, inplace=False)
+
+        handle, raw_path = tempfile.mkstemp(prefix="geolibre-xarray-", suffix=".tif")
+        os.close(handle)
+        path = pathlib.Path(raw_path)
+        try:
+            # The browser can range-read a COG directly. A plain GTiff makes
+            # the app warn and convert the full file client-side before it can
+            # display the layer.
+            options.setdefault("driver", "COG")
+            data.rio.to_raster(path, **options)
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+        self._temporary_rasters.append(path)
+        return path
 
     def add_wms(
         self,

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1997,7 +1997,19 @@ class Map(anywidget.AnyWidget):
                     "array_args={'crs': 'EPSG:...'} ."
                 )
         if nodata is not None:
-            data = data.rio.write_nodata(nodata, inplace=False)
+            if isinstance(data, xr.Dataset):
+                # RasterDataset has no write_nodata method; nodata metadata
+                # belongs to each DataArray variable instead. Assign the
+                # results explicitly because Dataset.map() discards the
+                # per-variable _FillValue attributes written by rioxarray.
+                data = data.copy()
+                for variable_name in data.data_vars:
+                    data[variable_name] = data[variable_name].rio.write_nodata(
+                        nodata, inplace=False
+                    )
+                data = data.rio.set_spatial_dims(x_dim=x_dim, y_dim=y_dim, inplace=False)
+            else:
+                data = data.rio.write_nodata(nodata, inplace=False)
 
         handle, raw_path = tempfile.mkstemp(prefix="geolibre-xarray-", suffix=".tif")
         os.close(handle)

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -27,7 +27,7 @@ import traitlets
 
 from . import authoring as _authoring
 from . import project as _project
-from ._server import app_port, register_local_file, serve_app
+from ._server import app_port, register_local_file, serve_app, unregister_local_file
 from .basemaps import resolve_basemap
 from .polyline import polyline_to_geojson
 
@@ -75,6 +75,10 @@ def _remove_temporary_rasters(paths: list[pathlib.Path]) -> None:
             object can be shared with a ``weakref.finalize`` safety net.
     """
     for path in paths:
+        # Drop the static server's token as well: each materialization writes to
+        # a fresh temporary path, so the registry would otherwise keep an entry
+        # per call for the life of the kernel.
+        unregister_local_file(path)
         try:
             path.unlink(missing_ok=True)
         except OSError:  # pragma: no cover - best-effort cleanup at exit

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -611,6 +611,28 @@ def test_add_raster_xarray_requires_recognizable_spatial_dims(monkeypatch, m):
         m.add_raster(DataArray(dims=("row", "column")))
 
 
+def test_add_raster_xarray_temp_file_removed_without_close(monkeypatch):
+    """The finalizer must clean up when the user never calls Map.close()."""
+    monkeypatch.setattr(gmod, "serve_app", lambda *_a, **_k: "http://127.0.0.1:0/")
+    monkeypatch.setattr(gmod, "app_port", lambda: 0)
+    DataArray, _ = _fake_xarray_modules(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(
+        gmod,
+        "register_local_file",
+        lambda path: captured.update(path=path) or "http://local/x.tif",
+    )
+
+    widget = Map()
+    widget.add_raster(DataArray())
+    assert captured["path"].exists()
+
+    assert widget._raster_cleanup.alive
+    widget._raster_cleanup()  # what weakref runs at interpreter exit
+    assert not captured["path"].exists()
+    assert widget._temporary_rasters == []
+
+
 def test_add_raster_rejects_non_raster_object(monkeypatch, m):
     _fake_xarray_modules(monkeypatch)
     with pytest.raises(TypeError, match="xarray DataArray/Dataset"):

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -494,6 +494,109 @@ def test_add_raster_url_not_served(monkeypatch, m):
     assert _last_layer(m)["source"]["url"] == "https://e/dem.tif"
 
 
+def _fake_xarray_modules(monkeypatch):
+    """Install tiny xarray/rioxarray stand-ins for conversion unit tests."""
+
+    class Rio:
+        def __init__(self, owner):
+            self.owner = owner
+            self.crs = owner.crs
+
+        def set_spatial_dims(self, *, x_dim, y_dim, inplace):
+            assert not inplace
+            self.owner.spatial_dims = (x_dim, y_dim)
+            return self.owner
+
+        def write_crs(self, crs, *, inplace):
+            assert not inplace
+            self.owner.crs = crs
+            self.crs = crs
+            return self.owner
+
+        def write_nodata(self, nodata, *, inplace):
+            assert not inplace
+            self.owner.nodata = nodata
+            return self.owner
+
+        def to_raster(self, path, **options):
+            self.owner.raster_options = options
+            path.write_bytes(b"fake geotiff")
+
+    class DataArray:
+        def __init__(self, dims=("lat", "lon"), crs=None):
+            self.dims = dims
+            self.crs = crs
+            self.rio = Rio(self)
+
+        def isel(self, indexers):
+            self.indexers = indexers
+            return self
+
+    class Dataset(DataArray):
+        def __init__(self, variables):
+            super().__init__()
+            self.data_vars = variables
+
+        def __getitem__(self, key):
+            return self.data_vars[key]
+
+    monkeypatch.setitem(
+        sys.modules, "xarray", types.SimpleNamespace(DataArray=DataArray, Dataset=Dataset)
+    )
+    monkeypatch.setitem(sys.modules, "rioxarray", types.SimpleNamespace())
+    return DataArray, Dataset
+
+
+def test_add_raster_xarray_dataarray_materializes_geotiff(monkeypatch, m):
+    DataArray, _ = _fake_xarray_modules(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(
+        gmod,
+        "register_local_file",
+        lambda path: captured.update(path=path) or "http://127.0.0.1/xarray.tif",
+    )
+
+    array = DataArray()
+    m.add_raster(array, colormap="viridis", array_args={"nodata": -9999, "compress": "LZW"})
+
+    assert array.spatial_dims == ("lon", "lat")
+    assert array.crs == "EPSG:4326"
+    assert array.nodata == -9999
+    assert array.raster_options == {"driver": "COG", "compress": "LZW"}
+    assert captured["path"].read_bytes() == b"fake geotiff"
+    assert _last_layer(m)["source"]["url"] == "http://127.0.0.1/xarray.tif"
+    m.close()
+    assert not captured["path"].exists()
+
+
+def test_add_raster_xarray_dataset_selects_variable(monkeypatch, m):
+    DataArray, Dataset = _fake_xarray_modules(monkeypatch)
+    selected = DataArray(dims=("time", "y", "x"), crs="EPSG:3857")
+    dataset = Dataset({"temperature": selected})
+    monkeypatch.setattr(gmod, "register_local_file", lambda _path: "http://local/x.tif")
+
+    m.add_raster(
+        dataset,
+        array_args={"variable": "temperature", "isel": {"time": 0}},
+    )
+
+    assert selected.indexers == {"time": 0}
+    assert selected.spatial_dims == ("x", "y")
+    m.close()
+
+
+def test_add_raster_xarray_requires_recognizable_spatial_dims(monkeypatch, m):
+    DataArray, _ = _fake_xarray_modules(monkeypatch)
+    with pytest.raises(ValueError, match="Could not identify x/y dimensions"):
+        m.add_raster(DataArray(dims=("row", "column")))
+
+
+def test_add_raster_rejects_non_raster_object(monkeypatch, m):
+    _fake_xarray_modules(monkeypatch)
+    with pytest.raises(TypeError, match="xarray DataArray/Dataset"):
+        m.add_raster(object())
+
+
 # -- markers --------------------------------------------------------------
 
 

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -544,7 +544,12 @@ def _fake_xarray_modules(monkeypatch):
             self.data_vars[key] = value
 
         def copy(self):
-            return self
+            """Model xarray's shallow copy: a new Dataset over the same variables."""
+            duplicate = Dataset(dict(self.data_vars))
+            duplicate.dims = self.dims
+            duplicate.crs = self.crs
+            duplicate.rio.crs = self.crs
+            return duplicate
 
     monkeypatch.setitem(
         sys.modules, "xarray", types.SimpleNamespace(DataArray=DataArray, Dataset=Dataset)
@@ -602,6 +607,8 @@ def test_add_raster_xarray_dataset_applies_nodata_to_each_variable(monkeypatch, 
 
     assert red.nodata == 255
     assert green.nodata == 255
+    # The GeoTIFF must be written from the copy, not from the caller's Dataset.
+    assert not hasattr(dataset, "raster_options")
     m.close()
 
 

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -630,6 +630,9 @@ def test_add_raster_xarray_temp_file_removed_without_close(monkeypatch):
         lambda path: captured.update(path=path) or "http://local/x.tif",
     )
 
+    unregistered = []
+    monkeypatch.setattr(gmod, "unregister_local_file", unregistered.append)
+
     widget = Map()
     widget.add_raster(DataArray())
     assert captured["path"].exists()
@@ -638,6 +641,48 @@ def test_add_raster_xarray_temp_file_removed_without_close(monkeypatch):
     widget._raster_cleanup()  # what weakref runs at interpreter exit
     assert not captured["path"].exists()
     assert widget._temporary_rasters == []
+    # The static server's token goes with the file, so a looping session does
+    # not leave a registry entry per materialization behind.
+    assert unregistered == [captured["path"]]
+
+
+def test_add_raster_xarray_round_trip_with_real_rioxarray(monkeypatch, m):
+    """Pin real rioxarray behavior the fake modules above cannot model.
+
+    The Dataset nodata path copies the Dataset and reassigns every variable,
+    which drops rio's cached spatial dims (hence the explicit re-set) but not
+    the CRS, which lives in each variable's ``spatial_ref``. Assert the written
+    COG really keeps both, so a rioxarray change is caught here rather than by
+    a user staring at an unplaced raster.
+    """
+    xr = pytest.importorskip("xarray")
+    pytest.importorskip("rioxarray")
+    rasterio = pytest.importorskip("rasterio")
+    np = pytest.importorskip("numpy")
+
+    dataset = xr.Dataset(
+        {
+            "red": (("lat", "lon"), np.zeros((4, 5), dtype="float32")),
+            "green": (("lat", "lon"), np.ones((4, 5), dtype="float32")),
+        },
+        coords={"lat": np.linspace(40, 30, 4), "lon": np.linspace(-100, -90, 5)},
+    )
+    captured = {}
+    monkeypatch.setattr(
+        gmod,
+        "register_local_file",
+        lambda path: captured.update(path=path) or "http://local/ds.tif",
+    )
+
+    m.add_raster(dataset, array_args={"nodata": 255})
+
+    with rasterio.open(captured["path"]) as src:
+        assert src.crs.to_string() == "EPSG:4326"  # inferred from lon/lat
+        assert src.count == 2
+        assert src.nodata == 255
+        assert src.driver == "GTiff"  # what rasterio reports for a COG
+    m.close()
+    assert not captured["path"].exists()
 
 
 def test_add_raster_accepts_deprecated_url_keyword(m):

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -540,6 +540,12 @@ def _fake_xarray_modules(monkeypatch):
         def __getitem__(self, key):
             return self.data_vars[key]
 
+        def __setitem__(self, key, value):
+            self.data_vars[key] = value
+
+        def copy(self):
+            return self
+
     monkeypatch.setitem(
         sys.modules, "xarray", types.SimpleNamespace(DataArray=DataArray, Dataset=Dataset)
     )
@@ -582,6 +588,20 @@ def test_add_raster_xarray_dataset_selects_variable(monkeypatch, m):
 
     assert selected.indexers == {"time": 0}
     assert selected.spatial_dims == ("x", "y")
+    m.close()
+
+
+def test_add_raster_xarray_dataset_applies_nodata_to_each_variable(monkeypatch, m):
+    DataArray, Dataset = _fake_xarray_modules(monkeypatch)
+    red = DataArray()
+    green = DataArray()
+    dataset = Dataset({"red": red, "green": green})
+    monkeypatch.setattr(gmod, "register_local_file", lambda _path: "http://local/rgb.tif")
+
+    m.add_raster(dataset, array_args={"nodata": 255})
+
+    assert red.nodata == 255
+    assert green.nodata == 255
     m.close()
 
 

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -640,6 +640,23 @@ def test_add_raster_xarray_temp_file_removed_without_close(monkeypatch):
     assert widget._temporary_rasters == []
 
 
+def test_add_raster_accepts_deprecated_url_keyword(m):
+    """The pre-rename `url=` keyword still works, with a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="add_raster\\(url=...\\) is deprecated"):
+        m.add_raster(url="https://e/dem.tif", name="DEM")
+    assert _last_layer(m)["source"]["url"] == "https://e/dem.tif"
+
+
+def test_add_raster_rejects_source_and_url_together(m):
+    with pytest.raises(TypeError, match="deprecated alias"):
+        m.add_raster("https://e/a.tif", url="https://e/b.tif")
+
+
+def test_add_raster_requires_a_source(m):
+    with pytest.raises(TypeError, match="missing required argument"):
+        m.add_raster()
+
+
 def test_add_raster_rejects_non_raster_object(monkeypatch, m):
     _fake_xarray_modules(monkeypatch)
     with pytest.raises(TypeError, match="xarray DataArray/Dataset"):

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -114,6 +114,25 @@ def test_register_same_file_reuses_token(served):
     assert len(_server._local_files) == 1
 
 
+def test_unregister_local_file_drops_the_token(served, tmp_path):
+    url, _payload = served
+    assert len(_server._local_files) == 1
+    registered = next(iter(_server._local_files.values()))
+
+    _server.unregister_local_file(registered)
+    assert _server._local_files == {}
+
+    # The route is gone once the token is dropped.
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        _get(url)
+    assert excinfo.value.code == 404
+
+
+def test_unregister_unknown_file_is_a_no_op(served, tmp_path):
+    _server.unregister_local_file(tmp_path / "never-registered.tif")
+    assert len(_server._local_files) == 1
+
+
 def test_options_preflight_allows_range(served):
     url, _payload = served
     request = urllib.request.Request(url, method="OPTIONS")

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -46,7 +46,7 @@ m.add_geoparquet(data, name="GeoParquet")
 m.add_flatgeobuf(data, name="FlatGeobuf")
 m.add_csv(data, x="longitude", y="latitude", name="CSV")
 m.add_cog(url, name="COG", bands=None, colormap=None, rescale=None)
-m.add_raster(...)                                     # same, incl. a local GeoTIFF
+m.add_raster(...)                                     # same, plus xarray DataArray/Dataset
 m.add_tile_layer(url, name, tile_size=256, attribution=None)
 m.add_ee_layer(ee_object, vis_params=None, name="Earth Engine", shown=True,
                opacity=1.0)

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -48,6 +48,7 @@ m.add_csv(data, x="longitude", y="latitude", name="CSV")
 m.add_cog(url, name="COG", bands=None, colormap=None, rescale=None)
 m.add_raster(source, name="Raster", bands=None, colormap=None, rescale=None,
              array_args=None)                         # same, plus xarray DataArray/Dataset
+             # `url=` still works as a deprecated keyword alias of `source`
 m.add_tile_layer(url, name, tile_size=256, attribution=None)
 m.add_ee_layer(ee_object, vis_params=None, name="Earth Engine", shown=True,
                opacity=1.0)
@@ -92,8 +93,10 @@ m.add_polyline(...)
 
 `add_raster` also accepts an `xarray.DataArray` or `xarray.Dataset`, which needs
 `pip install "geolibre[raster]"` (xarray + rioxarray + rasterio). The kernel
-writes it to a temporary Cloud-Optimized GeoTIFF and serves that the same way it
-serves a local file, so every caveat in the next section applies to it as well.
+writes it to a temporary GeoTIFF — Cloud-Optimized by default — and serves that
+the same way it serves a local file, so every caveat in the next section applies
+to it as well. Keep the default: the app range-reads a COG directly, and a plain
+GeoTIFF makes it warn and convert the whole file in the browser first.
 
 ```python
 m.add_raster(data_array, name="Temperature", colormap="viridis")
@@ -113,7 +116,8 @@ and is ignored). It takes:
 | `nodata` | Nodata value to write. |
 
 Anything else in `array_args` is forwarded to `rio.to_raster` (`compress`, and
-so on; `driver` defaults to `"COG"`).
+so on). `driver` only *defaults* to `"COG"`, so passing
+`array_args={"driver": "GTiff"}` really does write a plain GeoTIFF instead.
 
 Only `lon`/`lat` and `longitude`/`latitude` dimensions imply EPSG:4326. Any
 other object must already carry a CRS (`.rio.write_crs(...)`) or be given

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -46,7 +46,8 @@ m.add_geoparquet(data, name="GeoParquet")
 m.add_flatgeobuf(data, name="FlatGeobuf")
 m.add_csv(data, x="longitude", y="latitude", name="CSV")
 m.add_cog(url, name="COG", bands=None, colormap=None, rescale=None)
-m.add_raster(...)                                     # same, plus xarray DataArray/Dataset
+m.add_raster(source, name="Raster", bands=None, colormap=None, rescale=None,
+             array_args=None)                         # same, plus xarray DataArray/Dataset
 m.add_tile_layer(url, name, tile_size=256, attribution=None)
 m.add_ee_layer(ee_object, vis_params=None, name="Earth Engine", shown=True,
                opacity=1.0)
@@ -86,6 +87,46 @@ m.add_marker_cluster(points, cluster_radius=50, cluster_max_zoom=14)
 m.add_heatmap(points, radius=35, intensity=1)
 m.add_polyline(...)
 ```
+
+### In-memory xarray rasters
+
+`add_raster` also accepts an `xarray.DataArray` or `xarray.Dataset`, which needs
+`pip install "geolibre[raster]"` (xarray + rioxarray + rasterio). The kernel
+writes it to a temporary Cloud-Optimized GeoTIFF and serves that the same way it
+serves a local file, so every caveat in the next section applies to it as well.
+
+```python
+m.add_raster(data_array, name="Temperature", colormap="viridis")
+m.add_raster(dataset, name="Temperature",
+             array_args={"variable": "temperature", "isel": {"time": 0}})
+```
+
+`array_args` is used only for xarray input (passing it with a URL or path warns
+and is ignored). It takes:
+
+| Key | Meaning |
+| --- | --- |
+| `variable` | Pick one variable out of a `Dataset` (otherwise every variable becomes a band). |
+| `isel` | Mapping of dimension name → index, applied with `.isel()` to drop extra dimensions (time, depth). |
+| `x_dim` / `y_dim` | Spatial dimension names, when they are not `x`/`y`, `lon`/`lat`, or `longitude`/`latitude`. |
+| `crs` | CRS to write, e.g. `"EPSG:3857"`. |
+| `nodata` | Nodata value to write. |
+
+Anything else in `array_args` is forwarded to `rio.to_raster` (`compress`, and
+so on; `driver` defaults to `"COG"`).
+
+Only `lon`/`lat` and `longitude`/`latitude` dimensions imply EPSG:4326. Any
+other object must already carry a CRS (`.rio.write_crs(...)`) or be given
+`array_args={"crs": ...}` — otherwise `add_raster` raises. It also raises when
+the x/y dimensions cannot be identified, when `variable` names something the
+Dataset does not have, and when a `Dataset` has no data variables.
+
+The temporary GeoTIFF is removed by `m.close()`, and, if that is never called,
+when the `Map` is garbage collected or the interpreter exits normally; a killed
+kernel leaves the file in the system temp directory. Because the file is
+session-scoped, **a project saved with an xarray layer will not reopen it
+later** — write the raster to a hosted COG and pass its URL for anything
+durable.
 
 ### Local files vs. hosted URLs
 


### PR DESCRIPTION
## Summary
- accept xarray DataArray and Dataset inputs in the Python `add_raster` API
- materialize in-memory arrays as session-scoped COGs with spatial metadata, variable selection, and dimension slicing
- add optional raster dependencies, documentation, unit coverage, and a runnable notebook example

## Install footprint

`geolibre[all]` is the union of the data extras, so it now pulls in
xarray/rioxarray/**rasterio** (and GDAL with it) on top of the existing
GeoPandas/Shapely. That is intentional -- `all` stays "all" -- but it is a
meaningful increase in install size/time for anyone who was installing `[all]`
only for the vector support. To keep those environments as light as before, this
PR adds a `vector` extra:

- `pip install "geolibre[vector]"` -- GeoPandas/Shapely only (the previous `all`)
- `pip install "geolibre[raster]"` -- xarray/rioxarray/rasterio only
- `pip install "geolibre[all]"` -- both

## Backward compatibility

`add_raster`'s first parameter is renamed `url` -> `source`, since it now takes
an xarray object as well. `url` remains a keyword-only **deprecated alias**, so
`m.add_raster(url=...)` keeps working (with a `DeprecationWarning`); passing both
raises `TypeError`. `add_cog` is unchanged.

## Temporary raster lifetime

An xarray layer is materialized as a COG in the system temp directory. It is
removed by `Map.close()`, and a `weakref.finalize` safety net removes it when the
`Map` is garbage collected or when the interpreter exits normally, so forgetting
`close()` no longer leaks the file. A kernel that is killed outright still leaves
it behind; this is documented in `docs/python.md` and in `add_raster`'s docstring.

## Test plan
- [x] Run all repository pre-commit hooks, including the production build and linters
- [x] Run the complete Python package test suite
- [x] Execute the xarray notebook cells and validate DataArray and multiband Dataset COG output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for visualizing xarray `DataArray` and `Dataset` objects as raster layers.
  * Added variable selection, dimension slicing, CRS, nodata, and raster output options.
  * Added support for local and remote COG/GeoTIFF sources.
  * Added automatic temporary raster cleanup when maps close.
  * Added a Jupyter notebook demonstrating xarray raster workflows.

* **Documentation**
  * Updated Python API guides with setup requirements, usage examples, CRS defaults, and cleanup behavior.
  * Added separate vector and raster installation extras, with raster support included in the complete installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

