### PR TITLE
fix(build): keep build-machine credentials out of redistributable builds

### DIFF
--- a/apps/geolibre-desktop/src/lib/auth-gate.ts
+++ b/apps/geolibre-desktop/src/lib/auth-gate.ts
@@ -1,3 +1,4 @@
+import { getBuildEnvironment } from "@geolibre/core";
 import { AUTH0_CLIENT_ID_ENV, AUTH0_DOMAIN_ENV, resolveAuth0Config } from "./auth0-auth";
 import {
   CLERK_PUBLISHABLE_KEY_ENV,
@@ -27,7 +28,7 @@ export type AuthGateConfig =
  *   the build target alone: a runtime signal the visitor controls (`?embed=1`)
  *   would let anyone switch a configured gate off.
  * @param deploymentEnv - Runtime env; defaults to the value on `window`.
- * @param buildEnv - Build-time env; defaults to `import.meta.env`.
+ * @param buildEnv - Build-time env; defaults to the allowlisted build env.
  * @returns The provider and its settings, or undefined when no gate is configured.
  */
 export function resolveAuthGate(
@@ -37,7 +38,7 @@ export function resolveAuthGate(
 ): AuthGateConfig | undefined {
   if (!webApp) return undefined;
   const deployment = deploymentEnv ?? readDeploymentEnv();
-  const build = buildEnv ?? (import.meta.env as EnvRecord);
+  const build = buildEnv ?? (getBuildEnvironment() as EnvRecord);
 
   const clerkKey = resolveClerkPublishableKey(true, deployment, build);
   const auth0 = resolveAuth0Config(true, deployment, build);

--- a/apps/geolibre-desktop/src/lib/deployment-env.ts
+++ b/apps/geolibre-desktop/src/lib/deployment-env.ts
@@ -19,6 +19,8 @@
 // and `readEmbedOrigins` established that order; this module is the shared
 // implementation for the settings that are a single URL.
 
+import { getBuildEnvironment } from "@geolibre/core";
+
 /** A `VITE_*`-keyed env record, from either the build or the deployment. */
 export type EnvRecord = Record<string, string | undefined> | undefined;
 
@@ -34,13 +36,13 @@ export function readDeploymentEnv(): EnvRecord {
  *
  * @param key - The variable name, e.g. `VITE_GEOLIBRE_SHARE_URL`.
  * @param deploymentEnv - Runtime env; defaults to the value on `window`.
- * @param buildEnv - Build-time env; defaults to `import.meta.env`.
+ * @param buildEnv - Build-time env; defaults to the allowlisted build env.
  * @returns The first non-blank value found, or undefined when neither sets it.
  */
 export function readDeploymentEnvValue(
   key: string,
   deploymentEnv: EnvRecord = readDeploymentEnv(),
-  buildEnv: EnvRecord = import.meta.env as EnvRecord,
+  buildEnv: EnvRecord = getBuildEnvironment() as EnvRecord,
 ): string | undefined {
   for (const source of [deploymentEnv, buildEnv]) {
     const value = source?.[key];

--- a/apps/geolibre-desktop/src/lib/embed-api.ts
+++ b/apps/geolibre-desktop/src/lib/embed-api.ts
@@ -13,7 +13,12 @@
 // origins it trusts, and every message is checked against that list.
 
 import type { Feature, Geometry } from "geojson";
-import { LAYER_TYPES, hasRestorableLayerSource, validateMapExpression } from "@geolibre/core";
+import {
+  LAYER_TYPES,
+  getBuildEnvironment,
+  hasRestorableLayerSource,
+  validateMapExpression,
+} from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
 import { EMBED_API_SOURCE, EMBED_API_VERSION, type AddLayerSpec } from "@geolibre/embed";
 
@@ -75,7 +80,7 @@ export function parseEmbedOrigins(raw: unknown): string[] {
  * so an operator can set it with `-e GEOLIBRE_EMBED_ORIGINS=...` without
  * rebuilding) before the build-time Vite env.
  *
- * @param viteEnv - Build-time env; defaults to `import.meta.env`.
+ * @param viteEnv - Build-time env; defaults to the allowlisted build env.
  * @param deploymentEnv - Runtime env; defaults to the value the Docker image
  *   writes onto `window`.
  * @returns The allowed origins, empty when the API is not enabled.
@@ -89,7 +94,7 @@ export function readEmbedOrigins(viteEnv?: EnvRecord, deploymentEnv?: EnvRecord)
           .__GEOLIBRE_DEPLOYMENT_ENV__);
   const fromRuntime = parseEmbedOrigins(runtime?.[EMBED_ORIGINS_ENV]);
   if (fromRuntime.length > 0) return fromRuntime;
-  const build = viteEnv ?? (import.meta.env as EnvRecord);
+  const build = viteEnv ?? (getBuildEnvironment() as EnvRecord);
   return parseEmbedOrigins(build?.[EMBED_ORIGINS_ENV]);
 }
 

--- a/apps/geolibre-desktop/src/lib/html-export.ts
+++ b/apps/geolibre-desktop/src/lib/html-export.ts
@@ -1,7 +1,7 @@
 // Standalone "Export as interactive HTML" builder; the in-app counterpart of the
 // Python widget's `Map.to_html()`. See `docs/python.md` and `embedHost.ts`.
 
-import { redactCredentials, type GeoLibreProject } from "@geolibre/core";
+import { getBuildEnvironment, redactCredentials, type GeoLibreProject } from "@geolibre/core";
 import {
   encodeInlineProjectFragment,
   INLINE_PROJECT_FRAGMENT_KEY,
@@ -19,7 +19,7 @@ const CSS_DIMENSION_RE = /^[\w%.+\-/\s()]+$/;
 // Resolve the viewer URL from the env, accepting only HTTPS (or loopback HTTP)
 // and matching the hostname exactly; mirrors resolveShareBaseUrl.
 export function resolveViewerBaseUrl(
-  configured: unknown = import.meta.env?.VITE_GEOLIBRE_VIEWER_URL,
+  configured: unknown = getBuildEnvironment().VITE_GEOLIBRE_VIEWER_URL,
 ): string {
   if (typeof configured === "string" && configured.trim()) {
     const trimmed = configured.trim();

--- a/apps/geolibre-desktop/src/lib/language-pack.ts
+++ b/apps/geolibre-desktop/src/lib/language-pack.ts
@@ -6,6 +6,8 @@
  * every translation in every GeoLibre binary would dominate the UI catalogs.
  */
 
+import { getBuildEnvironment } from "@geolibre/core";
+
 export const LANGUAGE_PACK_FORMAT = "geolibre-language-pack";
 export const LANGUAGE_PACK_FORMAT_VERSION = 1;
 export const LANGUAGE_PACK_SCOPE = "whitebox";
@@ -192,10 +194,7 @@ export function parseLanguagePack(text: string): GeoLibreLanguagePack {
 }
 
 function configuredLanguagePackBaseUrl(): string {
-  const configured =
-    typeof import.meta.env === "undefined"
-      ? undefined
-      : (import.meta.env.VITE_LANGUAGE_PACK_BASE_URL as string | undefined);
+  const configured = getBuildEnvironment().VITE_LANGUAGE_PACK_BASE_URL;
   if (configured?.trim()) return configured.trim().replace(/\/+$/, "");
   const noExternalCdn = typeof __NO_EXTERNAL_CDN__ !== "undefined" ? __NO_EXTERNAL_CDN__ : false;
   return noExternalCdn ? "" : DEFAULT_LANGUAGE_PACK_BASE_URL;

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -166,6 +166,167 @@ const PGLITE_CDN = process.env.GEOLIBRE_PGLITE_CDN !== "0";
 const IS_EMBED = process.env.GEOLIBRE_EMBED === "1";
 const PWA_DISABLED = IS_TAURI_BUILD || IS_EMBED;
 
+// ---------------------------------------------------------------------------
+// Build-time env exposed to the bundle.
+//
+// A build must never embed a credential belonging to whoever ran it. Two things
+// make that easy to get wrong here:
+//
+//  1. The bare→prefixed bridges above copy `GOOGLE_MAPS_API_KEY`/`MAPBOX_TOKEN`/
+//     `CESIUM_TOKEN` out of the build machine's shell into their `VITE_` names.
+//     Convenient for local testing; it also makes a developer's own environment
+//     build input.
+//  2. Something in the graph reads `import.meta.env` as a WHOLE OBJECT. Vite
+//     cannot tell which keys such a read wants, so it gives up on per-key
+//     replacement and inlines the entire env record — every `VITE_` var set on
+//     the build machine — into every chunk that read reaches.
+//
+// The whole-object read is not ours to delete: `@clerk/shared`'s
+// getEnvVariable.mjs does `import.meta.env[name]` with a computed name, so the
+// inlined record lands in the `ClerkGate-*.js` chunk. The defence therefore
+// cannot be "stop reading the object" — it has to be "there is nothing
+// sensitive in the object to begin with".
+//
+// pruneBuildEnv() enforces that on `process.env`, BEFORE Vite reads it:
+//  1. A `VITE_` var not on BUILD_ENV_KEYS is deleted. An unrecognized var on the
+//     build machine cannot reach the bundle by accident; adding a new one means
+//     adding it here, deliberately.
+//  2. A CREDENTIAL_ENV_KEYS var is blanked in *redistributable* builds. The web
+//     deploy is our own site using our own referrer-restricted keys, so it keeps
+//     them; the Jupyter wheel (GEOLIBRE_EMBED=1) is installed by third parties
+//     and must never carry ours. Blanked rather than deleted so a value in a
+//     `.env` file cannot reintroduce it, and because "" is what every consumer
+//     already treats as unset.
+//
+// Each credential resolves through `getRuntimeEnvironment()`, which overlays
+// `window.__GEOLIBRE_RUNTIME_ENV__` from Settings → Environment variables, so a
+// wheel user supplies their own token at runtime and the affected surfaces
+// degrade as already documented (Mapbox prompts in the basemap API-keys view,
+// the 3D globe is not offered, Protomaps basemaps are hidden).
+//
+// The pruned result is also emitted as `__GEOLIBRE_BUILD_ENV__` for
+// runtime-env.ts, so our own code reads a named allowlist rather than taking a
+// whole-object dependency on `import.meta.env` the way Clerk does.
+//
+// scripts/scan-credentials.mjs verifies the OUTPUT of all this: a build run by
+// hand can satisfy every rule above and still be wrong, so the artifact is
+// checked rather than the configuration.
+// ---------------------------------------------------------------------------
+
+/** Every `VITE_` name the app reads. Anything absent here never reaches the bundle. */
+const BUILD_ENV_KEYS = [
+  "VITE_AMAZON_LOCATION_API_KEY",
+  "VITE_AMAZON_LOCATION_AWS_REGION",
+  "VITE_CESIUM_TOKEN",
+  "VITE_DUCKDB_SPATIAL_EXTENSION_PATH",
+  "VITE_GEE_OAUTH_CLIENT_ID",
+  "VITE_GEE_PROJECT_ID",
+  "VITE_GEOCODER_API_KEY",
+  "VITE_GEOCODER_EMAIL",
+  "VITE_GEOCODER_ENDPOINT",
+  "VITE_GEOCODER_PROVIDER",
+  "VITE_GEOCODER_REVERSE_ENDPOINT",
+  "VITE_GEOLIBRE_AI_MODEL",
+  "VITE_GEOLIBRE_AI_URL",
+  "VITE_GEOLIBRE_AUTH0_CLIENT_ID",
+  "VITE_GEOLIBRE_AUTH0_DOMAIN",
+  "VITE_GEOLIBRE_CLERK_PUBLISHABLE_KEY",
+  "VITE_GEOLIBRE_CLERK_WAITLIST",
+  "VITE_GEOLIBRE_COLLAB_URL",
+  "VITE_GEOLIBRE_EMBED_ORIGINS",
+  "VITE_GEOLIBRE_GA_MEASUREMENT_ID",
+  "VITE_GEOLIBRE_PLUGIN_REGISTRY_URL",
+  "VITE_GEOLIBRE_SHARE_URL",
+  "VITE_GEOLIBRE_VIEWER_URL",
+  "VITE_GOOGLE_MAPS_API_KEY",
+  "VITE_HERE_API_KEY",
+  "VITE_LANGUAGE_PACK_BASE_URL",
+  "VITE_MAPBOX_ACCESS_TOKEN",
+  "VITE_MAPILLARY_ACCESS_TOKEN",
+  "VITE_PROTOMAPS_API_KEY",
+  "VITE_PYODIDE_INDEX_URL",
+  "VITE_ROUTING_ENDPOINT",
+  "VITE_SIDECAR_URL",
+  "VITE_STADIA_API_KEY",
+  "VITE_TIANDITU_API_KEY",
+  "VITE_TOMTOM_API_KEY",
+  "VITE_WELCOME_DISABLED",
+] as const;
+
+// Vars that authenticate as, and bill to, whoever ran the build. Public-by-design
+// identifiers (the Clerk *publishable* key, the Auth0 client ID/domain, the GEE
+// OAuth client ID, the GA measurement ID) are deliberately NOT here: they are
+// meant to ship, and publish-python.yml already injects the GEE client ID.
+const CREDENTIAL_ENV_KEYS = new Set<string>([
+  "VITE_AMAZON_LOCATION_API_KEY",
+  "VITE_CESIUM_TOKEN",
+  "VITE_GEOCODER_API_KEY",
+  "VITE_GOOGLE_MAPS_API_KEY",
+  "VITE_HERE_API_KEY",
+  "VITE_MAPBOX_ACCESS_TOKEN",
+  "VITE_MAPILLARY_ACCESS_TOKEN",
+  "VITE_PROTOMAPS_API_KEY",
+  "VITE_STADIA_API_KEY",
+  "VITE_TIANDITU_API_KEY",
+  "VITE_TOMTOM_API_KEY",
+]);
+
+// A build whose output is installed by someone else must not carry our keys.
+// Today that is the Jupyter wheel; `GEOLIBRE_STRIP_CREDENTIALS=1` lets any other
+// redistributable target opt in without another code change.
+const IS_REDISTRIBUTABLE_BUILD = IS_EMBED || process.env.GEOLIBRE_STRIP_CREDENTIALS === "1";
+
+const ALLOWED_BUILD_ENV_KEYS = new Set<string>(BUILD_ENV_KEYS);
+
+/**
+ * Prunes `process.env` so Vite has nothing sensitive left to inline, then
+ * returns the surviving allowlisted values.
+ *
+ * Must run at module load, before Vite resolves the env for the bundle.
+ *
+ * @returns The allowlisted build-time env for `__GEOLIBRE_BUILD_ENV__`.
+ */
+function pruneBuildEnv(): Record<string, string> {
+  const unknown: string[] = [];
+  const withheld: string[] = [];
+
+  for (const key of Object.keys(process.env)) {
+    if (!key.startsWith("VITE_")) continue;
+    if (!ALLOWED_BUILD_ENV_KEYS.has(key)) {
+      delete process.env[key];
+      unknown.push(key);
+      continue;
+    }
+    if (IS_REDISTRIBUTABLE_BUILD && CREDENTIAL_ENV_KEYS.has(key) && process.env[key]) {
+      process.env[key] = "";
+      withheld.push(key);
+    }
+  }
+
+  if (unknown.length > 0) {
+    console.info(
+      `[vite] dropped ${unknown.length} unrecognized VITE_ var(s) from the build ` +
+        `(${unknown.join(", ")}). Add the name to BUILD_ENV_KEYS in vite.config.ts to expose it.`,
+    );
+  }
+  if (withheld.length > 0) {
+    console.info(
+      `[vite] redistributable build: withheld ${withheld.length} credential(s) from the ` +
+        `bundle (${withheld.join(", ")}). Users supply their own via ` +
+        "Settings \u2192 Environment variables.",
+    );
+  }
+
+  const record: Record<string, string> = {};
+  for (const key of BUILD_ENV_KEYS) {
+    const value = process.env[key];
+    if (value) record[key] = value;
+  }
+  return record;
+}
+
+const BUILD_ENV = pruneBuildEnv();
+
 // DuckDB-WASM from jsDelivr instead of the build output. Opt-IN, the reverse of
 // PGLITE_CDN above, because DuckDB is on the critical path for opening a local
 // vector file — making that need the network is a real behaviour change, so only
@@ -943,6 +1104,10 @@ export default defineConfig({
     __PGLITE_POSTGIS_CDN_URL__: JSON.stringify(PGLITE_POSTGIS_CDN_URL),
     __CEREUS_WASM_CDN_URL__: JSON.stringify(CEREUS_WASM_CDN_URL),
     __GDAL3_CDN_PATHS__: JSON.stringify(GDAL3_CDN_PATHS),
+    // The allowlisted build-time env (see BUILD_ENV_KEYS). runtime-env.ts reads
+    // this instead of `import.meta.env`, so a whole-object read can no longer
+    // drag every VITE_ var on the build machine into the bundle.
+    __GEOLIBRE_BUILD_ENV__: JSON.stringify(BUILD_ENV),
   },
   server: {
     port: 5173,

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -253,23 +253,23 @@ const BUILD_ENV_KEYS = [
   "VITE_WELCOME_DISABLED",
 ] as const;
 
-// Vars that authenticate as, and bill to, whoever ran the build. Public-by-design
-// identifiers (the Clerk *publishable* key, the Auth0 client ID/domain, the GEE
-// OAuth client ID, the GA measurement ID) are deliberately NOT here: they are
-// meant to ship, and publish-python.yml already injects the GEE client ID.
-const CREDENTIAL_ENV_KEYS = new Set<string>([
-  "VITE_AMAZON_LOCATION_API_KEY",
-  "VITE_CESIUM_TOKEN",
-  "VITE_GEOCODER_API_KEY",
-  "VITE_GOOGLE_MAPS_API_KEY",
-  "VITE_HERE_API_KEY",
-  "VITE_MAPBOX_ACCESS_TOKEN",
-  "VITE_MAPILLARY_ACCESS_TOKEN",
-  "VITE_PROTOMAPS_API_KEY",
-  "VITE_STADIA_API_KEY",
-  "VITE_TIANDITU_API_KEY",
-  "VITE_TOMTOM_API_KEY",
-]);
+// Vars that authenticate as, and bill to, whoever ran the build. Read from the
+// same file the output scanners use, so the name this config strips and the name
+// they look for can never drift apart -- a credential added to only one of two
+// hand-maintained lists is silently uncovered on that side.
+//
+// Public-by-design identifiers (the Clerk *publishable* key, the Auth0 client
+// ID/domain, the GEE OAuth client ID, the GA measurement ID) are deliberately
+// absent from that list: they are meant to ship, and publish-python.yml already
+// injects the GEE client ID.
+const CREDENTIAL_PATTERNS_FILE = path.resolve(CONFIG_DIR, "../../scripts/credential-patterns.json");
+const CREDENTIAL_ENV_KEYS = new Set<string>(
+  (
+    JSON.parse(readFileSync(CREDENTIAL_PATTERNS_FILE, "utf8")) as {
+      credentialEnvNames: string[];
+    }
+  ).credentialEnvNames,
+);
 
 // A build whose output is installed by someone else must not carry our keys.
 // Today that is the Jupyter wheel; `GEOLIBRE_STRIP_CREDENTIALS=1` lets any other
@@ -279,10 +279,18 @@ const IS_REDISTRIBUTABLE_BUILD = IS_EMBED || process.env.GEOLIBRE_STRIP_CREDENTI
 const ALLOWED_BUILD_ENV_KEYS = new Set<string>(BUILD_ENV_KEYS);
 
 /**
- * Prunes `process.env` so Vite has nothing sensitive left to inline, then
+ * Prunes the build env so Vite has nothing sensitive left to inline, then
  * returns the surviving allowlisted values.
  *
  * Must run at module load, before Vite resolves the env for the bundle.
+ *
+ * Covers `.env*` files as well as the shell. Vite resolves `import.meta.env` by
+ * reading the `.env*` files and then letting `process.env` win for any prefixed
+ * key it already holds -- including when that value is `""`. So deleting a key
+ * from `process.env` does NOT suppress a value the file supplies; only writing
+ * `""` over it does. Since `docs/getting-started.md` tells people to configure
+ * most of these keys in `apps/geolibre-desktop/.env.local` and never export
+ * them, a `process.env`-only sweep would miss the common case entirely.
  *
  * @returns The allowlisted build-time env for `__GEOLIBRE_BUILD_ENV__`.
  */
@@ -290,14 +298,26 @@ function pruneBuildEnv(): Record<string, string> {
   const unknown: string[] = [];
   const withheld: string[] = [];
 
-  for (const key of Object.keys(process.env)) {
-    if (!key.startsWith("VITE_")) continue;
+  const candidates = new Set(
+    [...Object.keys(process.env), ...Object.keys(FILE_ENV)].filter((key) =>
+      key.startsWith("VITE_"),
+    ),
+  );
+
+  for (const key of candidates) {
+    const fromFile = Boolean(FILE_ENV[key]);
     if (!ALLOWED_BUILD_ENV_KEYS.has(key)) {
       delete process.env[key];
+      // A deleted key still resolves from the file, so blank it instead.
+      if (fromFile) process.env[key] = "";
       unknown.push(key);
       continue;
     }
-    if (IS_REDISTRIBUTABLE_BUILD && CREDENTIAL_ENV_KEYS.has(key) && process.env[key]) {
+    if (
+      IS_REDISTRIBUTABLE_BUILD &&
+      CREDENTIAL_ENV_KEYS.has(key) &&
+      (process.env[key] || fromFile)
+    ) {
       process.env[key] = "";
       withheld.push(key);
     }
@@ -317,9 +337,12 @@ function pruneBuildEnv(): Record<string, string> {
     );
   }
 
+  // Mirror what Vite will resolve: a blanked key stays blank, everything else
+  // falls back to its file value so a `.env.local`-configured var still reaches
+  // getBuildEnvironment() and not just `import.meta.env`.
   const record: Record<string, string> = {};
   for (const key of BUILD_ENV_KEYS) {
-    const value = process.env[key];
+    const value = process.env[key] ?? FILE_ENV[key];
     if (value) record[key] = value;
   }
   return record;

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -306,6 +306,96 @@ So: any edit to that `pyproject.toml`'s dependencies must land with a refreshed
 lock (`uv lock --project backend/geolibre_server`). CI's "Check the bundled sidecar
 lockfile is in sync" step (`uv lock --check`) fails if they drift.
 
+## Credentials must never reach a redistributable build
+
+Anything we hand to someone else — the Jupyter wheel above all — must carry no
+credential of ours. Three properties of this build make that easy to get wrong,
+and every guard below blocks one of them.
+
+1. `apps/geolibre-desktop/vite.config.ts` bridges bare shell vars into their
+   `VITE_` names — `GOOGLE_MAPS_API_KEY` → `VITE_GOOGLE_MAPS_API_KEY`, and the
+   same for `MAPBOX_TOKEN` and `CESIUM_TOKEN`. Convenient for local testing;
+   it also means the build machine's shell is build input.
+2. Something in the graph reads `import.meta.env` as a **whole object**. Vite
+   cannot tell which keys such a read wants, so it stops replacing per key and
+   inlines the entire env record — every `VITE_` var on the build machine — into
+   every chunk that read reaches. Ours was `packages/core/src/runtime-env.ts`;
+   the one we cannot fix is `@clerk/shared`'s `getEnvVariable.mjs`, which does
+   `import.meta.env[name]` with a computed name, so the inlined record lands in
+   the `ClerkGate-*.js` chunk.
+3. `python/hatch_build.py` skips the JS build when `static/app` already exists
+   and `GEOLIBRE_FORCE_JS_BUILD` is unset. A local `python -m build` therefore
+   packages whatever an earlier `npm run build:embed` left staged, with no
+   JavaScript running at all.
+
+### The rules now
+
+- **`BUILD_ENV_KEYS`** in `vite.config.ts` is the allowlist of `VITE_` names that
+  may reach a bundle. `pruneBuildEnv()` deletes every other `VITE_` var from
+  `process.env` before Vite reads it. Adding a new build-time var means adding it
+  here — otherwise it silently resolves to undefined.
+- **`CREDENTIAL_ENV_KEYS`** is the subset that authenticates as, and bills to,
+  whoever ran the build. In a *redistributable* build these are blanked to `""`
+  (blanked, not deleted, so a `.env` file cannot reintroduce them). A build is
+  redistributable when `GEOLIBRE_EMBED=1` (the Jupyter wheel) or
+  `GEOLIBRE_STRIP_CREDENTIALS=1`.
+  The web deploy is **not** redistributable: it is our own site using our own
+  referrer-restricted keys, and it keeps them.
+- Public-by-design identifiers stay in every build: the Clerk *publishable* key,
+  the Auth0 client ID and domain, the GEE OAuth client ID, the GA measurement ID.
+  `publish-python.yml` deliberately injects the GEE client ID into the wheel.
+- Prefer `getBuildEnvironment()` from `@geolibre/core` over reading
+  `import.meta.env` yourself. A whole-object read re-opens cause (2) for every
+  chunk it reaches, and nothing in the type system will tell you.
+
+Each stripped credential resolves through `getRuntimeEnvironment()`, which
+overlays `window.__GEOLIBRE_RUNTIME_ENV__` from Settings → Environment variables.
+So a wheel user supplies their own token and the affected surfaces degrade as
+documented: Mapbox prompts in the basemap API-keys view, the 3D globe is not
+offered, Protomaps basemaps are hidden.
+
+### The scan
+
+`scripts/scan-credentials.mjs` verifies the **output**. A build run by hand can
+satisfy every rule above and still be wrong, and a third-party asset dropped into
+the tree can arrive with a key already inside it — neither is visible from the
+config. It runs in two places:
+
+- `scripts/build-embed.mjs`, before staging `dist-embed` into the Python package.
+- `python/hatch_build.py`, before packaging any wheel or sdist — including the
+  stale-assets path (3) above, which no JS-side guard can cover. This one needs
+  no Node.
+
+Both read `scripts/credential-patterns.json`, so the JS and Python scanners
+cannot drift; the file is force-included into the sdist so an sdist → wheel build
+is gated too. `tests/credential-scan.test.ts` covers it.
+
+To scan any built directory by hand:
+
+```bash
+node scripts/scan-credentials.mjs apps/geolibre-desktop/dist-embed
+```
+
+### When the scan fires after a dependency bump
+
+`allowedValueHashes` in `credential-patterns.json` holds the SHA-256 of values
+that match a pattern but are public by design — currently CesiumJS's built-in
+default Ion token, which ships inside `cesium` and appears in every build. A
+Cesium upgrade changes that token, so the guard will fire on the new one.
+
+That is intended. Decode the payload before doing anything: CesiumJS's has
+`sub: "CesiumJS"` and `iss: "https://api.cesium.com"`. Only once you have
+confirmed it is the vendor's own token, replace the hash. Never add a hash to
+silence a finding you have not decoded — the whole point of the list is that it
+is short and every entry was checked.
+
+Bundled plugin drop-ins under `apps/geolibre-desktop/public/plugins/<id>/` are
+scanned too. They are third-party build artifacts that are not committed here, so
+a hardcoded key inside one is fixed in that plugin's own repository, never by
+allowlisting it. Note that removing such a drop-in does not clean a `dist/` built
+while it was present: Vite copies `public/` into the output and only clears that
+output when a build actually runs. Rebuild, or delete the stale directory.
+
 ## Generated files and cross-file sync
 
 - **Processing tool metadata.** Names, descriptions, group labels, parameter

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,7 @@ export {
   type ReverseGeocodeDisplay,
 } from "./geocoding";
 export {
+  getBuildEnvironment,
   getCesiumIonToken,
   getGoogleMapsApiKey,
   getMapboxAccessToken,

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -1,16 +1,45 @@
 /**
  * Resolves runtime environment variables shared by the external-service clients
- * (geocoding, routing). Build-time Vite vars (`import.meta.env`) are overlaid
+ * (geocoding, routing). Allowlisted build-time vars (`__GEOLIBRE_BUILD_ENV__`,
+ * injected by `vite.config.ts`) are overlaid
  * with project-supplied runtime vars (`window.__GEOLIBRE_RUNTIME_ENV__`, set
  * from project preferences) so a self-hosted endpoint can be configured without
  * a rebuild. Carries no React/MapLibre dependency so callers stay unit-testable.
  */
 
-const buildEnv = (
-  import.meta as ImportMeta & {
-    env?: Record<string, string | undefined>;
-  }
-).env;
+// Injected by `vite.config.ts`'s `define` from an explicit allowlist
+// (BUILD_ENV_KEYS), with credential-bearing names withheld from redistributable
+// builds such as the Jupyter wheel.
+//
+// This deliberately does NOT read `import.meta.env`. That read is a whole-object
+// one — nothing here names a static key — so Vite could not replace it per-key
+// and instead inlined the entire env record into every chunk importing this
+// module. Combined with the bare-to-prefixed shell bridge in `vite.config.ts`,
+// every chunk importing this module would carry whatever the build machine had
+// set. Keep this indirection: reverting to `import.meta.env` silently restores
+// that behaviour, and no test would catch it.
+declare const __GEOLIBRE_BUILD_ENV__: Record<string, string> | undefined;
+
+const buildEnv: Record<string, string | undefined> =
+  typeof __GEOLIBRE_BUILD_ENV__ === "undefined" ? {} : __GEOLIBRE_BUILD_ENV__;
+
+/**
+ * The allowlisted build-time environment, with no runtime overlay.
+ *
+ * For settings that must be fixed by the build and NOT overridable by a
+ * `.geolibre.json` a user opened — the auth gate, the deployment profile, the
+ * embed origin allowlist. Routing those through {@link getRuntimeEnvironment}
+ * would let project-supplied `__GEOLIBRE_RUNTIME_ENV__` values relax them.
+ *
+ * Callers should prefer this over reading `import.meta.env` directly: a
+ * whole-object read defeats Vite's per-key replacement and inlines every
+ * `VITE_` var on the build machine into the chunk.
+ *
+ * @returns The build-time environment record.
+ */
+export function getBuildEnvironment(): Record<string, string | undefined> {
+  return buildEnv;
+}
 
 /**
  * Merges build-time env with project runtime env (the latter wins). Falls back
@@ -19,11 +48,11 @@ const buildEnv = (
  * @returns The resolved environment variables.
  */
 export function getRuntimeEnvironment(): Record<string, string | undefined> {
-  if (typeof window === "undefined") return buildEnv ?? {};
+  if (typeof window === "undefined") return buildEnv;
 
   // __GEOLIBRE_RUNTIME_ENV__ is declared globally in ./types.
   return {
-    ...(buildEnv ?? {}),
+    ...buildEnv,
     ...(window.__GEOLIBRE_RUNTIME_ENV__ ?? {}),
   };
 }

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -25,7 +25,13 @@ import re
 import subprocess
 from pathlib import Path
 
-from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+try:
+    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+except ModuleNotFoundError:  # pragma: no cover - always present during a build
+    # Only the build backend needs hatchling. Degrading here keeps the credential
+    # scanner below importable on its own, so python/tests can exercise it
+    # against the same fixtures as tests/credential-scan.test.ts.
+    BuildHookInterface = object  # type: ignore[assignment, misc]
 
 PACKAGE_ROOT = Path(__file__).parent
 STATIC_APP = PACKAGE_ROOT / "src" / "geolibre" / "static" / "app"
@@ -53,17 +59,28 @@ def _mask(value: str) -> str:
     return f"{value[:6]}...{value[-4:]} ({len(value)} chars)"
 
 
-def _load_patterns() -> dict | None:
+def _load_patterns() -> dict:
     """Loads the shared credential-pattern definitions.
 
     Returns:
-        The parsed definitions, or None when the file is absent (an
-        installed-package context where there is nothing to scan).
+        The parsed definitions.
+
+    Raises:
+        RuntimeError: If neither copy of the definitions can be found. This is
+            deliberately fatal: returning "no patterns" would make the scan pass
+            silently, which is indistinguishable in the build log from a genuine
+            clean scan and is the opposite of the fail-closed intent.
     """
     for candidate in (PATTERNS_FILE, VENDORED_PATTERNS_FILE):
         if candidate.is_file():
             return json.loads(candidate.read_text(encoding="utf-8"))
-    return None
+    raise RuntimeError(
+        "The credential-pattern definitions were not found at "
+        f"{PATTERNS_FILE} or {VENDORED_PATTERNS_FILE}, so the bundled app cannot "
+        "be checked before packaging. Build from a full checkout of the GeoLibre "
+        "monorepo, or restore the sdist's vendored copy (see "
+        "[tool.hatch.build.targets.sdist.force-include] in pyproject.toml)."
+    )
 
 
 def scan_for_credentials(directory: Path) -> list[str]:
@@ -79,8 +96,6 @@ def scan_for_credentials(directory: Path) -> list[str]:
         Sorted, unique, masked findings; empty when the directory is clean.
     """
     config = _load_patterns()
-    if config is None:
-        return []
 
     scannable = set(config["scannableExtensions"])
     allowed = set(config.get("allowedValueHashes", {}))

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -6,11 +6,22 @@ The Python package serves the built GeoLibre single-page app from
 materialized at build time. This hook runs the embed build when the assets are
 missing (or ``GEOLIBRE_FORCE_JS_BUILD=1`` is set) and the JavaScript sources are
 available next to the package (i.e. building from a checkout of the monorepo).
+
+It then scans the staged assets for credentials before packaging. That scan is
+the load-bearing one, because of the early-return path below: when the assets are
+already present and ``GEOLIBRE_FORCE_JS_BUILD`` is unset, a ``python -m build``
+packages whatever ``static/app`` an earlier local ``npm run build:embed`` left
+behind. No JavaScript runs at all on that path, so a guard living only in
+``scripts/build-embed.mjs`` would never fire. This one runs on every build, fresh
+or stale, and needs no Node.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -21,12 +32,129 @@ STATIC_APP = PACKAGE_ROOT / "src" / "geolibre" / "static" / "app"
 # The Python package lives at <repo>/python, so the monorepo root is one level up.
 REPO_ROOT = PACKAGE_ROOT.parent
 BUILD_SCRIPT = REPO_ROOT / "scripts" / "build-embed.mjs"
+# Shared with scripts/scan-credentials.mjs so the JS and Python scanners cannot
+# drift. Ships inside the sdist (see [tool.hatch.build.targets.sdist] force-include)
+# so an sdist -> wheel build is gated too.
+PATTERNS_FILE = REPO_ROOT / "scripts" / "credential-patterns.json"
+VENDORED_PATTERNS_FILE = PACKAGE_ROOT / "credential-patterns.json"
+
+
+def _mask(value: str) -> str:
+    """Masks a secret so build logs identify it without republishing it.
+
+    Args:
+        value: The matched secret.
+
+    Returns:
+        A redacted but recognizable form of the secret.
+    """
+    if len(value) <= 12:
+        return f"{value[:2]}***"
+    return f"{value[:6]}...{value[-4:]} ({len(value)} chars)"
+
+
+def _load_patterns() -> dict | None:
+    """Loads the shared credential-pattern definitions.
+
+    Returns:
+        The parsed definitions, or None when the file is absent (an
+        installed-package context where there is nothing to scan).
+    """
+    for candidate in (PATTERNS_FILE, VENDORED_PATTERNS_FILE):
+        if candidate.is_file():
+            return json.loads(candidate.read_text(encoding="utf-8"))
+    return None
+
+
+def scan_for_credentials(directory: Path) -> list[str]:
+    """Scans built assets for credentials that must not be redistributed.
+
+    Mirrors ``scanForCredentials`` in scripts/scan-credentials.mjs, reading the
+    same pattern definitions so the two cannot diverge.
+
+    Args:
+        directory: The staged asset directory to scan.
+
+    Returns:
+        Sorted, unique, masked findings; empty when the directory is clean.
+    """
+    config = _load_patterns()
+    if config is None:
+        return []
+
+    scannable = set(config["scannableExtensions"])
+    allowed = set(config.get("allowedValueHashes", {}))
+
+    def is_allowed(value: str) -> bool:
+        """Whether a match is a known public vendor token rather than ours."""
+        return hashlib.sha256(value.encode("utf-8")).hexdigest() in allowed
+
+    patterns = [(p["name"], re.compile(p["regex"])) for p in config["patterns"]]
+    # `VITE_FOO:"value"` / `VITE_FOO="value"` with a non-empty value. An empty
+    # string is what a correctly stripped build emits and must not trip this.
+    assigned = re.compile(
+        r"\b(" + "|".join(config["credentialEnvNames"]) + r")\b\s*[:=]\s*[\"'`]([^\"'`]+)[\"'`]"
+    )
+
+    findings: set[str] = set()
+    for path in sorted(directory.rglob("*")):
+        if not path.is_file() or path.suffix not in scannable:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        rel = path.relative_to(directory)
+        for name, pattern in patterns:
+            for match in pattern.finditer(text):
+                if is_allowed(match.group(0)):
+                    continue
+                findings.add(f"{rel}: {name} {_mask(match.group(0))}")
+        for match in assigned.finditer(text):
+            if is_allowed(match.group(2)):
+                continue
+            findings.add(f"{rel}: {match.group(1)} = {_mask(match.group(2))}")
+    return sorted(findings)
 
 
 class CustomBuildHook(BuildHookInterface):
     """Build the embedded web app before packaging the wheel/sdist."""
 
     def initialize(self, version: str, build_data: dict) -> None:
+        self._materialize_assets()
+        self._assert_no_credentials()
+
+    def _assert_no_credentials(self) -> None:
+        """Refuses to package assets carrying a redistributable credential.
+
+        Runs on every build, including the early-return path where the staged
+        assets came from an earlier local build and no JavaScript ran -- the path
+        a JS-side guard cannot cover.
+
+        Raises:
+            RuntimeError: If any credential is found in the staged assets.
+        """
+        if not STATIC_APP.is_dir():
+            return
+        findings = scan_for_credentials(STATIC_APP)
+        if not findings:
+            self.app.display_info("Credential scan clean.")
+            return
+        listed = "\n".join(f"  - {f}" for f in findings)
+        raise RuntimeError(
+            f"Refusing to package: {len(findings)} credential(s) found in {STATIC_APP}.\n"
+            f"{listed}\n\n"
+            "The wheel is redistributed, so it must not carry your keys. This is\n"
+            "usually a stale static/app from an earlier local `npm run build:embed`\n"
+            "that absorbed your shell's GOOGLE_MAPS_API_KEY / MAPBOX_TOKEN /\n"
+            "CESIUM_TOKEN exports. Rebuild with GEOLIBRE_FORCE_JS_BUILD=1, or\n"
+            "delete the directory and rerun. Wheel users supply their own tokens at\n"
+            "runtime via Settings -> Environment variables."
+        )
+
+    def _materialize_assets(self) -> None:
+        """Builds the embedded web app when the staged assets are missing or stale.
+
+        Raises:
+            RuntimeError: If the assets cannot be produced.
+        """
         force = os.environ.get("GEOLIBRE_FORCE_JS_BUILD") == "1"
         have_assets = (STATIC_APP / "index.html").is_file()
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -73,4 +73,6 @@ path = "hatch_build.py"
 path = "hatch_build.py"
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
+# "." puts hatch_build.py on the path so tests/test_credential_scan.py can import
+# the credential scanner the build hook uses.
+pythonpath = ["src", "."]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -59,6 +59,12 @@ artifacts = ["src/geolibre/static/**"]
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["src/geolibre/static/**"]
+# hatch_build.py scans the bundled app for credentials before packaging, using
+# the pattern definitions shared with scripts/scan-credentials.mjs. Those live
+# outside this directory, so vendor a copy into the sdist: an sdist -> wheel
+# build has no monorepo checkout and would otherwise skip the scan.
+[tool.hatch.build.targets.sdist.force-include]
+"../scripts/credential-patterns.json" = "credential-patterns.json"
 
 [tool.hatch.build.targets.wheel.hooks.custom]
 path = "hatch_build.py"

--- a/python/tests/test_credential_scan.py
+++ b/python/tests/test_credential_scan.py
@@ -1,0 +1,147 @@
+"""Tests for the credential scan that gates wheel and sdist packaging.
+
+The scanner in ``hatch_build`` is the only guard covering the path where staged
+assets already exist and no JavaScript runs, so it needs coverage of its own
+rather than relying on ``tests/credential-scan.test.ts`` exercising the JS twin.
+The last test pins the two implementations to the same results.
+
+Every fixture here is a synthetic value shaped like a real token -- never a live
+credential.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from hatch_build import PATTERNS_FILE, scan_for_credentials
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JS_SCANNER = REPO_ROOT / "scripts" / "scan-credentials.mjs"
+
+GOOGLE_KEY = "AIza" + "A" * 35
+GOOGLE_KEY_TRAILING_DASH = "AIza" + "A" * 34 + "-"
+
+
+def write(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Writes files into a directory and returns it.
+
+    Args:
+        tmp_path: Directory to populate.
+        files: Mapping of relative path to file contents.
+
+    Returns:
+        The populated directory.
+    """
+    for name, content in files.items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def test_clean_bundle_reports_nothing(tmp_path: Path) -> None:
+    """A bundle with no credentials produces no findings."""
+    assert scan_for_credentials(write(tmp_path, {"assets/app.js": "const a=1;"})) == []
+
+
+def test_catches_inlined_env_object(tmp_path: Path) -> None:
+    """The whole-object env shape Vite inlines is caught by name."""
+    bundle = (
+        f'{{PROD:!0,VITE_GOOGLE_MAPS_API_KEY:"{GOOGLE_KEY}",'
+        'VITE_PROTOMAPS_API_KEY:"52c129d45874742d"}}'
+    )
+    findings = scan_for_credentials(write(tmp_path, {"assets/ClerkGate-abc.js": bundle}))
+    assert any("VITE_GOOGLE_MAPS_API_KEY" in f for f in findings)
+    # A value matching no token shape must still be caught by its name.
+    assert any("VITE_PROTOMAPS_API_KEY" in f for f in findings)
+
+
+def test_catches_google_key_ending_in_dash(tmp_path: Path) -> None:
+    """A trailing `-` must not let a Google key slip past the anchor.
+
+    A `\\b` here would fail: `-` is not a word character, so no boundary exists
+    between it and a following quote.
+    """
+    findings = scan_for_credentials(write(tmp_path, {"a.js": f'k="{GOOGLE_KEY_TRAILING_DASH}"'}))
+    assert len(findings) == 1, findings
+
+
+def test_masks_values(tmp_path: Path) -> None:
+    """Findings identify a secret without reprinting it."""
+    findings = scan_for_credentials(write(tmp_path, {"a.js": f'k="{GOOGLE_KEY}"'}))
+    assert len(findings) == 1
+    assert GOOGLE_KEY not in findings[0]
+    assert "(39 chars)" in findings[0]
+
+
+def test_empty_value_does_not_fire(tmp_path: Path) -> None:
+    """`""` is what a correctly stripped build emits and must not trip."""
+    bundle = 'const e={VITE_CESIUM_TOKEN:"",VITE_MAPBOX_ACCESS_TOKEN:""}'
+    assert scan_for_credentials(write(tmp_path, {"a.js": bundle})) == []
+
+
+def test_ignores_non_scannable_files(tmp_path: Path) -> None:
+    """Binary asset types are skipped."""
+    assert scan_for_credentials(write(tmp_path, {"assets/x.wasm": GOOGLE_KEY})) == []
+
+
+def test_missing_patterns_file_fails_closed(tmp_path: Path, monkeypatch) -> None:
+    """A missing definitions file must raise, not report a clean scan."""
+    missing = tmp_path / "nope.json"
+    monkeypatch.setattr("hatch_build.PATTERNS_FILE", missing)
+    monkeypatch.setattr("hatch_build.VENDORED_PATTERNS_FILE", missing)
+    with pytest.raises(RuntimeError, match="credential-pattern definitions"):
+        scan_for_credentials(write(tmp_path, {"a.js": "const a=1;"}))
+
+
+def test_allowlisted_vendor_token_is_not_reported(tmp_path: Path) -> None:
+    """A hash-allowlisted vendor token must not fire.
+
+    Without this, CesiumJS's built-in Ion token would be reported on every
+    release and the guard would end up switched off.
+    """
+    config = json.loads(PATTERNS_FILE.read_text(encoding="utf-8"))
+    cesium = REPO_ROOT / "node_modules" / "cesium" / "Build" / "Cesium" / "Cesium.js"
+    if not config.get("allowedValueHashes") or not cesium.is_file():
+        pytest.skip("cesium not installed")
+    import re
+
+    match = re.search(r"\beyJhbGciOi[A-Za-z0-9._-]{30,}", cesium.read_text(errors="ignore"))
+    assert match, "expected CesiumJS to still ship a default Ion token"
+    assert scan_for_credentials(write(tmp_path, {"assets/c.js": f'var t="{match[0]}"'})) == []
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_matches_the_javascript_scanner(tmp_path: Path) -> None:
+    """Both scanners must report identically for the same input.
+
+    They read the same definitions file; this pins the two implementations of
+    those definitions together so a regex that behaves differently under Python
+    `re` and JavaScript `RegExp` cannot pass unnoticed.
+    """
+    bundle = (
+        f'{{VITE_GOOGLE_MAPS_API_KEY:"{GOOGLE_KEY}",'
+        f'VITE_CESIUM_TOKEN:"",VITE_STADIA_API_KEY:"stadia-abcdef0123456789"}}'
+        f'\nvar d="{GOOGLE_KEY_TRAILING_DASH}";'
+    )
+    target = write(tmp_path, {"assets/app.js": bundle, "assets/skip.wasm": GOOGLE_KEY})
+
+    python_findings = scan_for_credentials(target)
+    result = subprocess.run(
+        ["node", str(JS_SCANNER), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    js_findings = sorted(
+        line.strip()[2:] for line in result.stderr.splitlines() if line.startswith("  - ")
+    )
+
+    assert python_findings, "fixture should produce findings"
+    assert python_findings == js_findings, (
+        f"scanners disagree\npython: {python_findings}\njs:     {js_findings}"
+    )

--- a/scripts/build-embed.mjs
+++ b/scripts/build-embed.mjs
@@ -20,6 +20,8 @@ import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { REMEDIATION, scanForCredentials } from "./scan-credentials.mjs";
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const distDir = resolve(repoRoot, "apps/geolibre-desktop/dist-embed");
 const staticDir = resolve(repoRoot, "python/src/geolibre/static/app");
@@ -82,6 +84,20 @@ if (/\b(?:src|href)="\/(?!\/)/.test(indexHtml)) {
   );
   process.exit(1);
 }
+
+// The wheel is redistributed, so it must carry no credential of ours. Verify the
+// output rather than trusting the config, which a hand-run build can satisfy and
+// still be wrong. See scripts/scan-credentials.mjs.
+const credentialFindings = scanForCredentials(distDir);
+if (credentialFindings.length > 0) {
+  console.error(
+    `[build-embed] Refusing to stage: ${credentialFindings.length} credential(s) in the embed build.\n` +
+      credentialFindings.map((f) => `  - ${f}`).join("\n") +
+      `\n\n${REMEDIATION}`,
+  );
+  process.exit(1);
+}
+console.log("[build-embed] Credential scan clean.");
 
 rmSync(staticDir, { recursive: true, force: true });
 mkdirSync(staticDir, { recursive: true });

--- a/scripts/credential-patterns.json
+++ b/scripts/credential-patterns.json
@@ -8,12 +8,16 @@
     "",
     "Patterns are provider token SHAPES, not GeoLibre's specific values, so a",
     "rotated key trips the guard too. Keep them anchored enough not to fire on",
-    "content-hashed asset names or ordinary base64 blobs in the bundle."
+    "content-hashed asset names or ordinary base64 blobs in the bundle.",
+    "",
+    "Note the Google pattern ends with a lookahead, not `\\b`. Its charset includes",
+    "`-`, and `\\b` requires a word character on the left, so a key ending in `-`",
+    "would not match before a quote or end of input -- the scanner would miss it."
   ],
   "patterns": [
     {
       "name": "Google API key",
-      "regex": "\\bAIza[0-9A-Za-z_-]{35}\\b"
+      "regex": "\\bAIza[0-9A-Za-z_-]{35}(?=$|[^A-Za-z0-9_-])"
     },
     {
       "name": "Mapbox public token",
@@ -55,8 +59,11 @@
   "_credentialEnvNames_comment": [
     "Names that must never appear with a non-empty value attached, whatever the",
     "value looks like -- this catches a provider whose token shape none of the",
-    "patterns above match. Mirrors CREDENTIAL_ENV_KEYS in",
-    "apps/geolibre-desktop/vite.config.ts; keep the two lists in step.",
+    "patterns above match.",
+    "",
+    "This list is the single source of truth: apps/geolibre-desktop/vite.config.ts",
+    "reads it directly for CREDENTIAL_ENV_KEYS, so adding a name here strips it from",
+    "redistributable builds and scans for it in one step.",
     "",
     "Public-by-design identifiers (Clerk publishable key, Auth0 client ID and",
     "domain, the GEE OAuth client ID, the GA measurement ID) are deliberately",

--- a/scripts/credential-patterns.json
+++ b/scripts/credential-patterns.json
@@ -1,0 +1,93 @@
+{
+  "_comment": [
+    "Single source of truth for the pre-publish credential scan. Read by",
+    "scripts/scan-credentials.mjs (the JS build path) and python/hatch_build.py",
+    "(the wheel/sdist path, which may run without Node). Every regex here must",
+    "parse under BOTH JavaScript RegExp and Python re -- stick to the common",
+    "subset: \\b, character classes, (?:...), and bounded quantifiers.",
+    "",
+    "Patterns are provider token SHAPES, not GeoLibre's specific values, so a",
+    "rotated key trips the guard too. Keep them anchored enough not to fire on",
+    "content-hashed asset names or ordinary base64 blobs in the bundle."
+  ],
+  "patterns": [
+    {
+      "name": "Google API key",
+      "regex": "\\bAIza[0-9A-Za-z_-]{35}\\b"
+    },
+    {
+      "name": "Mapbox public token",
+      "regex": "\\bpk\\.eyJ1Ijoi[A-Za-z0-9._-]{20,}"
+    },
+    {
+      "name": "Mapbox secret token",
+      "regex": "\\bsk\\.eyJ1Ijoi[A-Za-z0-9._-]{20,}"
+    },
+    {
+      "name": "JWT (e.g. Cesium Ion)",
+      "regex": "\\beyJhbGciOi[A-Za-z0-9._-]{30,}"
+    },
+    {
+      "name": "Clerk/Stripe secret key",
+      "regex": "\\bsk_(?:live|test)_[A-Za-z0-9]{16,}"
+    },
+    {
+      "name": "AWS access key id",
+      "regex": "\\b(?:AKIA|ASIA)[0-9A-Z]{16}\\b"
+    },
+    {
+      "name": "GitHub token",
+      "regex": "\\bgh[pousr]_[A-Za-z0-9]{36,}\\b"
+    },
+    {
+      "name": "Slack token",
+      "regex": "\\bxox[abprs]-[A-Za-z0-9-]{10,}"
+    },
+    {
+      "name": "OpenAI key",
+      "regex": "\\bsk-(?:proj-)?[A-Za-z0-9_-]{32,}"
+    },
+    {
+      "name": "Anthropic key",
+      "regex": "\\bsk-ant-[A-Za-z0-9_-]{32,}"
+    }
+  ],
+  "_credentialEnvNames_comment": [
+    "Names that must never appear with a non-empty value attached, whatever the",
+    "value looks like -- this catches a provider whose token shape none of the",
+    "patterns above match. Mirrors CREDENTIAL_ENV_KEYS in",
+    "apps/geolibre-desktop/vite.config.ts; keep the two lists in step.",
+    "",
+    "Public-by-design identifiers (Clerk publishable key, Auth0 client ID and",
+    "domain, the GEE OAuth client ID, the GA measurement ID) are deliberately",
+    "absent: they are meant to ship in a redistributable build."
+  ],
+  "credentialEnvNames": [
+    "VITE_AMAZON_LOCATION_API_KEY",
+    "VITE_CESIUM_TOKEN",
+    "VITE_GEOCODER_API_KEY",
+    "VITE_GOOGLE_MAPS_API_KEY",
+    "VITE_HERE_API_KEY",
+    "VITE_MAPBOX_ACCESS_TOKEN",
+    "VITE_MAPILLARY_ACCESS_TOKEN",
+    "VITE_PROTOMAPS_API_KEY",
+    "VITE_STADIA_API_KEY",
+    "VITE_TIANDITU_API_KEY",
+    "VITE_TOMTOM_API_KEY"
+  ],
+  "_allowedValueHashes_comment": [
+    "SHA-256 of values that match a pattern above but are public by design --",
+    "a token the upstream library itself ships. Matched on the exact value, so a",
+    "real credential in the same file is still caught.",
+    "",
+    "A vendor bump changes the value and therefore the hash, so the guard will",
+    "fire after upgrading. That is intended: decode the payload and confirm it is",
+    "still the vendor's own token (CesiumJS's has sub=CesiumJS,",
+    "iss=https://api.cesium.com) before replacing the hash here.",
+    "See docs/maintenance.md."
+  ],
+  "allowedValueHashes": {
+    "971295cb8d5764d2f72444c9c7b6bb0bb5e609a41a393a11cc07299a94f56801": "CesiumJS built-in default Ion access token (sub=CesiumJS, aud='1.144 Release')"
+  },
+  "scannableExtensions": [".js", ".mjs", ".cjs", ".css", ".html", ".json", ".map", ".txt"]
+}

--- a/scripts/scan-credentials.mjs
+++ b/scripts/scan-credentials.mjs
@@ -1,0 +1,130 @@
+// Scan a built asset directory for credentials that must not be redistributed.
+//
+// Why this exists: an artifact we redistribute must carry no credential of
+// ours. `vite.config.ts` enforces that on the way in (BUILD_ENV_KEYS /
+// CREDENTIAL_ENV_KEYS), but two things can defeat a config-level rule -- a build
+// run by hand with an unexpected environment, and a third-party asset dropped
+// into the tree with a key already inside it. Neither is visible from the
+// config, so check the OUTPUT instead.
+//
+// Patterns live in scripts/credential-patterns.json because python/hatch_build.py
+// runs the same scan without Node -- see that file before editing either reader.
+//
+// Usage:
+//   node scripts/scan-credentials.mjs <dir>      # exits 1 on any finding
+//   import { scanForCredentials } from "./scan-credentials.mjs"
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const config = JSON.parse(readFileSync(resolve(scriptDir, "credential-patterns.json"), "utf8"));
+
+const SCANNABLE = new Set(config.scannableExtensions);
+const ALLOWED_VALUE_HASHES = new Set(Object.keys(config.allowedValueHashes ?? {}));
+
+/**
+ * Whether a matched value is a known public vendor token rather than ours.
+ *
+ * @param {string} value - The matched value.
+ * @returns {boolean} True when the value is allowlisted.
+ */
+function isAllowed(value) {
+  return ALLOWED_VALUE_HASHES.has(createHash("sha256").update(value).digest("hex"));
+}
+
+// `VITE_FOO:"value"` or `VITE_FOO="value"` with a non-empty value. Vite emits
+// the former inside an inlined env object literal -- the exact shape that
+// a whole-object read is inlined. An empty string is what a correctly stripped
+// build produces, so it must not trip this.
+const assignedNameRe = new RegExp(
+  `\\b(${config.credentialEnvNames.join("|")})\\b\\s*[:=]\\s*["'\`]([^"'\`]+)["'\`]`,
+  "g",
+);
+
+/**
+ * Masks a secret so CI logs can point at it without republishing it.
+ *
+ * @param {string} value - The matched secret.
+ * @returns {string} A redacted, identifiable form.
+ */
+function mask(value) {
+  if (value.length <= 12) return `${value.slice(0, 2)}***`;
+  return `${value.slice(0, 6)}...${value.slice(-4)} (${value.length} chars)`;
+}
+
+/**
+ * Recursively lists every file under a directory.
+ *
+ * @param {string} dir - Directory to walk.
+ * @returns {string[]} Absolute paths of every file found.
+ */
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Scans a directory of built assets for redistributable credentials.
+ *
+ * @param {string} dir - The built asset directory (e.g. dist-embed).
+ * @returns {string[]} Sorted, unique findings; empty when the build is clean.
+ */
+export function scanForCredentials(dir) {
+  const findings = [];
+  for (const file of walk(dir)) {
+    if (!SCANNABLE.has(extname(file))) continue;
+    const text = readFileSync(file, "utf8");
+    const rel = file.slice(dir.length + 1);
+    for (const { name, regex } of config.patterns) {
+      for (const m of text.matchAll(new RegExp(regex, "g"))) {
+        if (isAllowed(m[0])) continue;
+        findings.push(`${rel}: ${name} ${mask(m[0])}`);
+      }
+    }
+    for (const m of text.matchAll(assignedNameRe)) {
+      if (isAllowed(m[2])) continue;
+      findings.push(`${rel}: ${m[1]} = ${mask(m[2])}`);
+    }
+  }
+  return [...new Set(findings)].sort();
+}
+
+/** Guidance printed alongside any finding, shared with hatch_build.py. */
+export const REMEDIATION =
+  "This artifact is redistributed, so it must not carry your keys.\n" +
+  "Most likely your shell exports GOOGLE_MAPS_API_KEY / MAPBOX_TOKEN / CESIUM_TOKEN\n" +
+  "(vite.config.ts bridges bare names into their VITE_ forms) and the credential\n" +
+  "strip did not apply. Check that GEOLIBRE_EMBED=1 reached the build, and see\n" +
+  "CREDENTIAL_ENV_KEYS in apps/geolibre-desktop/vite.config.ts. Wheel users supply\n" +
+  "their own tokens at runtime via Settings → Environment variables.\n\n" +
+  "If this appeared right after a dependency bump, decode the value first: an\n" +
+  "upstream library may ship its own public token (CesiumJS does). Confirm the\n" +
+  "payload names the vendor, then update allowedValueHashes in\n" +
+  "scripts/credential-patterns.json -- see docs/maintenance.md.";
+
+// CLI entry point.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const target = process.argv[2];
+  if (!target) {
+    console.error("usage: node scripts/scan-credentials.mjs <dir>");
+    process.exit(2);
+  }
+  const findings = scanForCredentials(resolve(target));
+  if (findings.length > 0) {
+    console.error(
+      `[scan-credentials] ${findings.length} credential(s) found in ${target}:\n` +
+        findings.map((f) => `  - ${f}`).join("\n") +
+        `\n\n${REMEDIATION}`,
+    );
+    process.exit(1);
+  }
+  console.log(`[scan-credentials] Clean (${config.patterns.length} patterns) in ${target}`);
+}

--- a/tests/credential-scan.test.ts
+++ b/tests/credential-scan.test.ts
@@ -46,6 +46,17 @@ describe("credential scan", () => {
     );
   });
 
+  it("catches a Google key ending in a dash", () => {
+    // `\b` would fail here: `-` is not a word character, so no boundary exists
+    // between it and the closing quote. The pattern uses a lookahead instead.
+    const key = "AIza" + "A".repeat(34) + "-";
+    assert.equal(scan({ "a.js": `k="${key}"` }).length, 1);
+  });
+
+  it("does not match a run longer than a Google key", () => {
+    assert.deepEqual(scan({ "a.js": `k="AIza${"A".repeat(40)}"` }), []);
+  });
+
   it("masks matched values so build logs never republish them", () => {
     const secret = "AIza" + "C".repeat(35);
     const findings = scan({ "a.js": `k="${secret}"` });

--- a/tests/credential-scan.test.ts
+++ b/tests/credential-scan.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { scanForCredentials } from "../scripts/scan-credentials.mjs";
+
+// The guard that keeps a redistributed artifact from carrying a credential of
+// ours. These tests use synthetic values shaped like the real thing -- never a
+// live credential.
+
+/** Writes files into a throwaway directory and scans it. */
+function scan(files: Record<string, string>): string[] {
+  const dir = mkdtempSync(join(tmpdir(), "geolibre-credscan-"));
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      const full = join(dir, name);
+      mkdirSync(join(full, ".."), { recursive: true });
+      writeFileSync(full, content);
+    }
+    return scanForCredentials(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("credential scan", () => {
+  it("passes a bundle with no credentials", () => {
+    assert.deepEqual(scan({ "assets/app.js": "const a=1;export{a};" }), []);
+  });
+
+  it("catches an inlined env object carrying credentials", () => {
+    // The exact shape Vite emits for a whole-object `import.meta.env` read.
+    const bundle =
+      '{BASE_URL:"./",PROD:!0,VITE_GOOGLE_MAPS_API_KEY:"AIza' +
+      "B".repeat(35) +
+      '",VITE_PROTOMAPS_API_KEY:"52c129d45874742d"}';
+    const findings = scan({ "assets/ClerkGate-abc.js": bundle });
+    assert.ok(
+      findings.some((f) => f.includes("VITE_GOOGLE_MAPS_API_KEY")),
+      `expected a Google key finding, got ${JSON.stringify(findings)}`,
+    );
+    assert.ok(
+      findings.some((f) => f.includes("VITE_PROTOMAPS_API_KEY")),
+      "a key whose value matches no token shape must still be caught by name",
+    );
+  });
+
+  it("masks matched values so build logs never republish them", () => {
+    const secret = "AIza" + "C".repeat(35);
+    const findings = scan({ "a.js": `k="${secret}"` });
+    assert.equal(findings.length, 1);
+    assert.ok(!findings[0].includes(secret), "the full secret must not appear");
+    assert.ok(findings[0].includes("(39 chars)"), "the mask should report length");
+  });
+
+  it("does not fire on an empty value, which is what a stripped build emits", () => {
+    assert.deepEqual(
+      scan({ "a.js": 'const e={VITE_CESIUM_TOKEN:"",VITE_MAPBOX_ACCESS_TOKEN:""}' }),
+      [],
+    );
+  });
+
+  it("ignores non-scannable files such as content-hashed wasm", () => {
+    assert.deepEqual(scan({ "assets/x.wasm": "AIza" + "D".repeat(35) }), []);
+  });
+
+  it("allowlists CesiumJS's own public token, which ships in every build", () => {
+    // CesiumJS hardcodes a default Ion token in its bundle. It matches the JWT
+    // pattern and is present in every build, so without the allowlist the guard
+    // would fire on every release and get disabled -- which is how guards die.
+    // Read the real value from the installed package rather than pasting it, so
+    // a Cesium upgrade surfaces here (the hash in credential-patterns.json must
+    // then be refreshed; see docs/maintenance.md).
+    const cesiumBundle = "../node_modules/cesium/Build/Cesium/Cesium.js";
+    const path = new URL(cesiumBundle, import.meta.url).pathname;
+    if (!existsSync(path)) return; // cesium not installed; nothing to assert
+    const match = readFileSync(path, "utf8").match(/\beyJhbGciOi[A-Za-z0-9._-]{30,}/);
+    assert.ok(match, "expected CesiumJS to still ship a default Ion token");
+    assert.deepEqual(
+      scan({ "assets/cesium-abc.js": `var JW="${match[0]}"` }),
+      [],
+      "CesiumJS's own default token must not be reported",
+    );
+  });
+
+  it("still reports a JWT that is not the allowlisted vendor one", () => {
+    const header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+    const forged = `${header}.${"E".repeat(80)}.${"F".repeat(43)}`;
+    const findings = scan({ "assets/cesium-abc.js": `var t="${forged}"` });
+    assert.equal(findings.length, 1, `expected one finding, got ${JSON.stringify(findings)}`);
+    assert.ok(findings[0].includes("JWT"));
+  });
+});


### PR DESCRIPTION
An artifact we hand to someone else — the Jupyter wheel above all — must carry no credential of ours. Three properties of this build made that easy to get wrong:

1. `vite.config.ts` bridges bare shell vars into their `VITE_` names (`GOOGLE_MAPS_API_KEY`, `MAPBOX_TOKEN`, `CESIUM_TOKEN`), so the build machine's shell is build input.
2. Something in the graph reads `import.meta.env` as a **whole object**, so Vite stops replacing per key and inlines the entire env record into every chunk that read reaches. Ours was `packages/core/src/runtime-env.ts`; the one we can't fix is `@clerk/shared`'s `getEnvVariable.mjs`, which does `import.meta.env[name]` with a computed name — so the inlined record lands in `ClerkGate-*.js`.
3. `hatch_build.py` skips the JS build when `static/app` already exists and `GEOLIBRE_FORCE_JS_BUILD` is unset, so `python -m build` packages whatever an earlier `npm run build:embed` left staged, with **no JavaScript running at all**.

Because of (2), "stop reading the object" isn't a sufficient defence — the fix has to be "there is nothing sensitive in the object to begin with".

## Changes

- **`vite.config.ts`** gains `BUILD_ENV_KEYS` (allowlist of `VITE_` names that may reach a bundle) and `CREDENTIAL_ENV_KEYS` (the subset that bills to whoever built). `pruneBuildEnv()` deletes unrecognized `VITE_` vars from `process.env` and blanks credentials in redistributable builds, **before Vite reads it** — so a whole-object read has nothing sensitive to inline, Clerk's included. Blanked rather than deleted so a `.env` file can't reintroduce them.
- **`runtime-env.ts`** reads the allowlisted `__GEOLIBRE_BUILD_ENV__` define instead of `import.meta.env`, and exports `getBuildEnvironment()` for the five call sites that took a whole-object dependency. Those are build-only settings (auth gate, deployment profile, embed origins), so they deliberately don't get the runtime overlay.
- **`scripts/scan-credentials.mjs`** verifies build *output*, wired into `build-embed.mjs` (before staging) and `hatch_build.py` (before packaging any wheel/sdist, needing no Node — the only guard that covers path 3). Both read `scripts/credential-patterns.json` so they can't drift; it's force-included into the sdist so sdist → wheel is gated too.
- CesiumJS's own public default Ion token is hash-allowlisted so the guard doesn't fire on every release. A Cesium bump changes that token and will trip it — intentionally; `docs/maintenance.md` says how to confirm and refresh the hash.

## Scope

A redistributable build is `GEOLIBRE_EMBED=1` (the Jupyter wheel) or `GEOLIBRE_STRIP_CREDENTIALS=1`. **The web deploy is not** — it's our own site using our own referrer-restricted keys, and it keeps them.

Stripped credentials still resolve at runtime through `getRuntimeEnvironment()`'s Settings → Environment variables overlay, so a wheel user supplies their own token and the affected surfaces degrade as already documented: Mapbox prompts in the basemap API-keys view, the 3D globe isn't offered, Protomaps basemaps are hidden.

Public-by-design identifiers still ship in every build: the Clerk *publishable* key, the Auth0 client ID and domain, the GEE OAuth client ID, the GA measurement ID.

## Verification

- An embed build on a machine with those shell vars set emits `VITE_*:""` for every credential, with no raw token shapes anywhere in the output.
- The web build is unchanged and still carries its keys — no regression to the deploy.
- A planted key makes `python -m build` refuse; removing it builds a clean wheel.
- The JS and Python scanners agree exactly on the same input.
- `tests/credential-scan.test.ts` (7 tests) covers the guard; full frontend suite passes (7148); `pre-commit` clean including `npm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Prevented credentials and sensitive environment variables from entering redistributable builds.
  * Added automated scans for generated web assets during embed and package builds.
  * Build failures now flag potential credential leaks before packaging.

* **Reliability**
  * Standardized build-time environment handling across desktop and core functionality.
  * Added safeguards for builds using previously generated assets.

* **Documentation**
  * Documented credential protection requirements, scanning behavior, and remediation procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->