### PR TITLE
Fix Ollama model discovery and chat UUIDs

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -536,9 +536,10 @@ function ProfileEditor({
     profile.provider === "ollama" && ollamaDiscovery.models.length > 0
       ? [
           ...new Set(
-            [profile.modelId || defaultModelFor(profile.provider), ...ollamaDiscovery.models].filter(
-              Boolean,
-            ),
+            [
+              profile.modelId || defaultModelFor(profile.provider),
+              ...ollamaDiscovery.models,
+            ].filter(Boolean),
           ),
         ]
       : [...new Set([profile.modelId, ...models].filter(Boolean))];

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -25,7 +25,7 @@ import {
   Trash2,
   TriangleAlert,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { discoverOllamaModels } from "../../lib/assistant/ollama";
 
@@ -65,22 +65,33 @@ function useOllamaModels() {
   const [models, setModels] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestGeneration = useRef(0);
 
   const refresh = async (baseUrl: string) => {
+    const generation = ++requestGeneration.current;
     setLoading(true);
     setError(null);
     try {
-      setModels(await discoverOllamaModels(baseUrl));
+      const discovered = await discoverOllamaModels(baseUrl);
+      if (generation === requestGeneration.current) setModels(discovered);
     } catch (cause) {
+      if (generation !== requestGeneration.current) return;
       const message = cause instanceof Error ? cause.message : String(cause);
       setError(message);
       console.error("[GeoLibre] Could not load Ollama models", cause);
     } finally {
-      setLoading(false);
+      if (generation === requestGeneration.current) setLoading(false);
     }
   };
 
-  return { models, loading, error, refresh, reset: () => setModels([]) };
+  const reset = () => {
+    requestGeneration.current += 1;
+    setModels([]);
+    setError(null);
+    setLoading(false);
+  };
+
+  return { models, loading, error, refresh, reset };
 }
 
 /**
@@ -296,7 +307,12 @@ export function AiSectionContent({
                     aria-label={t("managePlugins.refresh")}
                     title={t("managePlugins.refresh")}
                     onClick={() =>
-                      void ollamaDiscovery.refresh(newProfileFieldValues.OLLAMA_BASE_URL ?? "")
+                      void ollamaDiscovery.refresh(
+                        newProfileFieldValues.OLLAMA_BASE_URL ||
+                          scopedOsEnv.OLLAMA_BASE_URL ||
+                          scopedOsEnv.OLLAMA_HOST ||
+                          "",
+                      )
                     }
                   >
                     <RefreshCw
@@ -518,7 +534,13 @@ function ProfileEditor({
   const models = PROVIDER_MODELS[profile.provider];
   const selectableModels =
     profile.provider === "ollama" && ollamaDiscovery.models.length > 0
-      ? [...new Set([profile.modelId, ...ollamaDiscovery.models].filter(Boolean))]
+      ? [
+          ...new Set(
+            [profile.modelId || defaultModelFor(profile.provider), ...ollamaDiscovery.models].filter(
+              Boolean,
+            ),
+          ),
+        ]
       : [...new Set([profile.modelId, ...models].filter(Boolean))];
   const docsUrl = PROVIDER_DOCS_URL[profile.provider];
 

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -28,6 +28,7 @@ import {
 import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { discoverOllamaModels } from "../../lib/assistant/ollama";
+import { classifyFetchFailure } from "../../lib/fetch-error";
 
 // ── Locally-defined types to avoid circular import with SettingsDialog ──
 
@@ -62,6 +63,7 @@ interface AiSectionContentProps {
 
 /** Shared Ollama discovery state for profile editors. */
 function useOllamaModels() {
+  const { t } = useTranslation();
   const [models, setModels] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -76,8 +78,20 @@ function useOllamaModels() {
       if (generation === requestGeneration.current) setModels(discovered);
     } catch (cause) {
       if (generation !== requestGeneration.current) return;
-      const message = cause instanceof Error ? cause.message : String(cause);
-      setError(message);
+      // Route through the repo's fetch-failure classification: the browser
+      // collapses a CORS rejection (Ollama needs OLLAMA_ORIGINS to allow this
+      // origin) and an unreachable host into the same opaque "Failed to fetch",
+      // so surfacing that message verbatim tells the user nothing actionable.
+      const { kind } = classifyFetchFailure(cause);
+      setError(
+        kind === "network"
+          ? t("settings.ai.ollamaNetworkFailure")
+          : kind === "timeout"
+            ? t("settings.ai.ollamaTimedOut")
+            : cause instanceof Error
+              ? cause.message
+              : String(cause),
+      );
       console.error("[GeoLibre] Could not load Ollama models", cause);
     } finally {
       if (generation === requestGeneration.current) setLoading(false);

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -27,7 +27,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { discoverOllamaModels } from "../../lib/assistant/ollama";
+import { DEFAULT_OLLAMA_BASE_URL, discoverOllamaModels } from "../../lib/assistant/ollama";
 import { classifyFetchFailure } from "../../lib/fetch-error";
 
 // ── Locally-defined types to avoid circular import with SettingsDialog ──
@@ -70,7 +70,12 @@ function useOllamaModels() {
   const requestGeneration = useRef(0);
   const inFlight = useRef<AbortController | null>(null);
 
-  const refresh = async (baseUrl: string) => {
+  /**
+   * Discover the models installed at `baseUrl`. Resolves to the discovered list,
+   * or `null` when the request failed or was superseded — so a caller can
+   * reconcile its selection without having to re-check staleness itself.
+   */
+  const refresh = async (baseUrl: string): Promise<string[] | null> => {
     const generation = ++requestGeneration.current;
     inFlight.current?.abort();
     const controller = new AbortController();
@@ -79,10 +84,12 @@ function useOllamaModels() {
     setError(null);
     try {
       const discovered = await discoverOllamaModels(baseUrl, controller.signal);
-      if (generation === requestGeneration.current) setModels(discovered);
+      if (generation !== requestGeneration.current) return null;
+      setModels(discovered);
+      return discovered;
     } catch (cause) {
-      if (generation !== requestGeneration.current) return;
-      if (controller.signal.aborted) return;
+      if (generation !== requestGeneration.current) return null;
+      if (controller.signal.aborted) return null;
       // Route through the repo's fetch-failure classification: the browser
       // collapses a CORS rejection (Ollama needs OLLAMA_ORIGINS to allow this
       // origin) and an unreachable host into the same opaque "Failed to fetch",
@@ -101,6 +108,7 @@ function useOllamaModels() {
               }),
       );
       console.error("[GeoLibre] Could not load Ollama models", cause);
+      return null;
     } finally {
       if (generation === requestGeneration.current) setLoading(false);
     }
@@ -188,12 +196,23 @@ export function AiSectionContent({
     setIsCreatingProfile(false);
   };
 
+  /**
+   * The credential values a freshly-selected provider starts with. Ollama's base
+   * URL is required but has a well-known default, so it is prefilled rather than
+   * left blank — unless the OS environment already supplies one, which the field
+   * surfaces on its own and must not be shadowed by the default.
+   */
+  const initialFieldValues = (provider: AssistantProviderId): Record<string, string> =>
+    provider === "ollama" && !scopedOsEnv.OLLAMA_BASE_URL && !scopedOsEnv.OLLAMA_HOST
+      ? { OLLAMA_BASE_URL: DEFAULT_OLLAMA_BASE_URL }
+      : {};
+
   /** Start creating a new profile (shows full editor with credential fields). */
   const startCreating = () => {
     setNewProfileName("");
     setNewProfileProvider("google");
     setNewProfileModel(defaultModelFor("google"));
-    setNewProfileFieldValues({});
+    setNewProfileFieldValues(initialFieldValues("google"));
     ollamaDiscovery.reset();
     setIsCreatingProfile(true);
     setEditingProfileId(null);
@@ -299,7 +318,7 @@ export function AiSectionContent({
                 const provider = e.target.value as AssistantProviderId;
                 setNewProfileProvider(provider);
                 setNewProfileModel(defaultModelFor(provider));
-                setNewProfileFieldValues({});
+                setNewProfileFieldValues(initialFieldValues(provider));
                 ollamaDiscovery.reset();
               }}
             >
@@ -321,7 +340,7 @@ export function AiSectionContent({
                   onChange={(e) => setNewProfileModel(e.target.value)}
                 >
                   {(newProfileProvider === "ollama" && ollamaDiscovery.models.length > 0
-                    ? [...new Set([newProfileModel, ...ollamaDiscovery.models].filter(Boolean))]
+                    ? ollamaDiscovery.models
                     : PROVIDER_MODELS[newProfileProvider]
                   ).map((id) => (
                     <option key={id} value={id}>
@@ -338,12 +357,22 @@ export function AiSectionContent({
                     aria-label={t("settings.ai.refreshModels")}
                     title={t("settings.ai.refreshModels")}
                     onClick={() =>
-                      void ollamaDiscovery.refresh(
-                        newProfileFieldValues.OLLAMA_BASE_URL ||
-                          scopedOsEnv.OLLAMA_BASE_URL ||
-                          scopedOsEnv.OLLAMA_HOST ||
-                          "",
-                      )
+                      void ollamaDiscovery
+                        .refresh(
+                          newProfileFieldValues.OLLAMA_BASE_URL ||
+                            scopedOsEnv.OLLAMA_BASE_URL ||
+                            scopedOsEnv.OLLAMA_HOST ||
+                            "",
+                        )
+                        .then((discovered) => {
+                          // The presets are a guess at what a user might have
+                          // pulled; once discovery says otherwise, a selection
+                          // the server does not offer cannot be used, so fall
+                          // back to one it does.
+                          if (discovered?.length && !discovered.includes(newProfileModel)) {
+                            setNewProfileModel(discovered[0]);
+                          }
+                        })
                     }
                   >
                     <RefreshCw
@@ -543,10 +572,25 @@ function ProfileEditor({
 
   const updateProvider = (provider: AssistantProviderId) => {
     ollamaDiscovery.reset();
+    // Ollama's base URL is required but has a well-known default, so prefill it
+    // rather than leaving the profile reading "incomplete" on the stock install.
+    // An OS-supplied value wins: the field surfaces that on its own.
+    const seedBaseUrl =
+      provider === "ollama" && !scopedOsEnv.OLLAMA_BASE_URL && !scopedOsEnv.OLLAMA_HOST;
     setDraftDesktopSettings((current: any) => ({
       ...current,
       aiProfiles: current.aiProfiles.map((p: any) =>
-        p.id === profile.id ? { ...p, provider, modelId: defaultModelFor(provider) } : p,
+        p.id === profile.id
+          ? {
+              ...p,
+              provider,
+              modelId: defaultModelFor(provider),
+              fieldValues:
+                seedBaseUrl && !p.fieldValues?.OLLAMA_BASE_URL
+                  ? { ...p.fieldValues, OLLAMA_BASE_URL: DEFAULT_OLLAMA_BASE_URL }
+                  : p.fieldValues,
+            }
+          : p,
       ),
     }));
   };
@@ -563,25 +607,24 @@ function ProfileEditor({
   const models = PROVIDER_MODELS[profile.provider];
   const selectableModels =
     profile.provider === "ollama" && ollamaDiscovery.models.length > 0
-      ? [
-          ...new Set(
-            [
-              profile.modelId || defaultModelFor(profile.provider),
-              ...ollamaDiscovery.models,
-            ].filter(Boolean),
-          ),
-        ]
+      ? ollamaDiscovery.models
       : [...new Set([profile.modelId, ...models].filter(Boolean))];
   const docsUrl = PROVIDER_DOCS_URL[profile.provider];
 
-  const refreshOllamaModels = () => {
+  const refreshOllamaModels = async () => {
     const baseUrlField = PROVIDER_FIELDS.ollama.find((field) => field.envKey === "OLLAMA_BASE_URL");
-    return ollamaDiscovery.refresh(
+    const discovered = await ollamaDiscovery.refresh(
       (baseUrlField ? getProviderField(baseUrlField) : "") ||
         scopedOsEnv.OLLAMA_BASE_URL ||
         scopedOsEnv.OLLAMA_HOST ||
         "",
     );
+    // The saved model is only worth keeping if the server still offers it — the
+    // provider presets are a guess, and `defaultModelFor` in particular is a
+    // placeholder no local Ollama is guaranteed to have pulled.
+    if (discovered?.length && !discovered.includes(profile.modelId)) {
+      updateModel(discovered[0]);
+    }
   };
 
   return (

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -25,7 +25,7 @@ import {
   Trash2,
   TriangleAlert,
 } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { discoverOllamaModels } from "../../lib/assistant/ollama";
 import { classifyFetchFailure } from "../../lib/fetch-error";
@@ -102,6 +102,11 @@ function useOllamaModels() {
       if (generation === requestGeneration.current) setLoading(false);
     }
   };
+
+  // Cancel a pending discovery when the editor unmounts (a profile switch or
+  // "back" mid-refresh), for the same reason `reset` aborts rather than only
+  // invalidating: an orphaned request otherwise runs on to the deadline.
+  useEffect(() => () => inFlight.current?.abort(), []);
 
   const reset = () => {
     requestGeneration.current += 1;

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -98,7 +98,6 @@ export function AiSectionContent({
     try {
       const models = await discoverOllamaModels(newProfileFieldValues.OLLAMA_BASE_URL ?? "");
       setOllamaModels(models);
-      if (models.length > 0 && !models.includes(newProfileModel)) setNewProfileModel(models[0]);
     } catch (error) {
       console.error("[GeoLibre] Could not load Ollama models", error);
     } finally {
@@ -143,6 +142,7 @@ export function AiSectionContent({
     setNewProfileProvider("google");
     setNewProfileModel(defaultModelFor("google"));
     setNewProfileFieldValues({});
+    setOllamaModels([]);
     setIsCreatingProfile(true);
     setEditingProfileId(null);
   };
@@ -205,6 +205,7 @@ export function AiSectionContent({
       {editingProfileId && editingProfile ? (
         // ── Profile editor ──
         <ProfileEditor
+          key={editingProfile.id}
           profile={editingProfile}
           setDraftDesktopSettings={setDraftDesktopSettings}
           onBack={cancelEditing}
@@ -241,11 +242,13 @@ export function AiSectionContent({
             <Label className="text-xs">{t("settings.ai.providerLabel")}</Label>
             <Select
               value={newProfileProvider}
+              disabled={loadingOllamaModels}
               onChange={(e) => {
                 const provider = e.target.value as AssistantProviderId;
                 setNewProfileProvider(provider);
                 setNewProfileModel(defaultModelFor(provider));
                 setNewProfileFieldValues({});
+                setOllamaModels([]);
               }}
             >
               {ASSISTANT_PROVIDER_IDS.map((id) => (
@@ -266,7 +269,7 @@ export function AiSectionContent({
                   onChange={(e) => setNewProfileModel(e.target.value)}
                 >
                   {(newProfileProvider === "ollama" && ollamaModels.length > 0
-                    ? ollamaModels
+                    ? [...new Set([newProfileModel, ...ollamaModels].filter(Boolean))]
                     : PROVIDER_MODELS[newProfileProvider]
                   ).map((id) => (
                     <option key={id} value={id}>
@@ -478,6 +481,7 @@ function ProfileEditor({
   };
 
   const updateProvider = (provider: AssistantProviderId) => {
+    setOllamaModels([]);
     setDraftDesktopSettings((current: any) => ({
       ...current,
       aiProfiles: current.aiProfiles.map((p: any) =>
@@ -498,7 +502,7 @@ function ProfileEditor({
   const models = PROVIDER_MODELS[profile.provider];
   const selectableModels =
     profile.provider === "ollama" && ollamaModels.length > 0
-      ? ollamaModels
+      ? [...new Set([profile.modelId, ...ollamaModels].filter(Boolean))]
       : [...new Set([profile.modelId, ...models].filter(Boolean))];
   const docsUrl = PROVIDER_DOCS_URL[profile.provider];
 
@@ -507,12 +511,12 @@ function ProfileEditor({
     setLoadingOllamaModels(true);
     try {
       const discovered = await discoverOllamaModels(
-        baseUrlField ? getProviderField(baseUrlField) : "",
+        (baseUrlField ? getProviderField(baseUrlField) : "") ||
+          scopedOsEnv.OLLAMA_BASE_URL ||
+          scopedOsEnv.OLLAMA_HOST ||
+          "",
       );
       setOllamaModels(discovered);
-      if (discovered.length > 0 && !discovered.includes(profile.modelId)) {
-        updateModel(discovered[0]);
-      }
     } catch (error) {
       console.error("[GeoLibre] Could not load Ollama models", error);
     } finally {
@@ -547,6 +551,7 @@ function ProfileEditor({
         <Label className="text-xs">{t("settings.ai.providerLabel")}</Label>
         <Select
           value={profile.provider}
+          disabled={loadingOllamaModels}
           onChange={(e) => updateProvider(e.target.value as AssistantProviderId)}
         >
           {ASSISTANT_PROVIDER_IDS.map((id) => (

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -68,16 +68,21 @@ function useOllamaModels() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requestGeneration = useRef(0);
+  const inFlight = useRef<AbortController | null>(null);
 
   const refresh = async (baseUrl: string) => {
     const generation = ++requestGeneration.current;
+    inFlight.current?.abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
     setLoading(true);
     setError(null);
     try {
-      const discovered = await discoverOllamaModels(baseUrl);
+      const discovered = await discoverOllamaModels(baseUrl, controller.signal);
       if (generation === requestGeneration.current) setModels(discovered);
     } catch (cause) {
       if (generation !== requestGeneration.current) return;
+      if (controller.signal.aborted) return;
       // Route through the repo's fetch-failure classification: the browser
       // collapses a CORS rejection (Ollama needs OLLAMA_ORIGINS to allow this
       // origin) and an unreachable host into the same opaque "Failed to fetch",
@@ -100,6 +105,10 @@ function useOllamaModels() {
 
   const reset = () => {
     requestGeneration.current += 1;
+    // Abort rather than only invalidating, so a discarded request stops
+    // immediately instead of running on to the discovery deadline.
+    inFlight.current?.abort();
+    inFlight.current = null;
     setModels([]);
     setError(null);
     setLoading(false);
@@ -318,8 +327,8 @@ export function AiSectionContent({
                     size="icon"
                     variant="outline"
                     disabled={ollamaDiscovery.loading}
-                    aria-label={t("managePlugins.refresh")}
-                    title={t("managePlugins.refresh")}
+                    aria-label={t("settings.ai.refreshModels")}
+                    title={t("settings.ai.refreshModels")}
                     onClick={() =>
                       void ollamaDiscovery.refresh(
                         newProfileFieldValues.OLLAMA_BASE_URL ||
@@ -337,7 +346,7 @@ export function AiSectionContent({
               </div>
               {ollamaDiscovery.error ? (
                 <p className="text-xs text-destructive">
-                  {t("managePlugins.failedToLoad", { message: ollamaDiscovery.error })}
+                  {t("settings.ai.modelsFailedToLoad", { message: ollamaDiscovery.error })}
                 </p>
               ) : null}
             </div>
@@ -628,8 +637,8 @@ function ProfileEditor({
                 size="icon"
                 variant="outline"
                 disabled={ollamaDiscovery.loading}
-                aria-label={t("managePlugins.refresh")}
-                title={t("managePlugins.refresh")}
+                aria-label={t("settings.ai.refreshModels")}
+                title={t("settings.ai.refreshModels")}
                 onClick={() => void refreshOllamaModels()}
               >
                 <RefreshCw
@@ -640,7 +649,7 @@ function ProfileEditor({
           </div>
           {ollamaDiscovery.error ? (
             <p className="text-xs text-destructive">
-              {t("managePlugins.failedToLoad", { message: ollamaDiscovery.error })}
+              {t("settings.ai.modelsFailedToLoad", { message: ollamaDiscovery.error })}
             </p>
           ) : null}
         </div>

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -88,14 +88,17 @@ function useOllamaModels() {
       // origin) and an unreachable host into the same opaque "Failed to fetch",
       // so surfacing that message verbatim tells the user nothing actionable.
       const { kind } = classifyFetchFailure(cause);
+      // The classified messages are complete sentences, so only the unclassified
+      // fallback (an HTTP status, a parse error) gets the "Could not load
+      // models:" prefix — prefixing all three would read redundantly.
       setError(
         kind === "network"
           ? t("settings.ai.ollamaNetworkFailure")
           : kind === "timeout"
             ? t("settings.ai.ollamaTimedOut")
-            : cause instanceof Error
-              ? cause.message
-              : String(cause),
+            : t("settings.ai.modelsFailedToLoad", {
+                message: cause instanceof Error ? cause.message : String(cause),
+              }),
       );
       console.error("[GeoLibre] Could not load Ollama models", cause);
     } finally {
@@ -350,9 +353,7 @@ export function AiSectionContent({
                 ) : null}
               </div>
               {ollamaDiscovery.error ? (
-                <p className="text-xs text-destructive">
-                  {t("settings.ai.modelsFailedToLoad", { message: ollamaDiscovery.error })}
-                </p>
+                <p className="text-xs text-destructive">{ollamaDiscovery.error}</p>
               ) : null}
             </div>
           ) : null}
@@ -653,9 +654,7 @@ function ProfileEditor({
             ) : null}
           </div>
           {ollamaDiscovery.error ? (
-            <p className="text-xs text-destructive">
-              {t("settings.ai.modelsFailedToLoad", { message: ollamaDiscovery.error })}
-            </p>
+            <p className="text-xs text-destructive">{ollamaDiscovery.error}</p>
           ) : null}
         </div>
       ) : null}

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -19,6 +19,7 @@ import {
   Eye,
   EyeOff,
   Plus,
+  RefreshCw,
   Star,
   Terminal,
   Trash2,
@@ -26,6 +27,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { discoverOllamaModels } from "../../lib/assistant/ollama";
 
 // ── Locally-defined types to avoid circular import with SettingsDialog ──
 
@@ -88,6 +90,21 @@ export function AiSectionContent({
   const [newProfileModel, setNewProfileModel] = useState(() => defaultModelFor("google"));
   /** Draft field values keyed by env var name for the new profile. */
   const [newProfileFieldValues, setNewProfileFieldValues] = useState<Record<string, string>>({});
+  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
+  const [loadingOllamaModels, setLoadingOllamaModels] = useState(false);
+
+  const refreshOllamaModels = async () => {
+    setLoadingOllamaModels(true);
+    try {
+      const models = await discoverOllamaModels(newProfileFieldValues.OLLAMA_BASE_URL ?? "");
+      setOllamaModels(models);
+      if (models.length > 0 && !models.includes(newProfileModel)) setNewProfileModel(models[0]);
+    } catch (error) {
+      console.error("[GeoLibre] Could not load Ollama models", error);
+    } finally {
+      setLoadingOllamaModels(false);
+    }
+  };
 
   // Resolve which providers are configured from the effective env (from parent).
   // Re-derived here for internal status use.
@@ -243,13 +260,36 @@ export function AiSectionContent({
           {PROVIDER_MODELS[newProfileProvider].length > 0 ? (
             <div className="space-y-1.5">
               <Label className="text-xs">{t("assistant.model")}</Label>
-              <Select value={newProfileModel} onChange={(e) => setNewProfileModel(e.target.value)}>
-                {PROVIDER_MODELS[newProfileProvider].map((id) => (
-                  <option key={id} value={id}>
-                    {id}
-                  </option>
-                ))}
-              </Select>
+              <div className="flex items-center gap-2">
+                <Select
+                  value={newProfileModel}
+                  onChange={(e) => setNewProfileModel(e.target.value)}
+                >
+                  {(newProfileProvider === "ollama" && ollamaModels.length > 0
+                    ? ollamaModels
+                    : PROVIDER_MODELS[newProfileProvider]
+                  ).map((id) => (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  ))}
+                </Select>
+                {newProfileProvider === "ollama" ? (
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="outline"
+                    disabled={loadingOllamaModels}
+                    aria-label={t("managePlugins.refresh")}
+                    title={t("managePlugins.refresh")}
+                    onClick={() => void refreshOllamaModels()}
+                  >
+                    <RefreshCw
+                      className={cn("h-3.5 w-3.5", loadingOllamaModels && "animate-spin")}
+                    />
+                  </Button>
+                ) : null}
+              </div>
             </div>
           ) : null}
 
@@ -427,6 +467,8 @@ function ProfileEditor({
   osFieldEnvName,
 }: ProfileEditorProps) {
   const { t } = useTranslation();
+  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
+  const [loadingOllamaModels, setLoadingOllamaModels] = useState(false);
 
   const updateName = (name: string) => {
     setDraftDesktopSettings((current: any) => ({
@@ -454,7 +496,29 @@ function ProfileEditor({
   const providerFields = PROVIDER_FIELDS[profile.provider];
   const hasOsEnvNote = providerFields.some((field) => osFieldEnvName(field) !== null);
   const models = PROVIDER_MODELS[profile.provider];
+  const selectableModels =
+    profile.provider === "ollama" && ollamaModels.length > 0
+      ? ollamaModels
+      : [...new Set([profile.modelId, ...models].filter(Boolean))];
   const docsUrl = PROVIDER_DOCS_URL[profile.provider];
+
+  const refreshOllamaModels = async () => {
+    const baseUrlField = PROVIDER_FIELDS.ollama.find((field) => field.envKey === "OLLAMA_BASE_URL");
+    setLoadingOllamaModels(true);
+    try {
+      const discovered = await discoverOllamaModels(
+        baseUrlField ? getProviderField(baseUrlField) : "",
+      );
+      setOllamaModels(discovered);
+      if (discovered.length > 0 && !discovered.includes(profile.modelId)) {
+        updateModel(discovered[0]);
+      }
+    } catch (error) {
+      console.error("[GeoLibre] Could not load Ollama models", error);
+    } finally {
+      setLoadingOllamaModels(false);
+    }
+  };
 
   return (
     <div className="space-y-4">
@@ -497,16 +561,31 @@ function ProfileEditor({
       {models.length > 0 ? (
         <div className="space-y-1.5">
           <Label className="text-xs">{t("assistant.model")}</Label>
-          <Select
-            value={profile.modelId || defaultModelFor(profile.provider)}
-            onChange={(e) => updateModel(e.target.value)}
-          >
-            {models.map((id) => (
-              <option key={id} value={id}>
-                {id}
-              </option>
-            ))}
-          </Select>
+          <div className="flex items-center gap-2">
+            <Select
+              value={profile.modelId || defaultModelFor(profile.provider)}
+              onChange={(e) => updateModel(e.target.value)}
+            >
+              {selectableModels.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
+            </Select>
+            {profile.provider === "ollama" ? (
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                disabled={loadingOllamaModels}
+                aria-label={t("managePlugins.refresh")}
+                title={t("managePlugins.refresh")}
+                onClick={() => void refreshOllamaModels()}
+              >
+                <RefreshCw className={cn("h-3.5 w-3.5", loadingOllamaModels && "animate-spin")} />
+              </Button>
+            ) : null}
+          </div>
         </div>
       ) : null}
 

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -60,6 +60,29 @@ interface AiSectionContentProps {
   osFieldEnvName: (field: ProviderField) => string | null;
 }
 
+/** Shared Ollama discovery state for profile editors. */
+function useOllamaModels() {
+  const [models, setModels] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async (baseUrl: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      setModels(await discoverOllamaModels(baseUrl));
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      setError(message);
+      console.error("[GeoLibre] Could not load Ollama models", cause);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { models, loading, error, refresh, reset: () => setModels([]) };
+}
+
 /**
  * The "AI Providers" section content inside Settings. Shows a profile list when
  * no profile is being edited, and a profile editor when one is selected.
@@ -90,20 +113,7 @@ export function AiSectionContent({
   const [newProfileModel, setNewProfileModel] = useState(() => defaultModelFor("google"));
   /** Draft field values keyed by env var name for the new profile. */
   const [newProfileFieldValues, setNewProfileFieldValues] = useState<Record<string, string>>({});
-  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
-  const [loadingOllamaModels, setLoadingOllamaModels] = useState(false);
-
-  const refreshOllamaModels = async () => {
-    setLoadingOllamaModels(true);
-    try {
-      const models = await discoverOllamaModels(newProfileFieldValues.OLLAMA_BASE_URL ?? "");
-      setOllamaModels(models);
-    } catch (error) {
-      console.error("[GeoLibre] Could not load Ollama models", error);
-    } finally {
-      setLoadingOllamaModels(false);
-    }
-  };
+  const ollamaDiscovery = useOllamaModels();
 
   // Resolve which providers are configured from the effective env (from parent).
   // Re-derived here for internal status use.
@@ -142,7 +152,7 @@ export function AiSectionContent({
     setNewProfileProvider("google");
     setNewProfileModel(defaultModelFor("google"));
     setNewProfileFieldValues({});
-    setOllamaModels([]);
+    ollamaDiscovery.reset();
     setIsCreatingProfile(true);
     setEditingProfileId(null);
   };
@@ -242,13 +252,13 @@ export function AiSectionContent({
             <Label className="text-xs">{t("settings.ai.providerLabel")}</Label>
             <Select
               value={newProfileProvider}
-              disabled={loadingOllamaModels}
+              disabled={ollamaDiscovery.loading}
               onChange={(e) => {
                 const provider = e.target.value as AssistantProviderId;
                 setNewProfileProvider(provider);
                 setNewProfileModel(defaultModelFor(provider));
                 setNewProfileFieldValues({});
-                setOllamaModels([]);
+                ollamaDiscovery.reset();
               }}
             >
               {ASSISTANT_PROVIDER_IDS.map((id) => (
@@ -268,8 +278,8 @@ export function AiSectionContent({
                   value={newProfileModel}
                   onChange={(e) => setNewProfileModel(e.target.value)}
                 >
-                  {(newProfileProvider === "ollama" && ollamaModels.length > 0
-                    ? [...new Set([newProfileModel, ...ollamaModels].filter(Boolean))]
+                  {(newProfileProvider === "ollama" && ollamaDiscovery.models.length > 0
+                    ? [...new Set([newProfileModel, ...ollamaDiscovery.models].filter(Boolean))]
                     : PROVIDER_MODELS[newProfileProvider]
                   ).map((id) => (
                     <option key={id} value={id}>
@@ -282,17 +292,24 @@ export function AiSectionContent({
                     type="button"
                     size="icon"
                     variant="outline"
-                    disabled={loadingOllamaModels}
+                    disabled={ollamaDiscovery.loading}
                     aria-label={t("managePlugins.refresh")}
                     title={t("managePlugins.refresh")}
-                    onClick={() => void refreshOllamaModels()}
+                    onClick={() =>
+                      void ollamaDiscovery.refresh(newProfileFieldValues.OLLAMA_BASE_URL ?? "")
+                    }
                   >
                     <RefreshCw
-                      className={cn("h-3.5 w-3.5", loadingOllamaModels && "animate-spin")}
+                      className={cn("h-3.5 w-3.5", ollamaDiscovery.loading && "animate-spin")}
                     />
                   </Button>
                 ) : null}
               </div>
+              {ollamaDiscovery.error ? (
+                <p className="text-xs text-destructive">
+                  {t("managePlugins.failedToLoad", { message: ollamaDiscovery.error })}
+                </p>
+              ) : null}
             </div>
           ) : null}
 
@@ -470,8 +487,7 @@ function ProfileEditor({
   osFieldEnvName,
 }: ProfileEditorProps) {
   const { t } = useTranslation();
-  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
-  const [loadingOllamaModels, setLoadingOllamaModels] = useState(false);
+  const ollamaDiscovery = useOllamaModels();
 
   const updateName = (name: string) => {
     setDraftDesktopSettings((current: any) => ({
@@ -481,7 +497,7 @@ function ProfileEditor({
   };
 
   const updateProvider = (provider: AssistantProviderId) => {
-    setOllamaModels([]);
+    ollamaDiscovery.reset();
     setDraftDesktopSettings((current: any) => ({
       ...current,
       aiProfiles: current.aiProfiles.map((p: any) =>
@@ -501,27 +517,19 @@ function ProfileEditor({
   const hasOsEnvNote = providerFields.some((field) => osFieldEnvName(field) !== null);
   const models = PROVIDER_MODELS[profile.provider];
   const selectableModels =
-    profile.provider === "ollama" && ollamaModels.length > 0
-      ? [...new Set([profile.modelId, ...ollamaModels].filter(Boolean))]
+    profile.provider === "ollama" && ollamaDiscovery.models.length > 0
+      ? [...new Set([profile.modelId, ...ollamaDiscovery.models].filter(Boolean))]
       : [...new Set([profile.modelId, ...models].filter(Boolean))];
   const docsUrl = PROVIDER_DOCS_URL[profile.provider];
 
-  const refreshOllamaModels = async () => {
+  const refreshOllamaModels = () => {
     const baseUrlField = PROVIDER_FIELDS.ollama.find((field) => field.envKey === "OLLAMA_BASE_URL");
-    setLoadingOllamaModels(true);
-    try {
-      const discovered = await discoverOllamaModels(
-        (baseUrlField ? getProviderField(baseUrlField) : "") ||
-          scopedOsEnv.OLLAMA_BASE_URL ||
-          scopedOsEnv.OLLAMA_HOST ||
-          "",
-      );
-      setOllamaModels(discovered);
-    } catch (error) {
-      console.error("[GeoLibre] Could not load Ollama models", error);
-    } finally {
-      setLoadingOllamaModels(false);
-    }
+    return ollamaDiscovery.refresh(
+      (baseUrlField ? getProviderField(baseUrlField) : "") ||
+        scopedOsEnv.OLLAMA_BASE_URL ||
+        scopedOsEnv.OLLAMA_HOST ||
+        "",
+    );
   };
 
   return (
@@ -551,7 +559,7 @@ function ProfileEditor({
         <Label className="text-xs">{t("settings.ai.providerLabel")}</Label>
         <Select
           value={profile.provider}
-          disabled={loadingOllamaModels}
+          disabled={ollamaDiscovery.loading}
           onChange={(e) => updateProvider(e.target.value as AssistantProviderId)}
         >
           {ASSISTANT_PROVIDER_IDS.map((id) => (
@@ -582,15 +590,22 @@ function ProfileEditor({
                 type="button"
                 size="icon"
                 variant="outline"
-                disabled={loadingOllamaModels}
+                disabled={ollamaDiscovery.loading}
                 aria-label={t("managePlugins.refresh")}
                 title={t("managePlugins.refresh")}
                 onClick={() => void refreshOllamaModels()}
               >
-                <RefreshCw className={cn("h-3.5 w-3.5", loadingOllamaModels && "animate-spin")} />
+                <RefreshCw
+                  className={cn("h-3.5 w-3.5", ollamaDiscovery.loading && "animate-spin")}
+                />
               </Button>
             ) : null}
           </div>
+          {ollamaDiscovery.error ? (
+            <p className="text-xs text-destructive">
+              {t("managePlugins.failedToLoad", { message: ollamaDiscovery.error })}
+            </p>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -313,7 +313,6 @@ export function AiSectionContent({
             <Label className="text-xs">{t("settings.ai.providerLabel")}</Label>
             <Select
               value={newProfileProvider}
-              disabled={ollamaDiscovery.loading}
               onChange={(e) => {
                 const provider = e.target.value as AssistantProviderId;
                 setNewProfileProvider(provider);
@@ -585,8 +584,11 @@ function ProfileEditor({
               ...p,
               provider,
               modelId: defaultModelFor(provider),
+              // `getProviderField` resolves OLLAMA_BASE_URL before its
+              // OLLAMA_HOST alias, so seeding the default over a profile that
+              // only carries the alias would shadow a real custom value.
               fieldValues:
-                seedBaseUrl && !p.fieldValues?.OLLAMA_BASE_URL
+                seedBaseUrl && !p.fieldValues?.OLLAMA_BASE_URL && !p.fieldValues?.OLLAMA_HOST
                   ? { ...p.fieldValues, OLLAMA_BASE_URL: DEFAULT_OLLAMA_BASE_URL }
                   : p.fieldValues,
             }
@@ -654,7 +656,6 @@ function ProfileEditor({
         <Label className="text-xs">{t("settings.ai.providerLabel")}</Label>
         <Select
           value={profile.provider}
-          disabled={ollamaDiscovery.loading}
           onChange={(e) => updateProvider(e.target.value as AssistantProviderId)}
         >
           {ASSISTANT_PROVIDER_IDS.map((id) => (

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -625,7 +625,13 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
                   disabled={running}
                   onChange={(event) => onModelChange(event.target.value)}
                 >
-                  {PROVIDER_MODELS[activeProfile.provider].map((modelId) => (
+                  {[
+                    ...new Set(
+                      [activeProfile.modelId, ...PROVIDER_MODELS[activeProfile.provider]].filter(
+                        Boolean,
+                      ),
+                    ),
+                  ].map((modelId) => (
                     <option key={modelId} value={modelId}>
                       {modelId}
                     </option>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2140,6 +2140,8 @@
       "osEnvNote": "The desktop app also reads matching API keys from your system environment variables. Those are used automatically and are never saved to the project file — leave a field blank to keep using the environment value.",
       "osEnvField": "Read from your system environment variable {{name}}.",
       "osEnvPlaceholder": "Set in your system environment",
+      "ollamaNetworkFailure": "Could not reach the Ollama server. Check that it is running at this address and that OLLAMA_ORIGINS allows this app's origin, plus any firewall or proxy rules.",
+      "ollamaTimedOut": "The request to the Ollama server timed out. The host may be slow, unreachable, or blocked by a firewall or proxy.",
       "newProfile": "New profile",
       "cancel": "Cancel",
       "addProfile": "Add profile",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2140,6 +2140,8 @@
       "osEnvNote": "The desktop app also reads matching API keys from your system environment variables. Those are used automatically and are never saved to the project file — leave a field blank to keep using the environment value.",
       "osEnvField": "Read from your system environment variable {{name}}.",
       "osEnvPlaceholder": "Set in your system environment",
+      "refreshModels": "Refresh model list",
+      "modelsFailedToLoad": "Could not load models: {{message}}",
       "ollamaNetworkFailure": "Could not reach the Ollama server. Check that it is running at this address and that OLLAMA_ORIGINS allows this app's origin, plus any firewall or proxy rules.",
       "ollamaTimedOut": "The request to the Ollama server timed out. The host may be slow, unreachable, or blocked by a firewall or proxy.",
       "newProfile": "New profile",

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -24,8 +24,13 @@ export async function discoverOllamaModels(
   if (!/^https?:\/\//i.test(normalized)) normalized = `http://${normalized}`;
   normalized = normalized.replace(/\/+$/, "").replace(/\/v1$/i, "");
   const budget = AbortSignal.timeout(DISCOVERY_TIMEOUT_MS);
+  // AbortSignal.any shipped in Chrome 116 / Firefox 124 / Safari 17.4 — later
+  // than the WebViews `crypto-random-uuid-polyfill` exists for. On an older
+  // engine fall back to the budget alone (mirroring `offline-tiles.ts`), so the
+  // request still times out rather than throwing before it is even made.
+  const combine = signal && typeof AbortSignal.any === "function";
   const response = await fetch(`${normalized}/api/tags`, {
-    signal: signal ? AbortSignal.any([signal, budget]) : budget,
+    signal: combine ? AbortSignal.any([signal, budget]) : budget,
   });
   if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
   // `Response.json()` resolves to `null` for a literal `null` body, so the

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -16,13 +16,10 @@ export async function discoverOllamaModels(baseUrl: string): Promise<string[]> {
     return [
       ...new Set(
         (payload.models ?? [])
-          .map((entry) =>
-            typeof entry.name === "string"
-              ? entry.name.trim()
-              : typeof entry.model === "string"
-                ? entry.model.trim()
-                : "",
-          )
+          .map((entry) => {
+            const name = typeof entry.name === "string" ? entry.name.trim() : "";
+            return name || (typeof entry.model === "string" ? entry.model.trim() : "");
+          })
           .filter(Boolean),
       ),
     ].sort((a, b) => a.localeCompare(b));

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -10,16 +10,27 @@ interface OllamaTagsResponse {
  */
 const DISCOVERY_TIMEOUT_MS = 10_000;
 
-/** Fetch the model ids installed in an Ollama server. */
-export async function discoverOllamaModels(baseUrl: string): Promise<string[]> {
+/**
+ * Fetch the model ids installed in an Ollama server. `signal`, when given, is
+ * combined with the discovery budget so a caller that discards the result (a
+ * provider change, a profile switch) can abort the request instead of leaving
+ * it running to the deadline.
+ */
+export async function discoverOllamaModels(
+  baseUrl: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
   let normalized = baseUrl.trim() || "http://localhost:11434";
   if (!/^https?:\/\//i.test(normalized)) normalized = `http://${normalized}`;
   normalized = normalized.replace(/\/+$/, "").replace(/\/v1$/i, "");
+  const budget = AbortSignal.timeout(DISCOVERY_TIMEOUT_MS);
   const response = await fetch(`${normalized}/api/tags`, {
-    signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+    signal: signal ? AbortSignal.any([signal, budget]) : budget,
   });
   if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
-  const payload = (await response.json()) as OllamaTagsResponse;
+  // `Response.json()` resolves to `null` for a literal `null` body, so the
+  // payload is coalesced before `models` is read.
+  const payload = ((await response.json()) ?? {}) as OllamaTagsResponse;
   const entries = Array.isArray(payload.models) ? payload.models : [];
   return [
     ...new Set(

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -7,7 +7,14 @@ export async function discoverOllamaModels(baseUrl: string): Promise<string[]> {
   let normalized = baseUrl.trim() || "http://localhost:11434";
   if (!/^https?:\/\//i.test(normalized)) normalized = `http://${normalized}`;
   normalized = normalized.replace(/\/+$/, "").replace(/\/v1$/i, "");
-  const response = await fetch(`${normalized}/api/tags`);
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => controller.abort(), 10_000);
+  let response: Response;
+  try {
+    response = await fetch(`${normalized}/api/tags`, { signal: controller.signal });
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
   if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
   const payload = (await response.json()) as OllamaTagsResponse;
   return [

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -9,25 +9,24 @@ export async function discoverOllamaModels(baseUrl: string): Promise<string[]> {
   normalized = normalized.replace(/\/+$/, "").replace(/\/v1$/i, "");
   const controller = new AbortController();
   const timeout = globalThis.setTimeout(() => controller.abort(), 10_000);
-  let response: Response;
   try {
-    response = await fetch(`${normalized}/api/tags`, { signal: controller.signal });
+    const response = await fetch(`${normalized}/api/tags`, { signal: controller.signal });
+    if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
+    const payload = (await response.json()) as OllamaTagsResponse;
+    return [
+      ...new Set(
+        (payload.models ?? [])
+          .map((entry) =>
+            typeof entry.name === "string"
+              ? entry.name.trim()
+              : typeof entry.model === "string"
+                ? entry.model.trim()
+                : "",
+          )
+          .filter(Boolean),
+      ),
+    ].sort((a, b) => a.localeCompare(b));
   } finally {
     globalThis.clearTimeout(timeout);
   }
-  if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
-  const payload = (await response.json()) as OllamaTagsResponse;
-  return [
-    ...new Set(
-      (payload.models ?? [])
-        .map((entry) =>
-          typeof entry.name === "string"
-            ? entry.name.trim()
-            : typeof entry.model === "string"
-              ? entry.model.trim()
-              : "",
-        )
-        .filter(Boolean),
-    ),
-  ].sort((a, b) => a.localeCompare(b));
 }

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -1,0 +1,26 @@
+interface OllamaTagsResponse {
+  models?: Array<{ name?: unknown; model?: unknown }>;
+}
+
+/** Fetch the model ids installed in an Ollama server. */
+export async function discoverOllamaModels(baseUrl: string): Promise<string[]> {
+  let normalized = baseUrl.trim() || "http://localhost:11434";
+  if (!/^https?:\/\//i.test(normalized)) normalized = `http://${normalized}`;
+  normalized = normalized.replace(/\/+$/, "").replace(/\/v1$/i, "");
+  const response = await fetch(`${normalized}/api/tags`);
+  if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
+  const payload = (await response.json()) as OllamaTagsResponse;
+  return [
+    ...new Set(
+      (payload.models ?? [])
+        .map((entry) =>
+          typeof entry.name === "string"
+            ? entry.name.trim()
+            : typeof entry.model === "string"
+              ? entry.model.trim()
+              : "",
+        )
+        .filter(Boolean),
+    ),
+  ].sort((a, b) => a.localeCompare(b));
+}

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -1,29 +1,37 @@
 interface OllamaTagsResponse {
-  models?: Array<{ name?: unknown; model?: unknown }>;
+  models?: unknown;
 }
+
+/**
+ * The discovery budget. Uses `AbortSignal.timeout` rather than a manual
+ * `AbortController` + `setTimeout` so the rejection is a `TimeoutError` that
+ * `classifyFetchFailure` can tell apart from a plain abort, and so the deadline
+ * stays armed while the response body is read.
+ */
+const DISCOVERY_TIMEOUT_MS = 10_000;
 
 /** Fetch the model ids installed in an Ollama server. */
 export async function discoverOllamaModels(baseUrl: string): Promise<string[]> {
   let normalized = baseUrl.trim() || "http://localhost:11434";
   if (!/^https?:\/\//i.test(normalized)) normalized = `http://${normalized}`;
   normalized = normalized.replace(/\/+$/, "").replace(/\/v1$/i, "");
-  const controller = new AbortController();
-  const timeout = globalThis.setTimeout(() => controller.abort(), 10_000);
-  try {
-    const response = await fetch(`${normalized}/api/tags`, { signal: controller.signal });
-    if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
-    const payload = (await response.json()) as OllamaTagsResponse;
-    return [
-      ...new Set(
-        (payload.models ?? [])
-          .map((entry) => {
-            const name = typeof entry.name === "string" ? entry.name.trim() : "";
-            return name || (typeof entry.model === "string" ? entry.model.trim() : "");
-          })
-          .filter(Boolean),
-      ),
-    ].sort((a, b) => a.localeCompare(b));
-  } finally {
-    globalThis.clearTimeout(timeout);
-  }
+  const response = await fetch(`${normalized}/api/tags`, {
+    signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`Ollama returned HTTP ${response.status}`);
+  const payload = (await response.json()) as OllamaTagsResponse;
+  const entries = Array.isArray(payload.models) ? payload.models : [];
+  return [
+    ...new Set(
+      entries
+        .map((entry) => {
+          // A malformed response can hold a null or non-object element; read it
+          // defensively so one bad entry does not reject the whole discovery.
+          const record = (entry ?? {}) as { name?: unknown; model?: unknown };
+          const name = typeof record.name === "string" ? record.name.trim() : "";
+          return name || (typeof record.model === "string" ? record.model.trim() : "");
+        })
+        .filter(Boolean),
+    ),
+  ].sort((a, b) => a.localeCompare(b));
 }

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -11,6 +11,13 @@ interface OllamaTagsResponse {
 const DISCOVERY_TIMEOUT_MS = 10_000;
 
 /**
+ * Where Ollama listens out of the box. Prefilled into a new profile's base-URL
+ * field — the field is required, so leaving it blank reads as "incomplete" even
+ * on the default install where discovery would have worked untouched.
+ */
+export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+
+/**
  * Fetch the model ids installed in an Ollama server. `signal`, when given, is
  * combined with the discovery budget so a caller that discards the result (a
  * provider change, a profile switch) can abort the request instead of leaving
@@ -20,7 +27,7 @@ export async function discoverOllamaModels(
   baseUrl: string,
   signal?: AbortSignal,
 ): Promise<string[]> {
-  let normalized = baseUrl.trim() || "http://localhost:11434";
+  let normalized = baseUrl.trim() || DEFAULT_OLLAMA_BASE_URL;
   if (!/^https?:\/\//i.test(normalized)) normalized = `http://${normalized}`;
   normalized = normalized.replace(/\/+$/, "").replace(/\/v1$/i, "");
   const budget = AbortSignal.timeout(DISCOVERY_TIMEOUT_MS);

--- a/apps/geolibre-desktop/src/lib/crypto-random-uuid-polyfill.ts
+++ b/apps/geolibre-desktop/src/lib/crypto-random-uuid-polyfill.ts
@@ -1,0 +1,21 @@
+/**
+ * Install the Web Crypto randomUUID API when the current WebView/origin does
+ * not expose it. Strands calls globalThis.crypto.randomUUID() directly when it
+ * creates chat messages, while some older WebViews and non-secure web origins
+ * only expose getRandomValues.
+ */
+if (globalThis.crypto && typeof globalThis.crypto.randomUUID !== "function") {
+  Object.defineProperty(globalThis.crypto, "randomUUID", {
+    configurable: true,
+    value: (): `${string}-${string}-${string}-${string}-${string}` => {
+      const bytes = new Uint8Array(16);
+      globalThis.crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+      return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex
+        .slice(6, 8)
+        .join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+    },
+  });
+}

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -1,4 +1,5 @@
 import "./lib/symbol-dispose-polyfill";
+import "./lib/crypto-random-uuid-polyfill";
 // Must precede any Map construction (see the module docs).
 import "./lib/maplibre-worker";
 import React from "react";

--- a/tests/assistant-ollama.test.ts
+++ b/tests/assistant-ollama.test.ts
@@ -35,4 +35,22 @@ describe("discoverOllamaModels", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("falls back to model when name is blank", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      Response.json({
+        models: [
+          { name: "   ", model: "llama3:8b" },
+          { name: "   ", model: "   " },
+          { name: "   " },
+        ],
+      });
+
+    try {
+      assert.deepEqual(await discoverOllamaModels("localhost:11434"), ["llama3:8b"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/tests/assistant-ollama.test.ts
+++ b/tests/assistant-ollama.test.ts
@@ -36,7 +36,7 @@ describe("discoverOllamaModels", () => {
     }
   });
 
-  it("falls back to model when name is blank", async () => {
+  it("falls back to model when name is blank and tolerates malformed entries", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async () =>
       Response.json({
@@ -44,6 +44,8 @@ describe("discoverOllamaModels", () => {
           { name: "   ", model: "llama3:8b" },
           { name: "   ", model: "   " },
           { name: "   " },
+          null,
+          "not-an-object",
         ],
       });
 

--- a/tests/assistant-ollama.test.ts
+++ b/tests/assistant-ollama.test.ts
@@ -55,4 +55,34 @@ describe("discoverOllamaModels", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("treats a null payload as an empty model list", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => Response.json(null);
+
+    try {
+      assert.deepEqual(await discoverOllamaModels("localhost:11434"), []);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("aborts the request when the caller's signal aborts", async () => {
+    const originalFetch = globalThis.fetch;
+    const controller = new AbortController();
+    globalThis.fetch = async (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("Aborted", "AbortError")),
+        );
+      });
+
+    try {
+      const pending = discoverOllamaModels("localhost:11434", controller.signal);
+      controller.abort();
+      await assert.rejects(pending, { name: "AbortError" });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/tests/assistant-ollama.test.ts
+++ b/tests/assistant-ollama.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { discoverOllamaModels } from "../apps/geolibre-desktop/src/lib/assistant/ollama";
+
+describe("discoverOllamaModels", () => {
+  it("normalizes hosts and parses unique model names", async () => {
+    const originalFetch = globalThis.fetch;
+    const requested: string[] = [];
+    globalThis.fetch = async (input) => {
+      requested.push(String(input));
+      return Response.json({
+        models: [
+          { name: "qwen3:8b" },
+          { model: "smollm2:135m" },
+          { name: "qwen3:8b" },
+          { name: 42 },
+        ],
+      });
+    };
+
+    try {
+      assert.deepEqual(await discoverOllamaModels("localhost:11434/v1/"), [
+        "qwen3:8b",
+        "smollm2:135m",
+      ]);
+      assert.deepEqual(await discoverOllamaModels("http://localhost:11434"), [
+        "qwen3:8b",
+        "smollm2:135m",
+      ]);
+      assert.deepEqual(requested, [
+        "http://localhost:11434/api/tags",
+        "http://localhost:11434/api/tags",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- load locally installed Ollama models from `/api/tags` in new and existing AI profiles
- preserve custom Ollama model IDs in the assistant model picker
- polyfill `crypto.randomUUID()` for older WebViews and non-secure origins before Strands loads

## Verification

- verified Ollama model discovery in the real app with a two-model `/api/tags` response in light and dark themes
- simulated a WebView without native `crypto.randomUUID()` and confirmed the fallback returns a UUID v4
- ran the production build and all pre-commit hooks

Addresses https://github.com/opengeos/GeoLibre/discussions/2117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ollama model discovery and refresh in AI profile settings.
  * Custom models now appear in the assistant’s model selector.
  * Current model selections are preserved when available.

* **Bug Fixes**
  * Added loading indicators and localized error messages for Ollama requests.
  * Model lists reset appropriately when changing providers.
  * Duplicate or invalid model entries are filtered from results.
  * Improved compatibility in environments without built-in UUID generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->