### PR TITLE
docs: split the maintenance notes out of CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,8 @@ the MCP tools delegate to `authoring.py`. `server.py` is the only module that
 imports the `mcp` SDK (optional extra `geolibre[mcp]`), and `workspace.py`
 confines every path to `GEOLIBRE_MCP_ROOTS`/`--root` the way the sidecar confines
 to `GEOLIBRE_CONVERSION_ROOTS`. `python/tests/test_mcp_server.py` skips itself
-without the SDK, so `publish-python.yml` installs `mcp` explicitly.
+without the SDK, so `publish-python.yml` installs `mcp` explicitly — drop it
+and the server ships untested.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,19 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in this repository.
 
 ## Repository shape
 
-GeoLibre is a single **npm workspaces monorepo** (`apps/*`, `packages/*`, `workers/*`) plus two non-npm components: a Python FastAPI sidecar (`backend/geolibre_server`) and a separate Python package (`python/`, the `geolibre` Jupyter anywidget). One `npm install` at the root wires up every JS workspace. Use **npm** (the repo tracks `package-lock.json`), Node **22+**.
+GeoLibre is a single **npm workspaces monorepo** (`apps/*`, `packages/*`,
+`workers/*`) plus two non-npm components: a Python FastAPI sidecar
+(`backend/geolibre_server`) and a separate Python package (`python/`, the
+`geolibre` Jupyter anywidget). One `npm install` at the root wires up every JS
+workspace. Use **npm** (the repo tracks `package-lock.json`), Node **22+**.
 
-The same React app ships three ways: native desktop via **Tauri v2** (`apps/geolibre-desktop/src-tauri`), a browser web build served by nginx (Docker), and embedded in Jupyter (the `python/` package bundles a build of the web app into its wheel).
+The same React app ships three ways: native desktop via **Tauri v2**
+(`apps/geolibre-desktop/src-tauri`), a browser web build served by nginx
+(Docker), and embedded in Jupyter (the `python/` package bundles a build of the
+web app into its wheel).
 
 ## Commands
 
@@ -24,144 +31,122 @@ Tests:
 
 ```bash
 npm run test:frontend                              # node --test over tests/*.test.ts (tsx loader)
-npm run test:frontend:coverage                     # same, plus a per-file coverage summary (Node built-in)
+npm run test:frontend:coverage                     # same, plus a coverage summary (gated on a floor)
 node --import tsx --test tests/<name>.test.ts      # a single frontend test file
 npm run test:backend                               # pytest backend/geolibre_server/tests
-npm run test:backend:coverage                      # same, plus a pytest-cov term-missing report
+npm run test:backend:coverage                      # same, plus pytest-cov (gated on a floor)
 python -m pytest backend/geolibre_server/tests/test_x.py::test_y   # a single backend test
 npm run test:worker                                # typecheck workers/viewer
-npm run test:e2e                                    # Playwright smoke tests (e2e/) against the built web app
+npm run test:e2e                                   # Playwright smoke tests (e2e/) against the built web app
 npm run check:rust                                 # cargo check the Tauri crate
+cd python && pytest                                # the geolibre Python package's own suite
 ```
 
-The `:coverage` variants run the same suites and print a coverage summary; CI
-runs them so every build reports coverage. They are now **gated on a floor**:
-`test:frontend:coverage` fails below 78% lines / 78% branches / 63% functions,
-and `test:backend:coverage` fails below 55% (`--cov-fail-under`). The floors sit
-a few points under the current numbers as a **ratchet** — regressions fail CI,
-and when coverage rises comfortably above a floor, raise the floor to lock in the
-gain. The frontend
-report only counts files a test actually imports, so a module with no test does
-not appear at all rather than as 0%.
+Setup notes that bite:
 
-That last point is the one that bites: writing the _first_ test for a large
-untested module reads as a coverage **regression**, because the module and
-everything it imports enter the denominator at once. GeoLibre#1784 added a test
-that imported `usePlugins.ts` and so pulled in the whole built-in plugin
-registry, 39 files, dropping function coverage 72.90% → 60.36% and reddening
-`main`. The fix is to test against a leaf module rather than to lower the floor
-(GeoLibre#1888 extracted `lib/plugin-layer-queries.ts`; `geo-editor-geometry.ts`
-in `@geolibre/plugins` is the same pattern). Check what a new test _transitively_
-imports before assuming a coverage drop means the code got worse.
+- Install the backend **`test`** extra or the vector/raster/SQL/ML tests skip
+  themselves and CI is green but hollow:
+  `pip install -e "backend/geolibre_server[test]"`.
+- `npm run test:e2e` needs `npx playwright install chromium` once. It builds the
+  app, serves it with `vite preview`, and drives it with Playwright; add specs
+  under `e2e/`.
+- Coverage floors act as a **ratchet** and the frontend report only counts files
+  a test imports, so the first test for a big module can read as a regression.
+  See [Coverage floors](docs/maintenance.md#coverage-floors) before touching a
+  floor.
 
-`test:frontend:coverage` runs through `scripts/coverage-check.mjs` rather than
-calling `node --test` directly. Node still enforces all three floors; the wrapper
-only re-measures once when **line** coverage alone comes up short with every test
-passing. Line coverage is nondeterministic on CI (GeoLibre#1889: two runs over
-byte-identical sources reported 81.82% and 76.47%, 114 of 444 files differing on
-lines and _none_ on branches or functions), and it is not reproducible locally on
-either Node 22 or 26. Branch and function shortfalls, and any test failure, fail
-on the spot with no retry, so a real regression still fails fast. `classify()` is
-exported and covered by `tests/coverage-check.test.ts` — change the retry policy
-there, not by loosening a floor. If the retry starts firing regularly, fix the
-measurement instead of widening the mitigation.
-
-The backend coverage run (and `npm run ci`,
-which calls the `:coverage` variants) needs `pytest-cov` from the backend `dev`
-extra. Install the **`test`** extra to run the _full_ backend suite — without
-the optional engines (geopandas/rasterio/sedona/httpx) the vector/raster/SQL/ML
-tests skip themselves and CI is green but hollow:
-`pip install -e "backend/geolibre_server[test]"`.
-
-`npm run test:e2e` builds the web app, serves it with `vite preview`, and drives
-it with Playwright (`@playwright/test`). First run: `npx playwright install
-chromium`. The webServer reuses an already-running preview locally and rebuilds
-in CI; add specs under `e2e/`.
-
-Dependencies are watched two ways: **Dependabot** (`.github/dependabot.yml`)
-opens grouped weekly update PRs for npm, pip (backend + `python/`), cargo, and
-Actions, and the CI **`audit` job** runs `npm run audit:ci`
-(blocking) plus a non-blocking `pip-audit` of the resolved backend environment.
-`audit:ci` is `scripts/audit-check.mjs`, a thin wrapper over `npm audit
---omit=dev` that still fails on every high/critical advisory _except_ the ones
-listed in its `ALLOWLIST`. The wrapper exists because plain `npm audit` cannot
-accept a single finding, so one unpatchable transitive advisory reddens every PR
-until upstream ships a fix — which for an unmaintained leaf package may be never.
-Only allowlist an advisory when there is **no patched version to upgrade to** and
-the vulnerable code is **unreachable from a GeoLibre runtime path**, and say why
-on both counts in the entry. Anything upgradeable gets upgraded instead. Stale
-entries print a warning rather than failing, since the advisory database is a
-live service and a transient omission must not redden an unrelated PR.
-
-The `python/` package has its own pytest suite (`cd python && pytest`) and is built into a wheel via `npm run build:embed` (produces `apps/geolibre-desktop/dist-embed`, consumed by `python/hatch_build.py`). Its version is dynamic, sourced from `python/src/geolibre/__init__.py`.
+The `python/` package is built into a wheel via `npm run build:embed` (produces
+`apps/geolibre-desktop/dist-embed`, consumed by `python/hatch_build.py`). Its
+version is dynamic, sourced from `python/src/geolibre/__init__.py`.
 
 ## Pre-commit
 
-`.pre-commit-config.yaml` includes a **local `npm-build` hook**, so `pre-commit run` compiles the whole app — it is slow and can touch unrelated build state. Scope it to the files you changed: `pre-commit run --files <paths>`. Run it before pushing.
+`.pre-commit-config.yaml` includes a **local `npm-build` hook**, so
+`pre-commit run` compiles the whole app — it is slow and can touch unrelated
+build state. Scope it to the files you changed:
+`pre-commit run --files <paths>`. Run it before pushing.
 
 ## Architecture (the parts that span files)
 
-The app is **store-driven**. `@geolibre/core` holds the Zustand store, domain types, and the `.geolibre.json` project schema — it is the single source of truth. Data flows one way:
+The app is **store-driven**. `@geolibre/core` holds the Zustand store, domain
+types, and the `.geolibre.json` project schema — it is the single source of
+truth. Data flows one way:
 
-1. Data enters through the Add Data menus, Tauri dialogs, the browser file picker, drag-and-drop, or a plugin control.
-2. Local vector files that MapLibre can't render directly are converted to GeoJSON in-browser by **DuckDB-WASM Spatial** (`INSTALL spatial; LOAD spatial;` → `ST_Read`; GeoParquet via the Parquet reader; zipped Shapefiles via `shpjs` with a DuckDB fallback; KMZ unzipped client-side). The result calls `addGeoJsonLayer`.
-3. Tile/service/raster/ArcGIS/MBTiles/plugin layers become `GeoLibreLayer` records.
-4. `MapCanvas` subscribes to `layers`; `MapController.syncLayers` (`@geolibre/map`) reconciles MapLibre sources/layers and the layer control. **You don't mutate MapLibre directly from UI** — you change store state and let sync apply it.
+1. Data enters through the Add Data menus, Tauri dialogs, the browser file
+   picker, drag-and-drop, or a plugin control.
+2. Local vector files MapLibre can't render directly are converted to GeoJSON
+   in-browser by **DuckDB-WASM Spatial** (`INSTALL spatial; LOAD spatial;` →
+   `ST_Read`; GeoParquet via the Parquet reader; zipped Shapefiles via `shpjs`
+   with a DuckDB fallback; KMZ unzipped client-side), then `addGeoJsonLayer`.
+3. Tile/service/raster/ArcGIS/MBTiles/plugin layers become `GeoLibreLayer`
+   records.
+4. `MapCanvas` subscribes to `layers`; `MapController.syncLayers`
+   (`@geolibre/map`) reconciles MapLibre sources/layers and the layer control.
+   **You don't mutate MapLibre directly from UI** — change store state and let
+   sync apply it.
 
-Rendering is MapLibre GL JS in the webview, with **deck.gl** for raster/point-cloud/3D overlays.
+Rendering is MapLibre GL JS in the webview, with **deck.gl** for
+raster/point-cloud/3D overlays.
 
-**Packages:** `@geolibre/core` (types, project format, store) · `@geolibre/map` (MapLibre lifecycle + layer sync) · `@geolibre/ui` (shadcn-style primitives) · `@geolibre/processing` (client-side algorithm registry) · `@geolibre/plugins` (plugin interface + built-in plugins) · `@geolibre/embed` (typed iframe embed client — `.github/workflows/publish-embed.yml` publishes it on each GitHub Release, skipping a version already there) · `geolibre-desktop` (shell layout, Tauri I/O, composition).
+**Packages:** `@geolibre/core` (types, project format, store) · `@geolibre/map`
+(MapLibre lifecycle + layer sync) · `@geolibre/ui` (shadcn-style primitives) ·
+`@geolibre/processing` (client-side algorithm registry) · `@geolibre/plugins`
+(plugin interface + built-in plugins) · `@geolibre/embed` (typed iframe embed
+client) · `geolibre-desktop` (shell layout, Tauri I/O, composition).
 
-**Plugins:** Built-in plugins live in `packages/plugins/src/plugins/`, are exported from that package's `index.ts`, and registered in `apps/geolibre-desktop/src/hooks/usePlugins.ts`. External plugins load from zips or a `plugin.json` manifest; bundled drop-ins under `apps/geolibre-desktop/public/plugins/<id>/` bake into both web and desktop builds. See `docs/plugin-api.md`.
+**Plugins:** built-in plugins live in `packages/plugins/src/plugins/`, are
+exported from that package's `index.ts`, and registered in
+`apps/geolibre-desktop/src/hooks/usePlugins.ts`. External plugins load from zips
+or a `plugin.json` manifest; bundled drop-ins under
+`apps/geolibre-desktop/public/plugins/<id>/` bake into both web and desktop
+builds. See `docs/plugin-api.md`.
 
-**Python sidecar** (`backend/geolibre_server`, FastAPI on `127.0.0.1:8765`): backs the Whitebox toolbox, format Conversion tools, and Raster tools (rasterio). The desktop app starts it on demand. It is **optional** — Vector tools (Processing → Vector) run client-side with Turf.js and only use the sidecar's `/vector` endpoints (GeoPandas/Shapely) when the optional `vector` extra is installed; the dialog falls back to the client engine via `/vector/status`. Optional extras: `conversion`, `vector`, `raster`. Some conversions (PMTiles, Whitebox) are amd64-only.
+**Python sidecar** (`backend/geolibre_server`, FastAPI on `127.0.0.1:8765`):
+backs the Whitebox toolbox, format Conversion tools, and Raster tools (rasterio).
+The desktop app starts it on demand. It is **optional** — Vector tools run
+client-side with Turf.js and only use the sidecar's `/vector` endpoints
+(GeoPandas/Shapely) when the optional `vector` extra is installed; the dialog
+falls back to the client engine via `/vector/status`. Optional extras:
+`conversion`, `vector`, `raster`. Some conversions (PMTiles, Whitebox) are
+amd64-only. The browser build proxies the sidecar at `/sidecar` (same-origin, no
+CORS), confined to `GEOLIBRE_CONVERSION_ROOTS` (default `/data`). Local MBTiles
+use a custom MapLibre protocol backed by Tauri commands.
 
-The browser build proxies the sidecar at `/sidecar` (same-origin, no CORS); confined to `GEOLIBRE_CONVERSION_ROOTS` (default `/data`). Local MBTiles use a custom MapLibre protocol backed by Tauri commands.
-
-**MCP server** (`python/src/geolibre/mcp/`, the `geolibre-mcp` console script): a headless stdio MCP server that authors `.geolibre.json` files. It is layered so nothing duplicates: `project.py` _builds_ pieces (a layer, a plugin-state blob), `authoring.py` _applies_ them to a whole project (add/remove/restyle a layer, move the camera, compose the legend/colorbar/swipe controls), and both `Map` and the MCP tools delegate to `authoring.py` — so a change to how a control is composed lands in one place. `server.py` is the only module that imports the `mcp` SDK (optional extra `geolibre[mcp]`), and `workspace.py` confines every path to `GEOLIBRE_MCP_ROOTS`/`--root` the way the sidecar confines to `GEOLIBRE_CONVERSION_ROOTS`. `python/tests/test_mcp_server.py` skips itself without the SDK, so `publish-python.yml` installs `mcp` explicitly — drop it and the server ships untested.
+**MCP server** (`python/src/geolibre/mcp/`, the `geolibre-mcp` console script):
+a headless stdio MCP server that authors `.geolibre.json` files. It is layered so
+nothing duplicates: `project.py` *builds* pieces (a layer, a plugin-state blob),
+`authoring.py` *applies* them to a whole project (add/remove/restyle a layer,
+move the camera, compose the legend/colorbar/swipe controls), and both `Map` and
+the MCP tools delegate to `authoring.py`. `server.py` is the only module that
+imports the `mcp` SDK (optional extra `geolibre[mcp]`), and `workspace.py`
+confines every path to `GEOLIBRE_MCP_ROOTS`/`--root` the way the sidecar confines
+to `GEOLIBRE_CONVERSION_ROOTS`. `python/tests/test_mcp_server.py` skips itself
+without the SDK, so `publish-python.yml` installs `mcp` explicitly.
 
 ## Conventions
 
 - Never commit directly to `main`; branch and open a PR.
-- **`@geolibre/core` and `@geolibre/map` are published to npm** by
-  `.github/workflows/publish-packages.yml` on each GitHub Release, alongside
-  `@geolibre/embed`. Their checked-in `main`/`types`/`exports` point at
-  TypeScript **source**, because that is how the monorepo consumes them: Vite,
-  `tsc` and tsx all resolve `./src/index.ts` through the package's own
-  `exports`, so `npm run dev` and `node --import tsx --test tests/<name>.test.ts`
-  need no build step. The npm tarball ships `dist` instead, and npm cannot
-  express that split on its own: unlike pnpm and Yarn it deliberately **ignores
-  entry fields nested under `publishConfig`** (npm/cli#7586), so a manifest that
-  only states its dist entries there publishes `./src/index.ts` to consumers who
-  never receive `src`. The published entries therefore live under
-  `publishConfig`, and `scripts/prepare-npm-package.mjs` hoists them (and pins
-  the `"*"` `@geolibre/core` dependency to the release version) just before
-  `npm publish`. Point those top-level fields at `dist` and every frontend test
-  that imports a `@geolibre/map` subpath fails with `ERR_MODULE_NOT_FOUND`,
-  because `dist` is gitignored and nothing builds it before the suite.
-  `tests/prepare-npm-package.test.ts` guards both halves, including that each
-  published path is one the package's own `tsdown` entries actually emit
-  (`--format esm --dts` writes `<entry>.mjs` and `<entry>.d.mts`, **not**
-  `.d.ts`). The release workflow does build both packages, but a green build
-  proves only that the bundles were written, not that every path the manifest
-  publishes names one of them, so nothing else would notice that drift.
-- **`backend/geolibre_server/uv.lock` is committed** (the root `.gitignore` ignores `uv.lock` everywhere else and negates it for this one path). That project is bundled into the desktop installers and launched with `uv run --frozen --project <resource dir>` from `src-tauri/src/lib.rs` — a directory the user cannot write (`C:\Program Files\…`, `/usr/lib/GeoLibre Desktop/…`). Ship it lockless and uv resolves, then tries to _write_ `uv.lock` there, fails with "Permission denied" and exits 2 — which reaches the user as "Jupyter server exited before it was ready (exit code: 2)" with the cause invisible. So: any edit to that `pyproject.toml`'s dependencies must land with a refreshed lock (`uv lock --project backend/geolibre_server`). CI's "Check the bundled sidecar lockfile is in sync" step (`uv lock --check`) fails if they drift.
-- Tauri CSP allowlists tile/style hosts (OpenFreeMap, CARTO) — new external map/tile hosts must be added there.
-- Map/tile-host CORS for selected release assets is handled by a dev-server raster proxy.
-- For MapLibre control styling fixes, add scoped overrides in `apps/geolibre-desktop/src/index.css`, never edit `node_modules`.
-- The Processing **menu** (`ProcessingMenu.tsx`) renders from a checked-in, auto-generated catalog, `apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts` (do not hand-edit). Whenever `geolibre-wasm` is bumped (in `packages/processing/package.json`) — including Dependabot PRs — run `node scripts/gen-whitebox-menu-catalog.mjs` and commit the result, or new/renamed WASM tools silently miss the menu (the Processing **dialog** lists tools dynamically, so the gap only shows in the menu). Whitebox translations are optional external packs in `opengeos/geolibre-language-packs`, not entries generated into GeoLibre's bundled locale JSON.
-- `MAX_VECTOR_PMTILES_ZOOM` (`packages/processing/src/wasm-convert.ts`) mirrors the deepest zoom `vector_to_pmtiles` accepts (18 — past it the tool exits with `validation error: max_zoom must be <= 18`). The cap lives inside the WASM binary and is not exported, so whenever `geolibre-wasm` is bumped — including Dependabot PRs — re-check it. If it drifts, the browser's Vector to PMTiles either refuses a zoom the tiler would now accept, or accepts one it will reject after the user has waited. Note this is **not** the sidecar's cap: freestiler allows 24 (`MAX_PMTILES_ZOOM` in `ConversionDialog.tsx`, mirroring `backend/geolibre_server/geolibre_server/app/conversion.py`), and the dialog validates against whichever engine is about to run. `tests/wasm-convert.test.ts` ("accepts the documented maximum zoom and rejects one deeper") fails in CI if the mirror drifts, so running the frontend suite after a bump is enough to catch it.
-- `MAX_VECTOR_BYTES` (`packages/plugins/src/plugins/remote-file-formats.ts`) mirrors `MAX_REMOTE_FILE_BYTES`, an **internal, unexported** constant in `maplibre-gl-vector` (2 GiB — DuckDB-WASM holds remote file sizes in 32 bits). It cannot be imported, so whenever `maplibre-gl-vector` is bumped (in `packages/plugins/package.json`) — including Dependabot PRs — re-check `src/lib/utils/remote.ts` in that package and update the mirror if it moved. If it drifts, the remote-browse panels (Source Cooperative, Hugging Face) silently block GeoParquet the engine could now open, or offer an Add that is certain to fail. Updating the constant is enough: the limit the user is shown is rendered from it, not written into the copy. `remote-file-formats.ts` is the **single** home for this and the other format/reader/size rules those panels share — a per-panel copy would miss this check, so add new browse panels against that module rather than duplicating it (`source-coop-api.ts` re-exports it under its own names for compatibility).
-- `MAP_PANEL_SELECTOR` (`apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx`) mirrors the **rendered** control class names from `maplibre-gl-components` — `maplibre-gl-html-control`, `maplibre-gl-legend`, `maplibre-gl-colorbar` — so the Record Video "Include map panels" option can rasterize those on-map overlays into the recording. These are the display elements, deliberately **not** the `*-gui-control` authoring editors. The classes are internal and unexported, so whenever `maplibre-gl-components` is bumped (in `packages/plugins/package.json`) — including Dependabot PRs — re-check them against the rendered controls and update the selector if they moved. If a class drifts, the option silently stops burning that panel into the video (or the checkbox never appears) with no build error.
-- `GLOBE_CONTROL_TOGGLE_SELECTOR` (`packages/map/src/globe-control-toggle.ts`) mirrors the class names MapLibre's own `GlobeControl` puts on its toggle button — `maplibregl-ctrl-globe` and `maplibregl-ctrl-globe-enabled`, swapped on every projection change. `MapCanvas` persists a projection change from a **click** on that button rather than from the `projectiontransition` event, because style initialization and project reconciliation emit that event too and a stale one overwrites the projection of a project that has just loaded. The classes are internal and unexported, so whenever `maplibre-gl` is bumped (including Dependabot PRs) run the frontend suite — `tests/globe-control-toggle.test.ts` builds a real `GlobeControl` and fails if the mirror stops matching. Without that check a renamed class silently stops persisting the user's projection, with no build error.
-- `BASEMAP_PANEL_SELECTOR` / `BASEMAP_ROW_SELECTOR` / `BASEMAP_ROW_ID_ATTR` (`packages/plugins/src/plugins/basemap-thumbnails.ts`) mirror the DOM `maplibre-gl-basemap-control` renders — `.basemap-control-panel`, `.basemap-control-result`, `data-basemap-id` — which the Basemaps panel's thumbnails hook into to find rows and join each one back to its catalog entry. That package exports only `BasemapControl`/`BasemapDefinition`, so a renamed class fails nothing at build time: the queries stop matching and thumbnails silently stop appearing. Whenever `maplibre-gl-basemap-control` is bumped in `packages/plugins/package.json` — including Dependabot PRs — run the frontend suite; `tests/basemap-thumbnails.test.ts` builds a real control and asserts its rendered panel against the mirror. The same file's `hasUnresolvedPlaceholder` deliberately matches the **complement** of the tile tokens it substitutes rather than mirroring that package's credential placeholders (`{api-key}`, `{aws-region}`), so a new provider's placeholder is skipped instead of being fetched literally — keep it that way rather than enumerating placeholder names.
-- **Per-layer blend modes** (`packages/map/src/layer-blend-modes.ts`) wrap three *unexported* `maplibre-gl` internals, because MapLibre renders every layer into one canvas and ships no per-layer blend API (upstream draft: maplibre/maplibre-gl-js#8073). The wrappers are `Painter.prototype.renderLayer` (brackets one layer's draws), `Painter.prototype.useProgram` (tells the layer-opacity composite draw from the draws feeding it), and `Context.prototype.setColorMode` (the single place every draw resolves GL blend state). Fill and line layers additionally get `fill-layer-opacity` / `line-layer-opacity` pinned just under 1 by `style-mapper`, which elects MapLibre 6's render-to-texture composite so a layer blends **as a whole** rather than once per overlapping polygon. `installLayerBlendModes` feature-detects every seam and disables the feature (hiding the Style-panel control) rather than breaking the map, so drift fails *quietly* — which is why `tests/layer-blend-modes.test.ts` asserts the seams and `e2e/blend-modes.spec.ts` asserts real pixels. Run both whenever `maplibre-gl` is bumped, including Dependabot PRs. **Do not add a blend mode without checking it in the browser**: MapLibre's blend state covers the alpha channel too, and it composites a blended layer as one viewport-filling quad, so any mode that does not reduce to "leave the destination alone" at zero source alpha repaints the whole map. That is what disqualified `darken` (a `MIN` equation erased the entire basemap to transparent black) and `subtract` (a reverse subtract left the canvas at `dstA - srcA`, showing the page through the layer); the shipped list is `BLEND_MODES` in `@geolibre/core`, and both the unit test's blend simulator and the e2e spec pin their exclusion. Only `fill` and `line` have a `*-layer-opacity` in the style spec, so only they blend as a **whole layer**; `circle` and `fill-extrusion` blend per symbol and visibly double-darken where symbols overlap on screen (measured under Multiply: `rgb(23, 77, 220)` in the overlap vs `rgb(76, 136, 222)` on a single symbol). That is upstream's limitation, documented in `docs/user-guide/layers.md`; the test "has a layer-level composite for fill and line only" fails if a bump adds one of the missing properties, at which point extend `COMPOSITE_LAYER_TYPES` and `style-mapper` together and drop the caveat. The Style-panel control (`blendModeControl` in `StylePanel.tsx`, rendered in each of its terminal branches) is gated on `!pluginOwnsPaint && !controlRendersLayer`: blending only reaches layers **GeoLibre itself paints**, so anything a control renders or paints (3D Tiles, Gaussian splats, LiDAR, the COG raster control, and Add Vector Layer, which sets `customLayerType` *and* `controlOwnsPaint`) is excluded -- layer-sync never applies `fillPaint`/`linePaint` to those, so the `*-layer-opacity` that elects the composite never lands and a Blend menu there would silently do nothing. Keep `docs/user-guide/layers.md` and `tests/layer-blend-modes.test.ts` ("the layer kinds the Blend control is offered for") in step with that gate; build the test's mocks the way the real controls build their metadata, or they pass on shapes that never occur.
-- **The PMTiles control's layer ids** (`pmtilesControlLayerId` / `pmtilesIdsForSourceLayers` / `pmtilesIdNamesSourceLayer`, `packages/map/src/pmtiles-layer.ts`, read from `layer-sync.ts` and `packages/plugins/src/plugins/maplibre-components.ts`) mirror an unexported fact about `maplibre-gl-components`' `PMTilesLayerControl`: it names its MapLibre layers `${sourceId}-${name}-${kind}` from the **raw** source-layer name, where `pmtilesVectorLayerId` percent-encodes it. The two agree for every name needing no encoding, so a store layer carrying the control's own ids — the archive kept whole, or a split part, which keeps the ids naming its own source layer — is recognised under the encoded scheme alone until a name holds a `/`, a space or non-ASCII. Then `layer-sync` decides the source layer has no native layer and adds a **second** fill/line/circle trio on top of the control's: drawn twice, and only the control's copy answers the panel. Both schemes are therefore matched, and only ids naming a source layer the store actually holds are kept. What the user **ticked** is deliberately _not_ inferred from those ids: `selectedSourceLayers` is a documented field of the exported `PMTilesLayerControlState` handed to every handler, so `pmtilesLayerOptions` reads it and the compiler checks it — the rules for a stale selection, and for the archive ids the control reuses across a panel close, are written at that function and at `addPMTilesArchive`. A reused id is the one case GeoLibre cannot repair: two archives then name one MapLibre source, the first to sync wins it and the other draws nothing, so `addPMTilesArchive` warns rather than pretending otherwise — while an archive that takes a layer over outright is drawn correctly, keeping the name, folder and styling of the one it replaced. Whenever `maplibre-gl-components` is bumped in `packages/plugins/package.json` — including Dependabot PRs — run the frontend suite: `tests/pmtiles-control-contract.test.ts` drives a **real** `PMTilesLayerControl` against a real archive, through the real `layeradd` handler into the store, and fails if the id scheme moves or the selection stops reaching the handler.
-- `GeoLibreCogRenderEngine` (`packages/plugins/src/types.ts`) mirrors the `RenderEngine` union `maplibre-gl-raster` exports (`maplibre-gl-raster` | `cog-tiler-wasm` | `titiler`). It is hand-written rather than imported because `types.ts` is the public plugin-API surface and importing there would make that package's types a hard dependency of every external plugin. Unlike the mirrors above this one is checked by the **compiler**, not a test: `CogRenderEngineMirrorIsExact` in `packages/plugins/src/plugins/maplibre-raster.ts` asserts both directions of assignability against the real imported type, so a renamed or dropped engine identifier fails `npm run typecheck`. Nothing extra to do on a `maplibre-gl-raster` bump beyond letting the build run; without it a stale identifier would reach `control.setEngine()` as a string the control no longer recognizes, silently leaving the raster unrendered.
-- `propertySpecFor` (`packages/core/src/expressions.ts`) fabricates the **unexported** `StylePropertySpecification` shape that `@maplibre/maplibre-gl-style-spec`'s `createExpression` uses for expected-result-type enforcement (the Expression Builder's filter → boolean / color checks). The cast hides any contract change from the compiler, so whenever `@maplibre/maplibre-gl-style-spec` is bumped (including Dependabot PRs) run the frontend suite — the "enforces an expected result type" test in `tests/expressions.test.ts` fails if the shape stops being honored.
-- `DISTANCE_SEGMENTS` / `NON_DISTANCE_NAMES` (`apps/geolibre-desktop/src/lib/whitebox-distance-params.ts`) decide, by parameter _name_, which Whitebox parameters are ground distances and so get the Processing dialog's metric unit picker (GeoLibre#1540). The segments are generic (`tolerance`, `radius`, `length`, `resolution`), so a tool can carry a matching name that is not a length — `corridor_tolerance` is a 0-1 fraction. Those are safe today only because the picker is confined to tools whose every dataset input is a vector layer, and the colliding names happen to sit on imagery/LiDAR tools; that is a coincidence, not a guarantee. So whenever `geolibre-wasm` is bumped (in `packages/processing/package.json`) — including Dependabot PRs — scan the new catalog for a `double` matching the rule whose description reads as a fraction, ratio, angle or weight, and add it to `NON_DISTANCE_NAMES`. If one is missed, that tool's field offers metres and silently converts a dimensionless number as if it were a distance, with no build error.
-- **Before starting any i18n work** (adding, updating, or auditing locale catalogs), read `docs/i18n.md` in full. It covers CLDR plural rules (e.g. Chinese/Japanese/Korean drop `_one` and keep `_other`), what must not be translated (URLs, store IDs, file-format names, persisted values), how `<Trans>` markup tags and interpolation placeholders must be preserved verbatim, and the test contract (`tests/i18n-catalogs.test.ts`). Skipping this step is the most common source of locale bugs.
-- Processing **tool metadata** (names, descriptions, group labels, parameter labels/help, select options) lives in registries with no i18n access, so the dialogs resolve it through `apps/geolibre-desktop/src/lib/processing-tool-i18n.ts` and fall back to the registry's own English string. For the four small bundled registries, `en.json`'s `processing.toolMeta`/`processing.toolGroup` subtrees are the **generated** baseline translators work from. After adding or renaming one of those tools, parameters, or select options, run `npm run i18n:tools` and commit the result; CI fails on drift. Whitebox's much larger metadata is deliberately absent from all bundled locales and comes from optional, validated packs at `languages.geolibre.app` (or local file import); do not add `processing.toolMeta.whitebox`, `processing.whitebox.categories`, `menuTool`, or `menuSubcategory` back to a bundled locale.
-- UI strings are translatable via **react-i18next**; catalogs live in `apps/geolibre-desktop/src/i18n/locales/*.json` (`en.json` is the source of truth, typed by `i18next.d.ts`). Use `t()` for new user-facing strings; a `?locale`/`?lang` query param sets the embed language. The UI mirrors for right-to-left locales (Arabic), so style new components with Tailwind's logical utilities (`ms-`/`me-`/`ps-`/`pe-`/`text-start`/`border-s`/`start-`…), not the physical `ml-`/`left-` forms. See `docs/i18n.md`.
-- `skills/geolibre/` is a **user-facing agent skill** — a `SKILL.md` plus `references/` that teaches an external AI agent to author `.geolibre.json` projects through `geolibre-mcp`, the Python package, or hand-written JSON. It is not for contributors working on GeoLibre itself (that is this file). It restates things that live elsewhere: the MCP tool surface (`python/src/geolibre/mcp/server.py`), the basemap/color-ramp/legend catalogs (`python/src/geolibre/basemaps.py`, `color_ramp.py`, `legends.py`), the project schema (`docs/project-format.md`), and the embed parameters (`docs/user-guide/embedding.md`). `python/tests/test_agent_skill.py` guards the parts that can be checked mechanically: every registered MCP tool must appear in the tool reference, every tool and `Map` method the skill names must exist, and the basemap, color-ramp, legend-preset, layer-type, frontmatter, and reference-file lists must match their sources. It cannot check prose, so a changed size cap, limit, or behavioral caveat still has to be carried over by hand — update the skill in the same PR. A stale caveat sends an agent down a path that no longer works, with no failure anywhere.
-- Reference docs: `docs/architecture.md`, `docs/project-format.md`, `docs/plugin-api.md`, `docs/python.md`, `docs/mcp.md`, `docs/agent-skill.md`, `docs/i18n.md`, `docs/contributing.md`.
+- Tauri CSP allowlists tile/style hosts (OpenFreeMap, CARTO) — new external
+  map/tile hosts must be added there. Map/tile-host CORS for selected release
+  assets is handled by a dev-server raster proxy.
+- For MapLibre control styling fixes, add scoped overrides in
+  `apps/geolibre-desktop/src/index.css`, never edit `node_modules`.
+- UI strings are translatable via **react-i18next**; catalogs live in
+  `apps/geolibre-desktop/src/i18n/locales/*.json` (`en.json` is the source of
+  truth, typed by `i18next.d.ts`). Use `t()` for new user-facing strings. The UI
+  mirrors for right-to-left locales, so style new components with Tailwind's
+  logical utilities (`ms-`/`me-`/`ps-`/`pe-`/`text-start`/`border-s`/`start-`…),
+  not the physical `ml-`/`left-` forms. **Read `docs/i18n.md` in full before any
+  i18n work** — skipping it is the most common source of locale bugs.
+- **Some things upstream doesn't export are mirrored by hand, and drift fails
+  silently.** Before bumping `maplibre-gl`, any `maplibre-gl-*` package, or
+  `geolibre-wasm` — including Dependabot PRs — read
+  [`docs/maintenance.md`](docs/maintenance.md) and run the frontend suite. That
+  page also covers the coverage floors, the `npm audit` allowlist, the npm
+  publish layout for `@geolibre/core`/`@geolibre/map`, the committed
+  `backend/geolibre_server/uv.lock`, and the generated files (Whitebox menu
+  catalog, `npm run i18n:tools`, the `skills/geolibre/` agent skill) that must be
+  regenerated or updated in the same PR.
+- Reference docs: `docs/architecture.md`, `docs/project-format.md`,
+  `docs/plugin-api.md`, `docs/python.md`, `docs/mcp.md`, `docs/agent-skill.md`,
+  `docs/i18n.md`, `docs/maintenance.md`, `docs/contributing.md`.

--- a/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
@@ -52,7 +52,7 @@ const DEFAULT_FILE_NAME = "map-recording";
 // *rendered* overlays (`maplibre-gl-html-control` / `maplibre-gl-legend` /
 // `maplibre-gl-colorbar`), NOT the `*-gui-control` authoring editors -- we burn
 // the info in, not the editor chrome. Those class names mirror
-// maplibre-gl-components internals; see CLAUDE.md and re-check them when that
+// maplibre-gl-components internals; see docs/maintenance.md and re-check them when that
 // package is bumped.
 const MAP_PANEL_SELECTOR =
   ".maplibre-gl-html-control, .maplibre-gl-legend, .maplibre-gl-colorbar, .geolibre-legend-panel";

--- a/apps/geolibre-desktop/src/lib/persisted-right-panel.ts
+++ b/apps/geolibre-desktop/src/lib/persisted-right-panel.ts
@@ -1,6 +1,6 @@
 // The registry subpath rather than the package barrel: this module is a leaf the
 // test suite imports directly, and the barrel pulls in the whole built-in plugin
-// registry (including CSS imports Node cannot load). See CLAUDE.md on testing
+// registry (including CSS imports Node cannot load). See docs/maintenance.md on testing
 // against a leaf module.
 import {
   collapseRightPanel,

--- a/apps/geolibre-desktop/src/lib/whitebox-distance-params.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-distance-params.ts
@@ -69,7 +69,7 @@ const DISTANCE_NAMES = new Set(["cell_size", "width", "height"]);
  * The catalog scan behind this list looked for a matching `double` whose
  * description reads as a fraction, ratio, angle or weight; re-run it when
  * `geolibre-wasm` is bumped, since the tool-level gate that saves these today is
- * incidental. That re-check is recorded in `CLAUDE.md`'s Conventions section
+ * incidental. That re-check is recorded in `docs/maintenance.md`
  * alongside the repo's other name/version mirrors.
  */
 const NON_DISTANCE_NAMES = new Set(["corridor_tolerance", "densify_spacing"]);

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,337 @@
+# Maintenance Notes
+
+This page collects the repository rules that are easy to break **silently** —
+hand-written mirrors of unexported upstream constants, coverage and audit gates,
+publishing layouts, and generated files. `CLAUDE.md` links here rather than
+restating any of it.
+
+If you are just getting set up, read [Contributing](contributing.md) first.
+
+## Dependency bumps that need a manual check
+
+Several features depend on values or DOM contracts that upstream packages do not
+export, so GeoLibre mirrors them by hand. Drift usually produces **no build
+error** — the feature just stops working. After bumping any of the packages
+below (**including Dependabot PRs**), do the listed check and run the frontend
+suite.
+
+### `geolibre-wasm` (`packages/processing/package.json`)
+
+- **Processing menu catalog.** `ProcessingMenu.tsx` renders from a checked-in,
+  auto-generated catalog, `apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts`
+  (do not hand-edit). Run `node scripts/gen-whitebox-menu-catalog.mjs` and commit
+  the result, or new/renamed WASM tools silently miss the menu. The Processing
+  *dialog* lists tools dynamically, so the gap only shows in the menu.
+- **`MAX_VECTOR_PMTILES_ZOOM`** (`packages/processing/src/wasm-convert.ts`)
+  mirrors the deepest zoom `vector_to_pmtiles` accepts (18 — past it the tool
+  exits with `validation error: max_zoom must be <= 18`). The cap lives inside
+  the WASM binary and is not exported. If it drifts, the browser's Vector to
+  PMTiles either refuses a zoom the tiler would now accept, or accepts one it
+  will reject after the user has waited. This is **not** the sidecar's cap:
+  freestiler allows 24 (`MAX_PMTILES_ZOOM` in `ConversionDialog.tsx`, mirroring
+  `backend/geolibre_server/geolibre_server/app/conversion.py`), and the dialog
+  validates against whichever engine is about to run.
+  `tests/wasm-convert.test.ts` fails if the mirror drifts.
+- **`DISTANCE_SEGMENTS` / `NON_DISTANCE_NAMES`**
+  (`apps/geolibre-desktop/src/lib/whitebox-distance-params.ts`) decide, by
+  parameter *name*, which Whitebox parameters are ground distances and so get the
+  Processing dialog's metric unit picker (GeoLibre#1540). The segments are
+  generic (`tolerance`, `radius`, `length`, `resolution`), so a tool can carry a
+  matching name that is not a length — `corridor_tolerance` is a 0–1 fraction.
+  Those are safe today only because the picker is confined to tools whose every
+  dataset input is a vector layer, and the colliding names happen to sit on
+  imagery/LiDAR tools; that is a coincidence, not a guarantee. Scan the new
+  catalog for a `double` matching the rule whose description reads as a fraction,
+  ratio, angle or weight, and add it to `NON_DISTANCE_NAMES`. If one is missed,
+  that tool's field offers metres and silently converts a dimensionless number as
+  if it were a distance.
+
+### `maplibre-gl`
+
+- **`GLOBE_CONTROL_TOGGLE_SELECTOR`** (`packages/map/src/globe-control-toggle.ts`)
+  mirrors the class names MapLibre's own `GlobeControl` puts on its toggle button
+  — `maplibregl-ctrl-globe` and `maplibregl-ctrl-globe-enabled`, swapped on every
+  projection change. `MapCanvas` persists a projection change from a **click** on
+  that button rather than from the `projectiontransition` event, because style
+  initialization and project reconciliation emit that event too and a stale one
+  overwrites the projection of a project that has just loaded.
+  `tests/globe-control-toggle.test.ts` builds a real `GlobeControl` and fails if
+  the mirror stops matching.
+- **Per-layer blend modes** (`packages/map/src/layer-blend-modes.ts`) wrap three
+  *unexported* `maplibre-gl` internals, because MapLibre renders every layer into
+  one canvas and ships no per-layer blend API (upstream draft:
+  maplibre/maplibre-gl-js#8073). The wrappers are `Painter.prototype.renderLayer`
+  (brackets one layer's draws), `Painter.prototype.useProgram` (tells the
+  layer-opacity composite draw from the draws feeding it), and
+  `Context.prototype.setColorMode` (the single place every draw resolves GL blend
+  state). Fill and line layers additionally get `fill-layer-opacity` /
+  `line-layer-opacity` pinned just under 1 by `style-mapper`, which elects
+  MapLibre 6's render-to-texture composite so a layer blends **as a whole** rather
+  than once per overlapping polygon. `installLayerBlendModes` feature-detects
+  every seam and disables the feature (hiding the Style-panel control) rather than
+  breaking the map, so drift fails *quietly* — which is why
+  `tests/layer-blend-modes.test.ts` asserts the seams and
+  `e2e/blend-modes.spec.ts` asserts real pixels. Run both on a bump.
+
+  See [Adding a blend mode](#adding-a-blend-mode) before extending the list.
+
+### `@maplibre/maplibre-gl-style-spec`
+
+`propertySpecFor` (`packages/core/src/expressions.ts`) fabricates the
+**unexported** `StylePropertySpecification` shape that `createExpression` uses for
+expected-result-type enforcement (the Expression Builder's filter → boolean /
+color checks). The cast hides any contract change from the compiler, so run the
+frontend suite — the "enforces an expected result type" test in
+`tests/expressions.test.ts` fails if the shape stops being honored.
+
+### `maplibre-gl-components` (`packages/plugins/package.json`)
+
+- **`MAP_PANEL_SELECTOR`**
+  (`apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx`) mirrors
+  the **rendered** control class names — `maplibre-gl-html-control`,
+  `maplibre-gl-legend`, `maplibre-gl-colorbar` — so Record Video's "Include map
+  panels" option can rasterize those on-map overlays into the recording. These are
+  the display elements, deliberately **not** the `*-gui-control` authoring
+  editors. If a class drifts, the option silently stops burning that panel into
+  the video (or the checkbox never appears) with no build error.
+- **The PMTiles control's layer ids** (`pmtilesControlLayerId` /
+  `pmtilesIdsForSourceLayers` / `pmtilesIdNamesSourceLayer`,
+  `packages/map/src/pmtiles-layer.ts`, read from `layer-sync.ts` and
+  `packages/plugins/src/plugins/maplibre-components.ts`) mirror an unexported fact
+  about `PMTilesLayerControl`: it names its MapLibre layers
+  `${sourceId}-${name}-${kind}` from the **raw** source-layer name, where
+  `pmtilesVectorLayerId` percent-encodes it. The two agree for every name needing
+  no encoding, so a store layer carrying the control's own ids — the archive kept
+  whole, or a split part, which keeps the ids naming its own source layer — is
+  recognised under the encoded scheme alone until a name holds a `/`, a space or
+  non-ASCII. Then `layer-sync` decides the source layer has no native layer and
+  adds a **second** fill/line/circle trio on top of the control's: drawn twice,
+  and only the control's copy answers the panel. Both schemes are therefore
+  matched, and only ids naming a source layer the store actually holds are kept.
+
+  What the user **ticked** is deliberately *not* inferred from those ids:
+  `selectedSourceLayers` is a documented field of the exported
+  `PMTilesLayerControlState` handed to every handler, so `pmtilesLayerOptions`
+  reads it and the compiler checks it — the rules for a stale selection, and for
+  the archive ids the control reuses across a panel close, are written at that
+  function and at `addPMTilesArchive`. A reused id is the one case GeoLibre cannot
+  repair: two archives then name one MapLibre source, the first to sync wins it
+  and the other draws nothing, so `addPMTilesArchive` warns rather than pretending
+  otherwise — while an archive that takes a layer over outright is drawn
+  correctly, keeping the name, folder and styling of the one it replaced.
+  `tests/pmtiles-control-contract.test.ts` drives a **real** control against a
+  real archive, through the real `layeradd` handler into the store, and fails if
+  the id scheme moves or the selection stops reaching the handler.
+
+### `maplibre-gl-basemap-control` (`packages/plugins/package.json`)
+
+`BASEMAP_PANEL_SELECTOR` / `BASEMAP_ROW_SELECTOR` / `BASEMAP_ROW_ID_ATTR`
+(`packages/plugins/src/plugins/basemap-thumbnails.ts`) mirror the DOM the control
+renders — `.basemap-control-panel`, `.basemap-control-result`, `data-basemap-id` —
+which the Basemaps panel's thumbnails hook into to find rows and join each one
+back to its catalog entry. That package exports only
+`BasemapControl`/`BasemapDefinition`, so a renamed class fails nothing at build
+time: the queries stop matching and thumbnails silently stop appearing.
+`tests/basemap-thumbnails.test.ts` builds a real control and asserts its rendered
+panel against the mirror.
+
+The same file's `hasUnresolvedPlaceholder` deliberately matches the **complement**
+of the tile tokens it substitutes rather than mirroring that package's credential
+placeholders (`{api-key}`, `{aws-region}`), so a new provider's placeholder is
+skipped instead of being fetched literally. Keep it that way rather than
+enumerating placeholder names.
+
+### `maplibre-gl-vector` (`packages/plugins/package.json`)
+
+`MAX_VECTOR_BYTES` (`packages/plugins/src/plugins/remote-file-formats.ts`) mirrors
+`MAX_REMOTE_FILE_BYTES`, an **internal, unexported** constant in that package
+(2 GiB — DuckDB-WASM holds remote file sizes in 32 bits). It cannot be imported,
+so re-check `src/lib/utils/remote.ts` in that package and update the mirror if it
+moved. If it drifts, the remote-browse panels (Source Cooperative, Hugging Face)
+silently block GeoParquet the engine could now open, or offer an Add that is
+certain to fail. Updating the constant is enough: the limit the user is shown is
+rendered from it, not written into the copy.
+
+`remote-file-formats.ts` is the **single** home for this and the other
+format/reader/size rules those panels share — a per-panel copy would miss this
+check, so add new browse panels against that module rather than duplicating it
+(`source-coop-api.ts` re-exports it under its own names for compatibility).
+
+### `maplibre-gl-raster` — checked by the compiler
+
+`GeoLibreCogRenderEngine` (`packages/plugins/src/types.ts`) mirrors the
+`RenderEngine` union that package exports (`maplibre-gl-raster` |
+`cog-tiler-wasm` | `titiler`). It is hand-written rather than imported because
+`types.ts` is the public plugin-API surface and importing there would make that
+package's types a hard dependency of every external plugin. Unlike the mirrors
+above this one is checked by the **compiler**:
+`CogRenderEngineMirrorIsExact` in
+`packages/plugins/src/plugins/maplibre-raster.ts` asserts both directions of
+assignability against the real imported type, so a renamed or dropped engine
+identifier fails `npm run typecheck`. Nothing extra to do on a bump beyond letting
+the build run.
+
+## Adding a blend mode
+
+**Do not add a blend mode without checking it in the browser.** MapLibre's blend
+state covers the alpha channel too, and it composites a blended layer as one
+viewport-filling quad, so any mode that does not reduce to "leave the destination
+alone" at zero source alpha repaints the whole map. That is what disqualified
+`darken` (a `MIN` equation erased the entire basemap to transparent black) and
+`subtract` (a reverse subtract left the canvas at `dstA - srcA`, showing the page
+through the layer). The shipped list is `BLEND_MODES` in `@geolibre/core`, and
+both the unit test's blend simulator and the e2e spec pin their exclusion.
+
+Only `fill` and `line` have a `*-layer-opacity` in the style spec, so only they
+blend as a **whole layer**; `circle` and `fill-extrusion` blend per symbol and
+visibly double-darken where symbols overlap on screen (measured under Multiply:
+`rgb(23, 77, 220)` in the overlap vs `rgb(76, 136, 222)` on a single symbol). That
+is upstream's limitation, documented in
+[Managing Layers](user-guide/layers.md); the test "has a layer-level composite for
+fill and line only" fails if a bump adds one of the missing properties, at which
+point extend `COMPOSITE_LAYER_TYPES` and `style-mapper` together and drop the
+caveat.
+
+The Style-panel control (`blendModeControl` in `StylePanel.tsx`, rendered in each
+of its terminal branches) is gated on `!pluginOwnsPaint && !controlRendersLayer`:
+blending only reaches layers **GeoLibre itself paints**, so anything a control
+renders or paints (3D Tiles, Gaussian splats, LiDAR, the COG raster control, and
+Add Vector Layer, which sets `customLayerType` *and* `controlOwnsPaint`) is
+excluded — layer-sync never applies `fillPaint`/`linePaint` to those, so the
+`*-layer-opacity` that elects the composite never lands and a Blend menu there
+would silently do nothing. Keep `docs/user-guide/layers.md` and
+`tests/layer-blend-modes.test.ts` ("the layer kinds the Blend control is offered
+for") in step with that gate; build the test's mocks the way the real controls
+build their metadata, or they pass on shapes that never occur.
+
+## Coverage floors
+
+The `:coverage` test variants run the same suites and print a coverage summary;
+CI runs them so every build reports coverage. They are **gated on a floor**:
+`test:frontend:coverage` fails below 78% lines / 78% branches / 63% functions, and
+`test:backend:coverage` fails below 55% (`--cov-fail-under`). The floors sit a few
+points under the current numbers as a **ratchet** — regressions fail CI, and when
+coverage rises comfortably above a floor, raise the floor to lock in the gain.
+
+The frontend report only counts files a test actually imports, so a module with no
+test does not appear at all rather than as 0%. That is the part that bites:
+writing the *first* test for a large untested module reads as a coverage
+**regression**, because the module and everything it imports enter the denominator
+at once. GeoLibre#1784 added a test that imported `usePlugins.ts` and so pulled in
+the whole built-in plugin registry, 39 files, dropping function coverage 72.90% →
+60.36% and reddening `main`. The fix is to test against a leaf module rather than
+to lower the floor (GeoLibre#1888 extracted `lib/plugin-layer-queries.ts`;
+`geo-editor-geometry.ts` in `@geolibre/plugins` is the same pattern). Check what a
+new test *transitively* imports before assuming a coverage drop means the code got
+worse.
+
+`test:frontend:coverage` runs through `scripts/coverage-check.mjs` rather than
+calling `node --test` directly. Node still enforces all three floors; the wrapper
+only re-measures once when **line** coverage alone comes up short with every test
+passing. Line coverage is nondeterministic on CI (GeoLibre#1889: two runs over
+byte-identical sources reported 81.82% and 76.47%, 114 of 444 files differing on
+lines and *none* on branches or functions), and it is not reproducible locally on
+either Node 22 or 26. Branch and function shortfalls, and any test failure, fail on
+the spot with no retry, so a real regression still fails fast. `classify()` is
+exported and covered by `tests/coverage-check.test.ts` — change the retry policy
+there, not by loosening a floor. If the retry starts firing regularly, fix the
+measurement instead of widening the mitigation.
+
+The backend coverage run (and `npm run ci`, which calls the `:coverage` variants)
+needs `pytest-cov` from the backend `dev` extra. Install the **`test`** extra to
+run the *full* backend suite — without the optional engines
+(geopandas/rasterio/sedona/httpx) the vector/raster/SQL/ML tests skip themselves
+and CI is green but hollow: `pip install -e "backend/geolibre_server[test]"`.
+
+## Dependency updates and the audit allowlist
+
+Dependencies are watched two ways: **Dependabot** (`.github/dependabot.yml`) opens
+grouped weekly update PRs for npm, pip (backend + `python/`), cargo, and Actions,
+and the CI **`audit` job** runs `npm run audit:ci` (blocking) plus a non-blocking
+`pip-audit` of the resolved backend environment.
+
+`audit:ci` is `scripts/audit-check.mjs`, a thin wrapper over `npm audit
+--omit=dev` that still fails on every high/critical advisory *except* the ones
+listed in its `ALLOWLIST`. The wrapper exists because plain `npm audit` cannot
+accept a single finding, so one unpatchable transitive advisory reddens every PR
+until upstream ships a fix — which for an unmaintained leaf package may be never.
+Only allowlist an advisory when there is **no patched version to upgrade to** and
+the vulnerable code is **unreachable from a GeoLibre runtime path**, and say why on
+both counts in the entry. Anything upgradeable gets upgraded instead. Stale entries
+print a warning rather than failing, since the advisory database is a live service
+and a transient omission must not redden an unrelated PR.
+
+## Publishing `@geolibre/core` and `@geolibre/map`
+
+Both are published to npm by `.github/workflows/publish-packages.yml` on each
+GitHub Release, alongside `@geolibre/embed`. Their checked-in
+`main`/`types`/`exports` point at TypeScript **source**, because that is how the
+monorepo consumes them: Vite, `tsc` and tsx all resolve `./src/index.ts` through
+the package's own `exports`, so `npm run dev` and
+`node --import tsx --test tests/<name>.test.ts` need no build step.
+
+The npm tarball ships `dist` instead, and npm cannot express that split on its
+own: unlike pnpm and Yarn it deliberately **ignores entry fields nested under
+`publishConfig`** (npm/cli#7586), so a manifest that only states its dist entries
+there publishes `./src/index.ts` to consumers who never receive `src`. The
+published entries therefore live under `publishConfig`, and
+`scripts/prepare-npm-package.mjs` hoists them (and pins the `"*"`
+`@geolibre/core` dependency to the release version) just before `npm publish`.
+
+Point those top-level fields at `dist` and every frontend test that imports a
+`@geolibre/map` subpath fails with `ERR_MODULE_NOT_FOUND`, because `dist` is
+gitignored and nothing builds it before the suite.
+`tests/prepare-npm-package.test.ts` guards both halves, including that each
+published path is one the package's own `tsdown` entries actually emit
+(`--format esm --dts` writes `<entry>.mjs` and `<entry>.d.mts`, **not** `.d.ts`).
+The release workflow does build both packages, but a green build proves only that
+the bundles were written, not that every path the manifest publishes names one of
+them, so nothing else would notice that drift.
+
+## The bundled sidecar lockfile
+
+`backend/geolibre_server/uv.lock` **is committed** (the root `.gitignore` ignores
+`uv.lock` everywhere else and negates it for this one path). That project is
+bundled into the desktop installers and launched with
+`uv run --frozen --project <resource dir>` from `src-tauri/src/lib.rs` — a
+directory the user cannot write (`C:\Program Files\…`,
+`/usr/lib/GeoLibre Desktop/…`). Ship it lockless and uv resolves, then tries to
+*write* `uv.lock` there, fails with "Permission denied" and exits 2 — which reaches
+the user as "Jupyter server exited before it was ready (exit code: 2)" with the
+cause invisible.
+
+So: any edit to that `pyproject.toml`'s dependencies must land with a refreshed
+lock (`uv lock --project backend/geolibre_server`). CI's "Check the bundled sidecar
+lockfile is in sync" step (`uv lock --check`) fails if they drift.
+
+## Generated files and cross-file sync
+
+- **Processing tool metadata.** Names, descriptions, group labels, parameter
+  labels/help and select options live in registries with no i18n access, so the
+  dialogs resolve them through
+  `apps/geolibre-desktop/src/lib/processing-tool-i18n.ts` and fall back to the
+  registry's own English string. For the four small bundled registries,
+  `en.json`'s `processing.toolMeta`/`processing.toolGroup` subtrees are the
+  **generated** baseline translators work from. After adding or renaming one of
+  those tools, parameters, or select options, run `npm run i18n:tools` and commit
+  the result; CI fails on drift. Whitebox's much larger metadata is deliberately
+  absent from all bundled locales and comes from optional, validated packs at
+  `languages.geolibre.app` (or local file import); do not add
+  `processing.toolMeta.whitebox`, `processing.whitebox.categories`, `menuTool`, or
+  `menuSubcategory` back to a bundled locale.
+- **The agent skill.** `skills/geolibre/` is a *user-facing* agent skill — a
+  `SKILL.md` plus `references/` that teaches an external AI agent to author
+  `.geolibre.json` projects through `geolibre-mcp`, the Python package, or
+  hand-written JSON. It is not for contributors working on GeoLibre itself. It
+  restates things that live elsewhere: the MCP tool surface
+  (`python/src/geolibre/mcp/server.py`), the basemap/color-ramp/legend catalogs
+  (`python/src/geolibre/basemaps.py`, `color_ramp.py`, `legends.py`), the project
+  schema ([Project Format](project-format.md)), and the embed parameters
+  ([Embedding](user-guide/embedding.md)). `python/tests/test_agent_skill.py`
+  guards the parts that can be checked mechanically: every registered MCP tool
+  must appear in the tool reference, every tool and `Map` method the skill names
+  must exist, and the basemap, color-ramp, legend-preset, layer-type, frontmatter,
+  and reference-file lists must match their sources. It cannot check prose, so a
+  changed size cap, limit, or behavioral caveat still has to be carried over by
+  hand — update the skill in the same PR. A stale caveat sends an agent down a
+  path that no longer works, with no failure anywhere.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -21,7 +21,9 @@ suite.
   auto-generated catalog, `apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts`
   (do not hand-edit). Run `node scripts/gen-whitebox-menu-catalog.mjs` and commit
   the result, or new/renamed WASM tools silently miss the menu. The Processing
-  *dialog* lists tools dynamically, so the gap only shows in the menu.
+  *dialog* lists tools dynamically, so the gap only shows in the menu. Whitebox
+  translations are optional external packs in `opengeos/geolibre-language-packs`,
+  not entries generated into GeoLibre's bundled locale JSON.
 - **`MAX_VECTOR_PMTILES_ZOOM`** (`packages/processing/src/wasm-convert.ts`)
   mirrors the deepest zoom `vector_to_pmtiles` accepts (18 — past it the tool
   exits with `validation error: max_zoom must be <= 18`). The cap lives inside

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - Notebook Panel: notebook.md
       - Roadmap: roadmap.md
       - Contributing: contributing.md
+      - Maintenance Notes: maintenance.md
       - How to Cite: citation.md
       - Acknowledgements: acknowledgements.md
       - Privacy Policy: privacy.md

--- a/scripts/coverage-check.mjs
+++ b/scripts/coverage-check.mjs
@@ -24,7 +24,7 @@ import { readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// Kept in sync with the floors documented in CLAUDE.md. Raise them when
+// Kept in sync with the floors documented in docs/maintenance.md. Raise them when
 // coverage rises comfortably above, which is what makes this a ratchet.
 const LINES = 78;
 const BRANCHES = 78;
@@ -165,7 +165,7 @@ async function main() {
     `\ncoverage-check: line coverage was short twice in a row (${firstLine.actual}% then ` +
       `${secondLine ? `${secondLine.actual}%` : "short again"}, floor ${firstLine.floor}%). ` +
       "A real regression reproduces; this is one. Add tests or, if the drop is a module newly " +
-      "pulled into the report rather than code getting less tested, see the coverage notes in CLAUDE.md.",
+      "pulled into the report rather than code getting less tested, see the coverage notes in docs/maintenance.md.",
   );
   return 1;
 }


### PR DESCRIPTION
## Summary
- CLAUDE.md drops from 30 KB to 8.7 KB, keeping repo shape, commands, pre-commit scoping, architecture, and a short conventions list.
- Everything that only matters on a dependency bump or a CI/release change moves verbatim into a new `docs/maintenance.md`: the hand-written mirrors of unexported upstream internals (grouped by the package that triggers the re-check), the blend-mode rules, coverage floors, the npm audit allowlist, the `publishConfig` hoist, the committed sidecar `uv.lock`, and the generated files that must be refreshed in the same PR.
- The four in-repo comments that pointed at CLAUDE.md for those details now point at `docs/maintenance.md`, and the page is added to the mkdocs Reference nav.

## Test plan
- [x] `pre-commit run --all-files` passes, including the `npm build` hook
- [x] No content dropped: every rule removed from CLAUDE.md appears in `docs/maintenance.md`
- [ ] Docs build renders the new Reference page and its internal links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive maintenance guide covering validation checks, synchronization requirements, coverage, dependency auditing, publishing, and generated files.
  * Added the maintenance guide to the documentation Reference navigation.
  * Updated maintenance and testing references to point to the new guide.
  * Refined contributor guidance and consolidated maintenance instructions for easier reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->