### PR TITLE
Fix opaque analytics responses in diagnostics

### DIFF
--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -432,9 +432,15 @@ export function installDiagnosticsCapture(): () => void {
         forwarded.init !== undefined
           ? await originalFetch(forwarded.input, forwarded.init)
           : await originalFetch(forwarded.input);
+      // A completed `no-cors` fetch resolves to an opaque response whose real
+      // status is deliberately hidden as 0 and whose `ok` flag is false. That
+      // is not evidence of a failed request: genuine network failures reject
+      // the fetch and are handled by the catch block below. The same applies to
+      // a manually followed cross-origin redirect (`opaqueredirect`).
+      const opaque = response.type === "opaque" || response.type === "opaqueredirect";
       appendDiagnostic({
         category: "network",
-        level: response.ok || optional ? "info" : "error",
+        level: response.ok || optional || opaque ? "info" : "error",
         message: `${method} ${response.status} ${response.statusText}`.trim(),
         durationMs: Math.round(performance.now() - startedAt),
         method,

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -355,6 +355,34 @@ describe("diagnostics startup transient suppression", () => {
     assert.equal(getDiagnosticsSnapshot().errorCount, 1);
   });
 
+  it("treats a resolved opaque response as informational", async () => {
+    setCaptureNetworkInfo(true);
+    try {
+      // Browsers expose a successful no-cors response with these exact fields:
+      // the actual HTTP status is intentionally hidden, so status 0 and
+      // ok=false must not be mistaken for a network failure.
+      const opaqueResponse = {
+        ok: false,
+        status: 0,
+        statusText: "",
+        type: "opaque",
+      } as Response;
+      win.fetch = (() => Promise.resolve(opaqueResponse)) as unknown as typeof fetch;
+      install();
+      await (win.fetch as typeof fetch)("https://www.google-analytics.com/g/collect", {
+        mode: "no-cors",
+        method: "POST",
+      });
+      const [record] = getDiagnosticsSnapshot().records;
+      assert.equal(record.category, "network");
+      assert.equal(record.level, "info");
+      assert.equal(record.status, 0);
+      assert.equal(getDiagnosticsSnapshot().errorCount, 0);
+    } finally {
+      setCaptureNetworkInfo(false);
+    }
+  });
+
   it("downgrades a non-ok response on an optional-resource request", async () => {
     setCaptureNetworkInfo(true);
     try {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -355,33 +355,36 @@ describe("diagnostics startup transient suppression", () => {
     assert.equal(getDiagnosticsSnapshot().errorCount, 1);
   });
 
-  it("treats a resolved opaque response as informational", async () => {
-    setCaptureNetworkInfo(true);
-    try {
-      // Browsers expose a successful no-cors response with these exact fields:
-      // the actual HTTP status is intentionally hidden, so status 0 and
-      // ok=false must not be mistaken for a network failure.
-      const opaqueResponse = {
-        ok: false,
-        status: 0,
-        statusText: "",
-        type: "opaque",
-      } as Response;
-      win.fetch = (() => Promise.resolve(opaqueResponse)) as unknown as typeof fetch;
-      install();
-      await (win.fetch as typeof fetch)("https://www.google-analytics.com/g/collect", {
-        mode: "no-cors",
-        method: "POST",
-      });
-      const [record] = getDiagnosticsSnapshot().records;
-      assert.equal(record.category, "network");
-      assert.equal(record.level, "info");
-      assert.equal(record.status, 0);
-      assert.equal(getDiagnosticsSnapshot().errorCount, 0);
-    } finally {
-      setCaptureNetworkInfo(false);
-    }
-  });
+  for (const responseType of ["opaque", "opaqueredirect"] as const) {
+    it(`treats a resolved ${responseType} response as informational`, async () => {
+      setCaptureNetworkInfo(true);
+      try {
+        // Browsers expose a successful no-cors response with these exact fields:
+        // the actual HTTP status is intentionally hidden, so status 0 and
+        // ok=false must not be mistaken for a network failure. A manual
+        // cross-origin redirect exposes the same fields as `opaqueredirect`.
+        const opaqueResponse = {
+          ok: false,
+          status: 0,
+          statusText: "",
+          type: responseType,
+        } as Response;
+        win.fetch = (() => Promise.resolve(opaqueResponse)) as unknown as typeof fetch;
+        install();
+        await (win.fetch as typeof fetch)("https://www.google-analytics.com/g/collect", {
+          mode: "no-cors",
+          method: "POST",
+        });
+        const [record] = getDiagnosticsSnapshot().records;
+        assert.equal(record.category, "network");
+        assert.equal(record.level, "info");
+        assert.equal(record.status, 0);
+        assert.equal(getDiagnosticsSnapshot().errorCount, 0);
+      } finally {
+        setCaptureNetworkInfo(false);
+      }
+    });
+  }
 
   it("downgrades a non-ok response on an optional-resource request", async () => {
     setCaptureNetworkInfo(true);


### PR DESCRIPTION
## Summary

- treat resolved opaque and opaque-redirect fetch responses as informational
- keep rejected requests and non-OK visible responses classified as errors
- add regression coverage for successful no-cors requests with hidden status 0

## Verification

- production build with hosted analytics enabled
- browser verification with GA page-view and scroll requests: Diagnostics reports 0 errors
- node --import tsx --test tests/diagnostics.test.ts
- pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Network diagnostics now correctly classify completed opaque and redirected responses as informational instead of errors.
  - No-cors requests that complete successfully no longer generate misleading error entries.

- **Tests**
  - Added coverage confirming opaque responses are recorded with the correct status when network diagnostics are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->