### PR TITLE
Fix Ollama LAN origin error guidance

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AiSectionContent.tsx
@@ -27,7 +27,11 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { DEFAULT_OLLAMA_BASE_URL, discoverOllamaModels } from "../../lib/assistant/ollama";
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  discoverOllamaModels,
+  withOllamaOriginHint,
+} from "../../lib/assistant/ollama";
 import { classifyFetchFailure } from "../../lib/fetch-error";
 
 // ── Locally-defined types to avoid circular import with SettingsDialog ──
@@ -100,7 +104,7 @@ function useOllamaModels() {
       // models:" prefix — prefixing all three would read redundantly.
       setError(
         kind === "network"
-          ? t("settings.ai.ollamaNetworkFailure")
+          ? withOllamaOriginHint(t("settings.ai.ollamaNetworkFailure"))
           : kind === "timeout"
             ? t("settings.ai.ollamaTimedOut")
             : t("settings.ai.modelsFailedToLoad", {

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -38,6 +38,7 @@ import {
   hasProviderKey,
   PROVIDER_MODELS,
   PROVIDER_LABELS,
+  resolveProviderConfig,
   type AssistantProfile,
   type AssistantProviderId,
 } from "../../lib/assistant/provider";
@@ -393,7 +394,8 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
       // run's cancellation as a failure.
       if (cancelledGenerationRef.current !== myGeneration) {
         const message =
-          activeProfile?.provider === "ollama" && isOllamaNetworkFailure(error)
+          (activeProfile?.provider ?? resolveProviderConfig()?.provider) === "ollama" &&
+          isOllamaNetworkFailure(error)
             ? withOllamaOriginHint(t("settings.ai.ollamaNetworkFailure"))
             : error instanceof Error
               ? error.message

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -26,6 +26,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { AssistantSession } from "../../lib/assistant/agent";
 import { renderAssistantMarkdown } from "../../lib/assistant/markdown";
+import { isOllamaNetworkFailure, withOllamaOriginHint } from "../../lib/assistant/ollama";
 import { selectActiveAssistantProfile } from "../../lib/assistant/profiles";
 import { isSendKey } from "../../lib/assistant/send-key";
 import { openSettingsSection } from "../layout/SettingsDialog";
@@ -391,7 +392,12 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
       // Compare against myGeneration so a newer send can't unmask this older
       // run's cancellation as a failure.
       if (cancelledGenerationRef.current !== myGeneration) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message =
+          activeProfile?.provider === "ollama" && isOllamaNetworkFailure(error)
+            ? withOllamaOriginHint(t("settings.ai.ollamaNetworkFailure"))
+            : error instanceof Error
+              ? error.message
+              : String(error);
         const errorId = (turnIdRef.current += 1);
         setTurns((prev) => [...prev, { id: errorId, role: "error", text: message }]);
       }

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -38,10 +38,10 @@ export function isOllamaNetworkFailure(error: unknown): boolean {
   return false;
 }
 
-/** Append the exact browser origin Ollama must allow after a CORS failure. */
+/** Append the exact origin as a language-neutral example for OLLAMA_ORIGINS. */
 export function withOllamaOriginHint(message: string, origin?: string): string {
   const allowedOrigin = origin ?? globalThis.location?.origin;
-  return allowedOrigin ? `${message} CORS: OLLAMA_ORIGINS=${allowedOrigin}` : message;
+  return allowedOrigin ? `${message} (OLLAMA_ORIGINS=${allowedOrigin})` : message;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -1,3 +1,5 @@
+import { classifyFetchFailure } from "../fetch-error";
+
 interface OllamaTagsResponse {
   models?: unknown;
 }
@@ -16,6 +18,31 @@ const DISCOVERY_TIMEOUT_MS = 10_000;
  * on the default install where discovery would have worked untouched.
  */
 export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+
+/**
+ * Whether an Ollama/OpenAI client error ultimately came from the browser's
+ * network layer. The OpenAI SDK wraps `fetch` failures in an API connection
+ * error, so inspect the `cause` chain instead of classifying only the wrapper.
+ */
+export function isOllamaNetworkFailure(error: unknown): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current != null && !seen.has(current)) {
+    seen.add(current);
+    if (classifyFetchFailure(current).kind === "network") return true;
+    current =
+      typeof current === "object" && "cause" in current
+        ? (current as { cause?: unknown }).cause
+        : null;
+  }
+  return false;
+}
+
+/** Append the exact browser origin Ollama must allow after a CORS failure. */
+export function withOllamaOriginHint(message: string, origin?: string): string {
+  const allowedOrigin = origin ?? globalThis.location?.origin;
+  return allowedOrigin ? `${message} OLLAMA_ORIGINS=${allowedOrigin}` : message;
+}
 
 /**
  * Fetch the model ids installed in an Ollama server. `signal`, when given, is

--- a/apps/geolibre-desktop/src/lib/assistant/ollama.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/ollama.ts
@@ -41,7 +41,7 @@ export function isOllamaNetworkFailure(error: unknown): boolean {
 /** Append the exact browser origin Ollama must allow after a CORS failure. */
 export function withOllamaOriginHint(message: string, origin?: string): string {
   const allowedOrigin = origin ?? globalThis.location?.origin;
-  return allowedOrigin ? `${message} OLLAMA_ORIGINS=${allowedOrigin}` : message;
+  return allowedOrigin ? `${message} CORS: OLLAMA_ORIGINS=${allowedOrigin}` : message;
 }
 
 /**

--- a/docs/user-guide/ai-assistant.md
+++ b/docs/user-guide/ai-assistant.md
@@ -46,6 +46,77 @@ Hosted keys (and AWS credentials) are used **directly from your browser** to cal
 the provider; they are never sent to GeoLibre's servers. Saving the setting
 enables the panel immediately — no reload needed.
 
+### Using local Ollama from web.geolibre.app
+
+The hosted web app connects directly from your browser to Ollama on your
+computer. Prompts and responses do not pass through a GeoLibre server. Because
+the page origin is `https://web.geolibre.app`, Ollama must explicitly allow that
+origin before the browser can call its API.
+
+Set this environment variable for the Ollama server, then restart Ollama:
+
+```text
+OLLAMA_ORIGINS=https://web.geolibre.app
+```
+
+Then open **Settings → AI Providers**, add or edit an **Ollama** profile, and
+use this Base URL:
+
+```text
+http://localhost:11434
+```
+
+Configure `OLLAMA_ORIGINS` for your operating system:
+
+=== "Linux (systemd)"
+
+    Run `sudo systemctl edit ollama.service` and add:
+
+    ```ini
+    [Service]
+    Environment="OLLAMA_ORIGINS=https://web.geolibre.app"
+    ```
+
+    Save the file, then reload and restart the service:
+
+    ```bash
+    sudo systemctl daemon-reload
+    sudo systemctl restart ollama
+    ```
+
+=== "macOS"
+
+    Set the variable for the Ollama application, then quit and reopen Ollama:
+
+    ```bash
+    launchctl setenv OLLAMA_ORIGINS "https://web.geolibre.app"
+    ```
+
+=== "Windows"
+
+    1. Quit Ollama from the taskbar.
+    2. Open **Edit environment variables for your account**.
+    3. Create a user variable named `OLLAMA_ORIGINS` with the value
+       `https://web.geolibre.app`.
+    4. Start Ollama again from the Start menu.
+
+=== "Docker"
+
+    Pass the allowed origin when starting the container:
+
+    ```bash
+    docker run -d \
+      -e OLLAMA_ORIGINS=https://web.geolibre.app \
+      -p 11434:11434 \
+      ollama/ollama
+    ```
+
+For a self-hosted GeoLibre URL, replace `https://web.geolibre.app` with the
+exact origin shown in GeoLibre's error message, including its scheme and port,
+for example `http://192.168.1.98:4000`. This is an Ollama server permission and
+cannot be enabled automatically by a web page. See Ollama's
+[official server configuration and web-origin instructions](https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama).
+
 ### Managed AI in a password-protected Docker deployment
 
 A deployment operator can provide AI without distributing provider API keys.

--- a/tests/assistant-ollama.test.ts
+++ b/tests/assistant-ollama.test.ts
@@ -1,6 +1,27 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { discoverOllamaModels } from "../apps/geolibre-desktop/src/lib/assistant/ollama";
+import {
+  discoverOllamaModels,
+  isOllamaNetworkFailure,
+  withOllamaOriginHint,
+} from "../apps/geolibre-desktop/src/lib/assistant/ollama";
+
+describe("Ollama network errors", () => {
+  it("recognizes a browser fetch failure wrapped by the OpenAI client", () => {
+    const fetchError = new TypeError("Failed to fetch");
+    const sdkError = new Error("Connection error", { cause: fetchError });
+
+    assert.equal(isOllamaNetworkFailure(sdkError), true);
+    assert.equal(isOllamaNetworkFailure(new Error("Ollama returned HTTP 500")), false);
+  });
+
+  it("shows the exact origin to add to OLLAMA_ORIGINS", () => {
+    assert.equal(
+      withOllamaOriginHint("Could not reach Ollama.", "http://192.168.1.98:4000"),
+      "Could not reach Ollama. OLLAMA_ORIGINS=http://192.168.1.98:4000",
+    );
+  });
+});
 
 describe("discoverOllamaModels", () => {
   it("normalizes hosts and parses unique model names", async () => {

--- a/tests/assistant-ollama.test.ts
+++ b/tests/assistant-ollama.test.ts
@@ -18,7 +18,7 @@ describe("Ollama network errors", () => {
   it("shows the exact origin to add to OLLAMA_ORIGINS", () => {
     assert.equal(
       withOllamaOriginHint("Could not reach Ollama.", "http://192.168.1.98:4000"),
-      "Could not reach Ollama. OLLAMA_ORIGINS=http://192.168.1.98:4000",
+      "Could not reach Ollama. CORS: OLLAMA_ORIGINS=http://192.168.1.98:4000",
     );
   });
 });

--- a/tests/assistant-ollama.test.ts
+++ b/tests/assistant-ollama.test.ts
@@ -18,7 +18,7 @@ describe("Ollama network errors", () => {
   it("shows the exact origin to add to OLLAMA_ORIGINS", () => {
     assert.equal(
       withOllamaOriginHint("Could not reach Ollama.", "http://192.168.1.98:4000"),
-      "Could not reach Ollama. CORS: OLLAMA_ORIGINS=http://192.168.1.98:4000",
+      "Could not reach Ollama. (OLLAMA_ORIGINS=http://192.168.1.98:4000)",
     );
   });
 });


### PR DESCRIPTION
## Summary

- unwrap OpenAI client connection errors to identify Ollama browser network failures
- show the exact GeoLibre origin that must be added to `OLLAMA_ORIGINS` for both model refresh and chat
- document local Ollama setup for web.geolibre.app on Linux, macOS, Windows, and Docker
- cover wrapped fetch errors and origin-specific guidance with focused tests

## Verification

- reproduced Ollama returning HTTP 403 for a LAN GeoLibre origin while accepting loopback
- verified model refresh and chat error guidance at `http://10.129.15.212:5173` in light and dark themes
- ran the focused Ollama tests, TypeScript checks, production build, and all pre-commit hooks
- validated the documentation through repository hooks; the PR preview workflow performs the Material for MkDocs build

Addresses https://github.com/opengeos/GeoLibre/discussions/2117#discussioncomment-18172943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama connection error messages with clearer network and browser-origin guidance.
  * Preserved existing handling for timeouts, HTTP errors, and other provider failures.

* **Documentation**
  * Added setup instructions for using local Ollama with the hosted web app.
  * Included configuration guidance for Linux, macOS, Windows, Docker, and self-hosted deployments.

* **Tests**
  * Expanded coverage for wrapped network failures, HTTP errors, and origin-hint formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->