### PR TITLE
docs: add Maptitude vs GeoLibre to comparisons hosted elsewhere

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -202,7 +202,7 @@ here.
   Delete the "none submitted yet" line below once the first one lands.
 -->
 
-*No external comparisons have been submitted yet. Yours can be the first.*
+- [Maptitude vs GeoLibre](https://www.caliper.com/maptitude/solutions/maptitude-vs-geolibre.htm), maintained by Caliper Corporation
 
 To add one, follow the [documentation contribution
 instructions](contributing.md#documentation) and open a pull request adding a


### PR DESCRIPTION
docs: add Maptitude vs GeoLibre to comparisons hosted elsewhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the comparison documentation to include an external Maptitude versus GeoLibre comparison maintained by Caliper Corporation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->