### PR TITLE
fix(field-collection): let the session own an auto-resolved capture target

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/FieldCollectionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/FieldCollectionDialog.tsx
@@ -289,58 +289,59 @@ export function FieldCollectionDialog({
     contextSeqRef.current += 1;
   }, []);
 
-  // Drop everything the current capture owns and point the form at `target`.
+  // Everything one capture owns: the placed geometry, the form, the photo, the
+  // map preview, and the async work behind them. The saved count goes too — it
+  // belongs to the layer being left, so without this the first save into a new
+  // target reads as the Nth. Split out from `resetCapture` so switching the
+  // target layer can drop a capture without also discarding a half-composed
+  // layer on the setup step.
+  const clearCapture = useCallback(() => {
+    invalidateCapture();
+    setPending(null);
+    setValues({});
+    setPhoto(null);
+    setPicking(false);
+    setDrawing(false);
+    setVertices([]);
+    verticesRef.current = [];
+    setLocating(false);
+    setLastGpsFix(null);
+    setErrors({});
+    setNotice(null);
+    savedCountRef.current = 0;
+    clearPreview();
+  }, [clearPreview, invalidateCapture]);
+
+  // Drop the capture and point the form at `target`, taking the setup step back
+  // to a blank new-layer form. A non-empty target becomes the session's own:
+  // the pill names it from here on, so a later layer reorder must not move the
+  // target out from under what the user is being shown.
   const resetCapture = useCallback(
     (target: string) => {
-      invalidateCapture();
+      clearCapture();
       setLayerId(target);
+      if (target) targetChosenRef.current = true;
       setLayerName("");
       setGeometry("point");
       setDrafts(target ? [] : [makeDraft()]);
-      setPending(null);
-      setValues({});
-      setPhoto(null);
-      setPicking(false);
-      setDrawing(false);
-      setVertices([]);
-      verticesRef.current = [];
-      setLocating(false);
-      setLastGpsFix(null);
-      setErrors({});
-      setNotice(null);
-      savedCountRef.current = 0;
-      clearPreview();
     },
-    [clearPreview, invalidateCapture, makeDraft],
+    [clearCapture, makeDraft],
   );
 
   // Switching the capture target mid-session drops the in-progress capture: a
   // point picked for Culverts must not be saved into Water Sources, and the
-  // sequence bump makes sure a GPS fix or photo read still in flight for the
-  // old target can't land on the new one either. Any drafts typed into the
-  // "new layer" setup step are kept, so toggling to a layer and back doesn't
-  // lose them.
+  // invalidation makes sure a GPS fix still in flight for the old target can't
+  // land on the new one either. Unlike `resetCapture` this keeps the setup
+  // step's fields, so toggling to a layer and back doesn't lose a layer being
+  // composed — the step just needs a row to type into.
   const handleTargetChange = useCallback(
     (nextId: string) => {
-      invalidateCapture();
+      clearCapture();
       targetChosenRef.current = true;
       setLayerId(nextId);
-      setPending(null);
-      setLastGpsFix(null);
-      setLocating(false);
-      setValues({});
-      setPhoto(null);
-      setVertices([]);
-      verticesRef.current = [];
-      clearPreview();
-      setErrors({});
-      setNotice(null);
-      // The count belongs to the layer being left, not to the one arrived at:
-      // without this the first save into the new target reads as the Nth.
-      savedCountRef.current = 0;
       if (!nextId && drafts.length === 0) setDrafts([makeDraft()]);
     },
-    [clearPreview, drafts.length, invalidateCapture, makeDraft],
+    [clearCapture, drafts.length, makeDraft],
   );
 
   // Reset the capture form when the dialog opens. The capture *target* is not


### PR DESCRIPTION
Follow-up to #2145. Both items come from the last review round on that PR, which arrived after it had already merged.

## Target could drift when the session never explicitly picked one

`targetChosenRef` was only set when the user touched the target dropdown or created a layer — never when the dialog auto-resolved to the first collection layer on open. So the "the target survives close and reopen" guarantee that #2145 is built around only held once the user had touched the dropdown at least once.

Concretely: a project has `Culverts` and `Water Sources`. The user opens Field Collection, it auto-targets one of them, they capture a point and dismiss — the pill now reads "Field Collection  Water Sources". While the session sits idle they reorder the Layers panel so `Culverts` becomes first. Tapping the pill resolves with `null` (nothing was ever "chosen"), returns `Culverts`, and the dialog reopens pointed at a different layer than the pill was just displaying, with no notice.

`resetCapture` now claims any non-empty target it resolves. That is exactly the moment the pill starts naming the layer, so from the user's point of view the session has a target and a later reorder cannot move it.

## `handleTargetChange` had grown a near-copy of `resetCapture`

The two differed only in that switching targets keeps the setup step's `layerName`/`geometry`/`drafts`. Everything else — invalidate, clear pending/values/photo/vertices/errors/notice/saved-count, `clearPreview()` — was duplicated, so a field added to the capture state was easy to add in one and forget in the other. That shared part is now `clearCapture()`, and each caller is a single line of difference on top of it.

## Verification

Driven in the real app against this branch: create `Culverts` and `Water Sources`, dismiss so the pill reads "Field Collection  Water Sources", reorder the Layers panel so `Culverts` is first, then reopen from the pill — the dialog still targets `Water Sources`. Also re-checked that a target switch clears the capture and resets the saved-feature count ("Saved 1 point to Culverts", not "Saved 2"), and that capture, save, and Done still behave. No new console errors.

`npm run build`, `npm run test:frontend` (7188 passing), and `pre-commit` on the changed file all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capture reset behavior to reliably clear geometry, form data, photos, previews, and related UI state.
  * Prevented outdated asynchronous capture operations from affecting the current session.
  * Switching target layers now preserves in-progress new-layer setup while clearing previous capture data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->