### PR TITLE
feat: add DashMap support for Plotly Dash

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -42,10 +42,12 @@ jobs:
 
       # Tests cover the pure-Python builders and do not need the bundled web
       # app, so install only the runtime/test deps and run against the sources.
-      # `mcp` is an optional extra, but tests/test_mcp_server.py skips itself
-      # without it, so install it here or the MCP server ships untested.
+      # `mcp` and `dash` are optional extras, but tests/test_mcp_server.py skips
+      # itself without the former and test_dash_component.py only covers the
+      # missing-Dash fallback without the latter, so install both here or the
+      # MCP server and the Dash component ship untested.
       - name: Install test dependencies
-        run: python -m pip install anywidget traitlets pytest "mcp>=2.0"
+        run: python -m pip install anywidget traitlets pytest "mcp>=2.0" "dash>=2.16"
 
       - name: Run tests
         run: python -m pytest python/tests

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Full documentation, including the User Guide and Tutorials, is published at
   - [Plugin API](docs/plugin-api.md)
   - [UI Profiles](docs/ui-profiles.md)
   - [Internationalization](docs/i18n.md)
-  - [Python package (Jupyter)](docs/python.md)
+  - [Python package (Jupyter)](docs/python.md) — also supports `from geolibre import DashMap` for Dash (install `geolibre[dash]`)
   - [R package (RStudio, Quarto, and Shiny)](docs/r.md)
   - [Notebook Panel](docs/notebook.md)
   - [Roadmap](docs/roadmap.md)

--- a/python/README.md
+++ b/python/README.md
@@ -73,6 +73,30 @@ m.to_project()["mapView"]["center"]
 
 ## API
 
+### Dash
+
+Install the optional Dash integration with `pip install "geolibre[dash]"`.
+`DashMap` is a Dash component and exposes map interactions as callback
+properties while retaining GeoLibre's existing map implementation:
+
+```python
+from dash import Dash, Input, Output, html
+from geolibre import DashMap
+
+app = Dash(__name__)
+m = DashMap(center=(-119.0, 39.8), zoom=12, basemap="dark", height="800px")
+app.layout = html.Div([m, html.Div(id="click-output")])
+
+@app.callback(Output("click-output", "children"), Input(m, "clickData"))
+def show_click(click_data):
+    return "Click the map" if click_data is None else str(click_data)
+```
+
+The click payload has the form `{"lngLat": {"lng": ..., "lat": ...},
+"features": [...]}`. `selectionData` is also available for Dash callbacks;
+`viewData` is reserved for future camera-event support. The existing
+`Map.on_click()` API is unchanged.
+
 | Method | Description |
 | --- | --- |
 | `Map(center, zoom, basemap=, height=, layout=, theme=)` | Create a map. `layout` is `"embed"`, `"full"`, or `"maponly"`. |

--- a/python/examples/dash_example.py
+++ b/python/examples/dash_example.py
@@ -1,0 +1,26 @@
+from dash import Dash, Input, Output, html
+from geolibre import DashMap
+
+app = Dash(__name__)
+
+m = DashMap(
+    center=(-119.0, 39.8),
+    zoom=12,
+    basemap="dark",
+    height="800px",
+)
+
+app.layout = html.Div([
+    m,
+    html.Pre(id="click-output"),
+])
+
+@app.callback(
+    Output("click-output", "children"),
+    Input(m, "clickData"),
+)
+def show_click(click_data):
+    return "Click the map" if click_data is None else str(click_data)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/python/examples/dash_example.py
+++ b/python/examples/dash_example.py
@@ -1,4 +1,5 @@
 from dash import Dash, Input, Output, html
+
 from geolibre import DashMap
 
 app = Dash(__name__)
@@ -10,10 +11,13 @@ m = DashMap(
     height="800px",
 )
 
-app.layout = html.Div([
-    m,
-    html.Pre(id="click-output"),
-])
+app.layout = html.Div(
+    [
+        m,
+        html.Pre(id="click-output"),
+    ]
+)
+
 
 @app.callback(
     Output("click-output", "children"),
@@ -21,6 +25,7 @@ app.layout = html.Div([
 )
 def show_click(click_data):
     return "Click the map" if click_data is None else str(click_data)
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = ["anywidget>=0.9", "traitlets>=5", "jupyter-ui-poll>=0.2"]
 all = ["geopandas", "shapely", "xarray", "rioxarray", "rasterio", "rio-tiler"]
 vector = ["geopandas", "shapely"]
 raster = ["xarray", "rioxarray", "rasterio", "rio-tiler"]
+dash = ["dash>=2.16"]
 # The MCP server (geolibre.mcp) is the only thing that imports the SDK, so it
 # stays optional: the widget and the project builders work without it.
 mcp = ["mcp>=2.0"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,7 +32,7 @@ dash = ["dash>=2.16"]
 # The MCP server (geolibre.mcp) is the only thing that imports the SDK, so it
 # stays optional: the widget and the project builders work without it.
 mcp = ["mcp>=2.0"]
-dev = ["pytest", "build", "anywidget[dev]", "jupyter-server", "mcp>=2.0"]
+dev = ["pytest", "build", "anywidget[dev]", "jupyter-server", "mcp>=2.0", "dash>=2.16"]
 
 [project.scripts]
 # geolibre.mcp:main, not geolibre.mcp.server:main — the package-level wrapper

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -10,14 +10,25 @@ from .authoring import (
     save_project,
 )
 from .geolibre import Feature, Layer, Map
+from .dash_component import DashMap
 from .legends import builtin_legend_names
 from .polyline import decode_polyline, encode_polyline, polyline_to_geojson, unescape_polyline
+
+# Dash discovers component bundles from these package-level distribution
+# declarations. Keeping Dash optional means importing the normal Jupyter API
+# does not require Dash to be installed.
+_js_dist = [{
+    "relative_package_path": "static/dash/geolibre.js",
+    "namespace": "geolibre",
+}]
+_css_dist: list[dict[str, str]] = []
 
 __version__ = "2.8.0"
 __all__ = [
     "Feature",
     "Layer",
     "Map",
+    "DashMap",
     "__version__",
     "basemap_catalog",
     "builtin_legend_names",

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -9,18 +9,20 @@ from .authoring import (
     load_project,
     save_project,
 )
-from .geolibre import Feature, Layer, Map
 from .dash_component import DashMap
+from .geolibre import Feature, Layer, Map
 from .legends import builtin_legend_names
 from .polyline import decode_polyline, encode_polyline, polyline_to_geojson, unescape_polyline
 
 # Dash discovers component bundles from these package-level distribution
 # declarations. Keeping Dash optional means importing the normal Jupyter API
 # does not require Dash to be installed.
-_js_dist = [{
-    "relative_package_path": "static/dash/geolibre.js",
-    "namespace": "geolibre",
-}]
+_js_dist = [
+    {
+        "relative_package_path": "static/dash/geolibre.js",
+        "namespace": "geolibre",
+    }
+]
 _css_dist: list[dict[str, str]] = []
 
 __version__ = "2.8.0"

--- a/python/src/geolibre/dash_component.py
+++ b/python/src/geolibre/dash_component.py
@@ -1,0 +1,99 @@
+"""Dash component wrapper for the GeoLibre map iframe."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from . import project as _project
+from ._server import app_port, serve_app
+from .basemaps import resolve_basemap
+from .geolibre import _STATIC_APP, _VALID_LAYOUTS, _VALID_THEMES
+
+try:
+    from dash.development.base_component import Component
+except ImportError:  # pragma: no cover - Dash is an optional dependency
+    Component = None  # type: ignore[assignment,misc]
+
+
+_PROPERTIES = [
+    "id", "className", "style", "center", "zoom", "basemap", "height",
+    "layout", "theme", "clickData", "selectionData", "viewData",
+    "project", "appUrl", "appPort", "setProps",
+]
+
+
+if Component is not None:
+
+    class DashMap(Component):
+        """A GeoLibre map usable directly in a Dash layout.
+
+        Map interactions update ``clickData``, ``selectionData``, and (in a
+        future release) ``viewData`` so they can be callback inputs.
+        """
+
+        _namespace = "geolibre"
+        _type = "DashMap"
+        _prop_names = _PROPERTIES
+        _js_dist = [{
+            "relative_package_path": "static/dash/geolibre.js",
+            "namespace": "geolibre",
+        }]
+        _css_dist: list[dict[str, Any]] = []
+        _children_props: list[str] = []
+        _base_nodes: set[str] = set()
+        _valid_wildcard_attributes: list[str] = []
+
+        def __init__(
+            self,
+            center: list[float] | tuple[float, float] | None = None,
+            zoom: float | None = None,
+            *,
+            basemap: str | None = None,
+            height: str = "800px",
+            layout: str = "embed",
+            theme: str = "light",
+            id: str | None = None,
+            className: str | None = None,
+            style: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> None:
+            if layout not in _VALID_LAYOUTS:
+                raise ValueError(f"layout must be one of {sorted(_VALID_LAYOUTS)}, got {layout!r}")
+            if theme not in _VALID_THEMES:
+                raise ValueError(f"theme must be one of {sorted(_VALID_THEMES)}, got {theme!r}")
+            if any(name in kwargs for name in ("clickData", "selectionData", "viewData")):
+                raise TypeError("DashMap event properties are read-only")
+            project = _project.build_empty_project(
+                center=center,
+                zoom=zoom,
+                basemap_url=resolve_basemap(basemap) if basemap else None,
+            )
+            super().__init__(
+                # Dash's component-object callback syntax needs an id. Generate
+                # one when omitted so ``Input(m, "clickData")`` works exactly
+                # like the documented usage.
+                id=id or f"geolibre-map-{uuid.uuid4().hex}",
+                className=className,
+                style=style,
+                center=list(center) if center is not None else None,
+                zoom=zoom,
+                basemap=basemap,
+                height=height,
+                layout=layout,
+                theme=theme,
+                project=project,
+                appUrl=serve_app(_STATIC_APP),
+                appPort=app_port() or 0,
+                **kwargs,
+            )
+
+else:
+
+    class DashMap:  # type: ignore[no-redef]
+        """Placeholder providing an actionable error when Dash is absent."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "DashMap requires Dash. Install it with `pip install 'geolibre[dash]'`."
+            )

--- a/python/src/geolibre/dash_component.py
+++ b/python/src/geolibre/dash_component.py
@@ -17,9 +17,22 @@ except ImportError:  # pragma: no cover - Dash is an optional dependency
 
 
 _PROPERTIES = [
-    "id", "className", "style", "center", "zoom", "basemap", "height",
-    "layout", "theme", "clickData", "selectionData", "viewData",
-    "project", "appUrl", "appPort", "setProps",
+    "id",
+    "className",
+    "style",
+    "center",
+    "zoom",
+    "basemap",
+    "height",
+    "layout",
+    "theme",
+    "clickData",
+    "selectionData",
+    "viewData",
+    "project",
+    "appUrl",
+    "appPort",
+    "setProps",
 ]
 
 
@@ -35,10 +48,12 @@ if Component is not None:
         _namespace = "geolibre"
         _type = "DashMap"
         _prop_names = _PROPERTIES
-        _js_dist = [{
-            "relative_package_path": "static/dash/geolibre.js",
-            "namespace": "geolibre",
-        }]
+        _js_dist = [
+            {
+                "relative_package_path": "static/dash/geolibre.js",
+                "namespace": "geolibre",
+            }
+        ]
         _css_dist: list[dict[str, Any]] = []
         _children_props: list[str] = []
         _base_nodes: set[str] = set()

--- a/python/src/geolibre/static/dash/geolibre.js
+++ b/python/src/geolibre/static/dash/geolibre.js
@@ -1,0 +1,48 @@
+/* Dash front end for geolibre.DashMap. It uses GeoLibre's existing iframe
+ * embed protocol, keeping the Jupyter and Dash map implementations aligned. */
+(function () {
+  "use strict";
+  function DashMap(props) {
+    var React = window.React;
+    var dash = window.dash_component_api;
+    var iframeRef = React.useRef(null);
+    React.useEffect(function () {
+      var iframe = iframeRef.current;
+      if (!iframe) return undefined;
+      var origin = new URL(props.appUrl).origin;
+      var onMessage = function (event) {
+        if (event.source !== iframe.contentWindow || event.origin !== origin) return;
+        var data = event.data || {};
+        if (data.type === "geolibre:ready" && iframe.contentWindow) {
+          iframe.contentWindow.postMessage({
+            type: "geolibre:load-project", project: props.project,
+            trustedWidget: false, seq: 1
+          }, origin);
+        } else if (data.type === "geolibre:event") {
+          var payload = data.payload;
+          if (data.event === "click" && payload && Array.isArray(payload.lngLat)) {
+            payload = Object.assign({}, payload, {
+              lngLat: { lng: payload.lngLat[0], lat: payload.lngLat[1] }
+            });
+          }
+          var property = data.event === "click" ? "clickData" :
+            data.event === "selection-change" ? "selectionData" : null;
+          var setProps = props.setProps || (dash && (dash.set_props || dash.setProps));
+          if (property && setProps) setProps({ [property]: payload });
+        }
+      };
+      window.addEventListener("message", onMessage);
+      return function () { window.removeEventListener("message", onMessage); };
+    }, [props.appUrl, props.project]);
+    var query = "?embed=1&theme=" + encodeURIComponent(props.theme || "light");
+    if (props.layout === "maponly") query += "&maponly=1";
+    else if (props.layout !== "full") query += "&layout=embed";
+    return React.createElement("iframe", {
+      ref: iframeRef, src: props.appUrl + "index.html" + query,
+      title: "GeoLibre map", allow: "fullscreen; geolocation", allowFullScreen: true,
+      style: Object.assign({ width: "100%", height: props.height || "800px", border: 0, display: "block" }, props.style || {})
+    });
+  }
+  window.geolibre = window.geolibre || {};
+  window.geolibre.DashMap = DashMap;
+}());

--- a/python/src/geolibre/static/dash/geolibre.js
+++ b/python/src/geolibre/static/dash/geolibre.js
@@ -6,18 +6,36 @@
     var React = window.React;
     var dash = window.dash_component_api;
     var iframeRef = React.useRef(null);
+    // The app posts "geolibre:ready" once per load, so a project change on an
+    // already-mounted iframe (same src) has to push the new project itself.
+    // Mirrors the anywidget front end's ready flag + onProjectChange push.
+    var readyRef = React.useRef(false);
+    var seqRef = React.useRef(0);
+    // Latest props for the async message handler; refreshed after every render
+    // (this effect is declared first, so the effects below see fresh props).
+    var propsRef = React.useRef(props);
+    React.useEffect(function () { propsRef.current = props; });
+    var sendProject = React.useCallback(function () {
+      var iframe = iframeRef.current;
+      if (!iframe || !iframe.contentWindow) return;
+      seqRef.current += 1;
+      iframe.contentWindow.postMessage({
+        type: "geolibre:load-project", project: propsRef.current.project,
+        trustedWidget: false, seq: seqRef.current
+      }, new URL(propsRef.current.appUrl).origin);
+    }, []);
     React.useEffect(function () {
       var iframe = iframeRef.current;
       if (!iframe) return undefined;
       var origin = new URL(props.appUrl).origin;
+      // A changed src reloads the iframe, so readiness starts over.
+      readyRef.current = false;
       var onMessage = function (event) {
         if (event.source !== iframe.contentWindow || event.origin !== origin) return;
         var data = event.data || {};
-        if (data.type === "geolibre:ready" && iframe.contentWindow) {
-          iframe.contentWindow.postMessage({
-            type: "geolibre:load-project", project: props.project,
-            trustedWidget: false, seq: 1
-          }, origin);
+        if (data.type === "geolibre:ready") {
+          readyRef.current = true;
+          sendProject();
         } else if (data.type === "geolibre:event") {
           var payload = data.payload;
           if (data.event === "click" && payload && Array.isArray(payload.lngLat)) {
@@ -27,13 +45,22 @@
           }
           var property = data.event === "click" ? "clickData" :
             data.event === "selection-change" ? "selectionData" : null;
-          var setProps = props.setProps || (dash && (dash.set_props || dash.setProps));
+          var setProps = propsRef.current.setProps ||
+            (dash && (dash.set_props || dash.setProps));
           if (property && setProps) setProps({ [property]: payload });
         }
       };
       window.addEventListener("message", onMessage);
-      return function () { window.removeEventListener("message", onMessage); };
-    }, [props.appUrl, props.project]);
+      return function () {
+        window.removeEventListener("message", onMessage);
+        readyRef.current = false;
+      };
+    }, [props.appUrl, sendProject]);
+    // Push a project that changed after the iframe already signalled ready;
+    // before that, the ready handler sends the current project.
+    React.useEffect(function () {
+      if (readyRef.current) sendProject();
+    }, [props.project, sendProject]);
     var query = "?embed=1&theme=" + encodeURIComponent(props.theme || "light");
     if (props.layout === "maponly") query += "&maponly=1";
     else if (props.layout !== "full") query += "&layout=embed";

--- a/python/tests/test_dash_component.py
+++ b/python/tests/test_dash_component.py
@@ -17,7 +17,7 @@ def test_dash_bundle_is_packaged():
 
 def test_dashmap_requires_dash_or_has_component():
     if dmod.Component is None:
-        with pytest.raises(ImportError, match="geolibre\[dash\]"):
+        with pytest.raises(ImportError, match=r"geolibre\[dash\]"):
             dmod.DashMap()
     else:
         assert dmod.DashMap._namespace == "geolibre"

--- a/python/tests/test_dash_component.py
+++ b/python/tests/test_dash_component.py
@@ -1,0 +1,25 @@
+"""Tests for the optional Dash component integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import geolibre.dash_component as dmod
+
+
+def test_dash_bundle_is_packaged():
+    bundle = Path(dmod.__file__).parent / "static" / "dash" / "geolibre.js"
+    assert bundle.is_file()
+    assert "clickData" in bundle.read_text(encoding="utf-8")
+
+
+def test_dashmap_requires_dash_or_has_component():
+    if dmod.Component is None:
+        with pytest.raises(ImportError, match="geolibre\[dash\]"):
+            dmod.DashMap()
+    else:
+        assert dmod.DashMap._namespace == "geolibre"
+        assert dmod.DashMap._type == "DashMap"
+        assert "clickData" in dmod.DashMap._prop_names

--- a/tests/dash-component-frontend.test.ts
+++ b/tests/dash-component-frontend.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+// The Dash bundle is a plain IIFE served to the browser (no module system), so
+// it is evaluated here against a minimal React/window stand-in rather than
+// imported. The harness runs hooks the way React does: refs are attached
+// before effects, and effects re-run only when their deps change.
+const BUNDLE = readFileSync(
+  fileURLToPath(new URL("../python/src/geolibre/static/dash/geolibre.js", import.meta.url)),
+  "utf-8",
+);
+
+type Hook = { value?: unknown; deps?: unknown[]; cleanup?: (() => void) | void };
+type Posted = { message: Record<string, unknown>; origin: string };
+
+const sameDeps = (a: unknown[] | undefined, b: unknown[] | undefined) =>
+  a !== undefined && b !== undefined && a.length === b.length && a.every((d, i) => d === b[i]);
+
+function mount(initialProps: Record<string, unknown>) {
+  const hooks: Hook[] = [];
+  const posted: Posted[] = [];
+  const listeners = new Set<(event: unknown) => void>();
+  let index = 0;
+  let pending: { hook: Hook; fn: () => (() => void) | void; deps?: unknown[] }[] = [];
+
+  const contentWindow = {
+    postMessage: (message: Record<string, unknown>, origin: string) =>
+      posted.push({ message, origin }),
+  };
+  const iframe = { contentWindow };
+
+  const slot = (): Hook => (hooks[index] ??= {});
+  const React = {
+    useRef(initial: unknown) {
+      const hook = slot();
+      hook.value ??= { current: initial };
+      index += 1;
+      return hook.value;
+    },
+    useCallback(fn: () => void, deps: unknown[]) {
+      const hook = slot();
+      if (!sameDeps(hook.deps, deps)) {
+        hook.value = fn;
+        hook.deps = deps;
+      }
+      index += 1;
+      return hook.value;
+    },
+    useEffect(fn: () => (() => void) | void, deps?: unknown[]) {
+      pending.push({ hook: slot(), fn, deps });
+      index += 1;
+    },
+    createElement: (type: string, props: Record<string, unknown>) => ({ type, props }),
+  };
+
+  const win = {
+    React,
+    dash_component_api: undefined,
+    addEventListener: (type: string, fn: (event: unknown) => void) => {
+      if (type === "message") listeners.add(fn);
+    },
+    removeEventListener: (type: string, fn: (event: unknown) => void) => {
+      if (type === "message") listeners.delete(fn);
+    },
+  } as Record<string, unknown>;
+  new Function("window", BUNDLE)(win);
+  const DashMap = (
+    win.geolibre as { DashMap: (props: unknown) => { props: Record<string, unknown> } }
+  ).DashMap;
+
+  const render = (props: Record<string, unknown>) => {
+    index = 0;
+    pending = [];
+    const element = DashMap(props);
+    (element.props.ref as { current: unknown }).current = iframe;
+    for (const effect of pending) {
+      if (effect.deps !== undefined && sameDeps(effect.hook.deps, effect.deps)) continue;
+      effect.hook.cleanup?.();
+      effect.hook.cleanup = effect.fn();
+      effect.hook.deps = effect.deps;
+    }
+    return element;
+  };
+
+  const element = render(initialProps);
+  const dispatch = (event: Record<string, unknown>) => {
+    for (const listener of [...listeners]) listener(event);
+  };
+  const ready = () =>
+    dispatch({
+      source: contentWindow,
+      origin: "http://127.0.0.1:8765",
+      data: { type: "geolibre:ready" },
+    });
+
+  return { element, render, dispatch, ready, posted, contentWindow };
+}
+
+const APP_URL = "http://127.0.0.1:8765/";
+
+describe("Dash DashMap component", () => {
+  it("sends the project once the iframe reports ready", () => {
+    const app = mount({ appUrl: APP_URL, project: { layers: [] } });
+    assert.equal(app.posted.length, 0);
+    app.ready();
+    assert.deepEqual(app.posted, [
+      {
+        message: {
+          type: "geolibre:load-project",
+          project: { layers: [] },
+          trustedWidget: false,
+          seq: 1,
+        },
+        origin: "http://127.0.0.1:8765",
+      },
+    ]);
+  });
+
+  it("pushes a project changed after ready, without reloading the iframe", () => {
+    const first = { layers: [] };
+    const second = { layers: [{ id: "a" }] };
+    const app = mount({ appUrl: APP_URL, project: first });
+    app.ready();
+    const before = app.element.props.src as string;
+
+    const rerendered = app.render({ appUrl: APP_URL, project: second });
+
+    assert.equal(rerendered.props.src, before, "src must stay identical (no reload)");
+    assert.equal(app.posted.length, 2);
+    assert.deepEqual(app.posted[1].message, {
+      type: "geolibre:load-project",
+      project: second,
+      trustedWidget: false,
+      seq: 2,
+    });
+  });
+
+  it("waits for ready before pushing a project change", () => {
+    const app = mount({ appUrl: APP_URL, project: { layers: [] } });
+    const updated = { layers: [{ id: "a" }] };
+    app.render({ appUrl: APP_URL, project: updated });
+    assert.equal(app.posted.length, 0, "nothing is sent before the app is ready");
+    app.ready();
+    assert.equal(app.posted.length, 1);
+    assert.deepEqual(app.posted[0].message.project, updated);
+  });
+
+  it("ignores messages from another window or origin", () => {
+    const app = mount({ appUrl: APP_URL, project: { layers: [] } });
+    app.dispatch({ source: {}, origin: "http://127.0.0.1:8765", data: { type: "geolibre:ready" } });
+    app.dispatch({
+      source: app.contentWindow,
+      origin: "https://evil.example",
+      data: { type: "geolibre:ready" },
+    });
+    assert.equal(app.posted.length, 0);
+  });
+
+  it("maps a click event onto clickData with an object lngLat", () => {
+    const calls: Record<string, unknown>[] = [];
+    const app = mount({
+      appUrl: APP_URL,
+      project: { layers: [] },
+      setProps: (update: Record<string, unknown>) => calls.push(update),
+    });
+    app.dispatch({
+      source: app.contentWindow,
+      origin: "http://127.0.0.1:8765",
+      data: {
+        type: "geolibre:event",
+        event: "click",
+        payload: { lngLat: [-122.4, 37.8], features: [] },
+      },
+    });
+    assert.deepEqual(calls, [{ clickData: { lngLat: { lng: -122.4, lat: 37.8 }, features: [] } }]);
+  });
+});


### PR DESCRIPTION
#2134 

Allows for use with plotly/Dash.

```
from dash import Dash, Input, Output, html

from geolibre import DashMap

app = Dash(__name__)

m = DashMap(
    center=(-119.0, 39.8),
    zoom=12,
    basemap="dark",
    height="800px",
)

app.layout = html.Div([
    m,
    html.Pre(id="click-output"),
])
app.layout = html.Div(
    [
        m,
        html.Pre(id="click-output"),
    ]
)


@app.callback(
    Output("click-output", "children"),
    Input(m, "clickData"),
)
def show_click(click_data):
    return "Click the map" if click_data is None else str(click_data)


if __name__ == "__main__":
    app.run(debug=True)

```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Dash integration through the `DashMap` component.
  * Configure map center, zoom, basemap, theme, layout, height, and styling.
  * Supports click, selection, and view data for Dash callbacks.
  * Added the `geolibre[dash]` installation option and a working Dash example.

* **Documentation**
  * Added setup and API guidance for `DashMap`, including event payloads, callback usage, and reserved properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->