### PR TITLE
fix(python): list raster style layer ids in swipe sides

### DIFF
--- a/python/src/geolibre/authoring.py
+++ b/python/src/geolibre/authoring.py
@@ -35,6 +35,10 @@ LEGEND_SHAPES = frozenset({"square", "circle", "line"})
 # The pseudo-id the swipe control uses for the basemap (maplibre-swipe.ts).
 BASEMAP_LAYER_ID = "__basemap__"
 
+# Layer types the app draws through a single MapLibre raster style layer, named
+# `layer-<id>-raster` (see the style layer id helpers in the core layer sync).
+RASTER_STYLE_LAYER_TYPES = frozenset({"raster", "wms", "wmts", "xyz"})
+
 # Cap a project file read from disk. A project inlines its GeoJSON, so the
 # ceiling has to clear _MAX_GEOJSON_BYTES for a single layer with room for a few
 # more; past that the caller is better served by a tiled source than by loading
@@ -461,10 +465,11 @@ def _drop_swipe_reference(project: dict[str, Any], layer_id: str) -> None:
     swipe = settings.get(_project.SWIPE_PLUGIN_ID) if isinstance(settings, dict) else None
     if not isinstance(swipe, dict):
         return
+    dropped = {layer_id, _raster_style_layer_id(layer_id)}
     for side in ("leftLayers", "rightLayers"):
         ids = swipe.get(side)
         if isinstance(ids, list):
-            swipe[side] = [value for value in ids if value != layer_id]
+            swipe[side] = [value for value in ids if value not in dropped]
 
 
 def update_layer(
@@ -993,6 +998,39 @@ def add_colorbar(
     return entry
 
 
+def _raster_style_layer_id(layer_id: str) -> str:
+    """The MapLibre style layer id a raster-backed layer is drawn as."""
+    return f"layer-{layer_id}-raster"
+
+
+def _expand_swipe_side(project: dict[str, Any], layer_ids: list[str]) -> list[str]:
+    """Add the style layer id of every raster-backed layer to one swipe side.
+
+    The swipe control drives what each half shows by toggling MapLibre style
+    layer ids. A raster-backed layer (`raster`, `wms`, `wmts`, `xyz`) is drawn
+    as ``layer-<id>-raster``, so a side holding only the project layer id
+    matches no style layer: the control treats the layer as assigned to neither
+    side, which it renders on both halves. Listing both ids keeps the project
+    layer id (what the panel checkboxes read) and adds the id the control acts
+    on.
+    """
+    types = {
+        layer.get("id"): layer.get("type")
+        for layer in project.get("layers", [])
+        if isinstance(layer, dict)
+    }
+    expanded: list[str] = []
+    for layer_id in layer_ids:
+        if layer_id not in expanded:
+            expanded.append(layer_id)
+        if types.get(layer_id) not in RASTER_STYLE_LAYER_TYPES:
+            continue
+        style_id = _raster_style_layer_id(layer_id)
+        if style_id not in expanded:
+            expanded.append(style_id)
+    return expanded
+
+
 def add_swipe(
     project: dict[str, Any],
     *,
@@ -1027,8 +1065,8 @@ def add_swipe(
             f"control_position must be one of {sorted(CONTROL_POSITIONS)}, got {control_position!r}"
         )
     state = _project.swipe_state(
-        left_layers=list(left_layers),
-        right_layers=list(right_layers),
+        left_layers=_expand_swipe_side(project, list(left_layers)),
+        right_layers=_expand_swipe_side(project, list(right_layers)),
         orientation=orientation,
         position=min(100.0, max(0.0, float(position))),
     )

--- a/python/src/geolibre/authoring.py
+++ b/python/src/geolibre/authoring.py
@@ -35,8 +35,11 @@ LEGEND_SHAPES = frozenset({"square", "circle", "line"})
 # The pseudo-id the swipe control uses for the basemap (maplibre-swipe.ts).
 BASEMAP_LAYER_ID = "__basemap__"
 
-# Layer types the app draws through a single MapLibre raster style layer, named
-# `layer-<id>-raster` (see the style layer id helpers in the core layer sync).
+# Layer types the app always draws through a single MapLibre raster style layer
+# named `layer-<id>-raster` (see the style layer id helpers in the core layer
+# sync). `mbtiles` and `pmtiles` reach the same shape only when they carry
+# raster tiles, and `video` uses its own suffix, so those are resolved per
+# layer in `_style_layer_ids` rather than listed here.
 RASTER_STYLE_LAYER_TYPES = frozenset({"raster", "wms", "wmts", "xyz"})
 
 # Cap a project file read from disk. A project inlines its GeoJSON, so the
@@ -454,18 +457,22 @@ def remove_layer(project: dict[str, Any], ref: str) -> str:
     layer = find_layer(project, ref)
     layers_of(project).remove(layer)
     layer_id = str(layer["id"])
-    _drop_swipe_reference(project, layer_id)
+    _drop_swipe_reference(project, layer)
     return layer_id
 
 
-def _drop_swipe_reference(project: dict[str, Any], layer_id: str) -> None:
-    """Remove a layer id from the swipe control's two sides."""
+def _drop_swipe_reference(project: dict[str, Any], layer: dict[str, Any]) -> None:
+    """Remove a layer's ids from the swipe control's two sides.
+
+    Mirrors `_expand_swipe_side`: whatever that adds to a side, this takes back
+    out, so removing a layer cannot leave a derived style layer id behind.
+    """
     plugins = project.get("plugins")
     settings = plugins.get("settings") if isinstance(plugins, dict) else None
     swipe = settings.get(_project.SWIPE_PLUGIN_ID) if isinstance(settings, dict) else None
     if not isinstance(swipe, dict):
         return
-    dropped = {layer_id, _raster_style_layer_id(layer_id)}
+    dropped = {str(layer.get("id", "")), *_style_layer_ids(layer)}
     for side in ("leftLayers", "rightLayers"):
         ids = swipe.get(side)
         if isinstance(ids, list):
@@ -998,36 +1005,69 @@ def add_colorbar(
     return entry
 
 
-def _raster_style_layer_id(layer_id: str) -> str:
-    """The MapLibre style layer id a raster-backed layer is drawn as."""
-    return f"layer-{layer_id}-raster"
+def _style_layer_ids(layer: dict[str, Any]) -> list[str]:
+    """The MapLibre style layer ids a layer is drawn as, when they are derivable.
+
+    Only layers the app draws through a single style layer with a predictable
+    id qualify. `pmtiles` vector layers are deliberately absent: their ids are
+    `<sourceId>-<sourceLayer>-<kind>` (``pmtilesNativeLayerIds`` in
+    pmtiles-layer.ts), which the layer dict alone cannot spell out.
+
+    Args:
+        layer: A layer dict from the project's ``layers`` array.
+
+    Returns:
+        The style layer ids, or an empty list when none are derivable.
+    """
+    layer_id = str(layer.get("id", ""))
+    layer_type = layer.get("type")
+    metadata = layer.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    source = layer.get("source")
+    source = source if isinstance(source, dict) else {}
+    # syncMbtilesLayer/syncRasterTileLayer in layer-sync.ts read both.
+    is_raster = metadata.get("tileType") == "raster" or source.get("type") == "raster"
+
+    if layer_type == "pmtiles":
+        if not is_raster:
+            return []
+        # The archive's source id, which pmtiles_layer defaults to the layer id
+        # but callers may override, and without the `layer-` prefix the other
+        # raster paths carry.
+        return [f"{metadata.get('sourceId') or layer_id}-raster"]
+    if layer_type == "video":
+        return [f"layer-{layer_id}-video"]
+    if layer_type == "mbtiles":
+        return [f"layer-{layer_id}-raster"] if is_raster else []
+    if layer_type in RASTER_STYLE_LAYER_TYPES:
+        return [f"layer-{layer_id}-raster"]
+    return []
 
 
 def _expand_swipe_side(project: dict[str, Any], layer_ids: list[str]) -> list[str]:
-    """Add the style layer id of every raster-backed layer to one swipe side.
+    """Add the derived style layer ids of every listed layer to one swipe side.
 
     The swipe control drives what each half shows by toggling MapLibre style
-    layer ids. A raster-backed layer (`raster`, `wms`, `wmts`, `xyz`) is drawn
-    as ``layer-<id>-raster``, so a side holding only the project layer id
-    matches no style layer: the control treats the layer as assigned to neither
-    side, which it renders on both halves. Listing both ids keeps the project
-    layer id (what the panel checkboxes read) and adds the id the control acts
-    on.
+    layer ids. A layer drawn through a style layer of its own — a raster tile
+    source as ``layer-<id>-raster``, a video as ``layer-<id>-video`` — leaves a
+    side holding only the project layer id matching no style layer: the control
+    treats the layer as assigned to neither side, which it renders on both
+    halves. Listing both ids keeps the project layer id (what the panel
+    checkboxes read) and adds the ids the control acts on.
     """
-    types = {
-        layer.get("id"): layer.get("type")
-        for layer in project.get("layers", [])
-        if isinstance(layer, dict)
+    layers = {
+        layer.get("id"): layer for layer in project.get("layers", []) if isinstance(layer, dict)
     }
     expanded: list[str] = []
     for layer_id in layer_ids:
         if layer_id not in expanded:
             expanded.append(layer_id)
-        if types.get(layer_id) not in RASTER_STYLE_LAYER_TYPES:
+        layer = layers.get(layer_id)
+        if not isinstance(layer, dict):
             continue
-        style_id = _raster_style_layer_id(layer_id)
-        if style_id not in expanded:
-            expanded.append(style_id)
+        for style_id in _style_layer_ids(layer):
+            if style_id not in expanded:
+                expanded.append(style_id)
     return expanded
 
 

--- a/python/tests/test_authoring.py
+++ b/python/tests/test_authoring.py
@@ -476,6 +476,101 @@ def test_remove_layer_drops_the_style_layer_id_too(proj):
     assert swipe["rightLayers"] == []
 
 
+def test_add_swipe_lists_the_style_layer_id_of_a_raster_pmtiles_layer(proj):
+    """A raster PMTiles archive is drawn as `<sourceId>-raster`, with no prefix."""
+    authoring.add_layer(
+        proj,
+        project.pmtiles_layer("Scan", "https://example.org/scan.pmtiles", tile_type="raster"),
+    )
+    scan = authoring.find_layer(proj, "Scan")
+    source_id = scan["metadata"]["sourceId"]
+
+    state = authoring.add_swipe(proj, left_layers=["__basemap__"], right_layers=[scan["id"]])
+
+    assert state["rightLayers"] == [scan["id"], f"{source_id}-raster"]
+
+
+def test_add_swipe_leaves_a_vector_pmtiles_layer_alone(proj):
+    """Vector tile ids depend on source layer and kind, so none is derived here."""
+    authoring.add_layer(
+        proj,
+        project.pmtiles_layer(
+            "Roads", "https://example.org/roads.pmtiles", source_layers=["roads"]
+        ),
+    )
+    roads = authoring.find_layer(proj, "Roads")["id"]
+
+    state = authoring.add_swipe(proj, left_layers=["__basemap__"], right_layers=[roads])
+
+    assert state["rightLayers"] == [roads]
+
+
+def test_add_swipe_lists_the_style_layer_id_of_a_video_layer(proj):
+    """A video draws through `layer-<id>-video`, its own suffix."""
+    authoring.add_layer(
+        proj,
+        project.video_layer(
+            "Storm",
+            ["https://example.org/storm.mp4"],
+            [[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ),
+    )
+    storm = authoring.find_layer(proj, "Storm")["id"]
+
+    state = authoring.add_swipe(proj, left_layers=["__basemap__"], right_layers=[storm])
+
+    assert state["rightLayers"] == [storm, f"layer-{storm}-video"]
+
+
+def test_add_swipe_lists_the_style_layer_id_of_a_raster_mbtiles_layer(proj):
+    """An mbtiles layer has no builder here; it reaches this API through a saved project."""
+    authoring.add_layer(
+        proj,
+        {
+            "id": "mb-1",
+            "name": "Relief",
+            "type": "mbtiles",
+            "source": {"type": "raster", "url": "mbtiles://relief"},
+            "metadata": {"tileType": "raster"},
+        },
+    )
+
+    state = authoring.add_swipe(proj, left_layers=["__basemap__"], right_layers=["mb-1"])
+
+    assert state["rightLayers"] == ["mb-1", "layer-mb-1-raster"]
+
+
+def test_remove_layer_drops_a_derived_style_layer_id_of_any_shape(proj):
+    """Removal mirrors expansion, so no derived id outlives its layer."""
+    authoring.add_layer(
+        proj,
+        project.pmtiles_layer("Scan", "https://example.org/scan.pmtiles", tile_type="raster"),
+    )
+    authoring.add_layer(
+        proj,
+        project.video_layer(
+            "Storm",
+            ["https://example.org/storm.mp4"],
+            [[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ),
+    )
+    scan = authoring.find_layer(proj, "Scan")
+    storm = authoring.find_layer(proj, "Storm")["id"]
+    authoring.add_swipe(proj, left_layers=[scan["id"]], right_layers=[storm])
+    swipe = proj["plugins"]["settings"][project.SWIPE_PLUGIN_ID]
+    # Spell the sides out the way a project saved by the app carries them, so
+    # this covers removal on its own rather than only in step with add_swipe.
+    swipe["leftLayers"] = [scan["id"], f"{scan['metadata']['sourceId']}-raster"]
+    swipe["rightLayers"] = [storm, f"layer-{storm}-video"]
+
+    authoring.remove_layer(proj, "Scan")
+    authoring.remove_layer(proj, "Storm")
+
+    swipe = proj["plugins"]["settings"][project.SWIPE_PLUGIN_ID]
+    assert swipe["leftLayers"] == []
+    assert swipe["rightLayers"] == []
+
+
 def test_add_swipe_rejects_a_bad_orientation(proj):
     with pytest.raises(ValueError, match="orientation must be one of"):
         authoring.add_swipe(proj, left_layers=[], right_layers=[], orientation="diagonal")

--- a/python/tests/test_authoring.py
+++ b/python/tests/test_authoring.py
@@ -443,6 +443,39 @@ def test_add_swipe_clamps_the_slider_position(proj):
     assert project.SWIPE_PLUGIN_ID in proj["plugins"]["settings"]
 
 
+def test_add_swipe_lists_the_style_layer_id_of_a_raster_layer(proj):
+    """A WMS side carries the id the control acts on, not just the layer id."""
+    authoring.add_layer(proj, project.wms_layer("Aerial", "https://example.org/wms", "aerial"))
+    authoring.add_layer(proj, project.wms_layer("Historic", "https://example.org/wms", "historic"))
+    aerial = authoring.find_layer(proj, "Aerial")["id"]
+    historic = authoring.find_layer(proj, "Historic")["id"]
+
+    state = authoring.add_swipe(proj, left_layers=[historic], right_layers=[aerial])
+
+    assert state["leftLayers"] == [historic, f"layer-{historic}-raster"]
+    assert state["rightLayers"] == [aerial, f"layer-{aerial}-raster"]
+
+
+def test_add_swipe_leaves_non_raster_sides_alone(proj):
+    """A GeoJSON layer draws through several style layers, so it is untouched."""
+    cities = authoring.find_layer(proj, "Cities")["id"]
+    state = authoring.add_swipe(proj, left_layers=["__basemap__"], right_layers=[cities])
+    assert state["leftLayers"] == ["__basemap__"]
+    assert state["rightLayers"] == [cities]
+
+
+def test_remove_layer_drops_the_style_layer_id_too(proj):
+    """Removing a WMS layer leaves no dangling style id behind on a side."""
+    authoring.add_layer(proj, project.wms_layer("Aerial", "https://example.org/wms", "aerial"))
+    aerial = authoring.find_layer(proj, "Aerial")["id"]
+    authoring.add_swipe(proj, left_layers=["__basemap__"], right_layers=[aerial])
+
+    authoring.remove_layer(proj, "Aerial")
+
+    swipe = proj["plugins"]["settings"][project.SWIPE_PLUGIN_ID]
+    assert swipe["rightLayers"] == []
+
+
 def test_add_swipe_rejects_a_bad_orientation(proj):
     with pytest.raises(ValueError, match="orientation must be one of"):
         authoring.add_swipe(proj, left_layers=[], right_layers=[], orientation="diagonal")


### PR DESCRIPTION
## The problem

`add_swipe` writes each side of the split-map control as a list of project layer ids. For a raster-backed layer that produces a swipe that shows the same layer on both halves - it looks like the map being compared with itself.

The reason is that the control drives each half by toggling **MapLibre style layer ids**, and a layer of type `raster`, `wms`, `wmts` or `xyz` is drawn as `layer-<id>-raster`. A side holding only the project layer id matches no style layer, so the layer ends up assigned to neither side - and a layer with no side is drawn in the main map *and* mirrored into the comparison map, i.e. on both halves.

## Reproducing

Two WMS layers from the same public endpoint, the land-cover service of the Emilia-Romagna region (Italy), catalogued in the national spatial metadata repository (RNDT) as record `r_emiro:2016-04-01T154419`:

- endpoint: `https://servizigis.regione.emilia-romagna.it/wms/uso_del_suolo`
- layers: `1853_uso_suolo_storico_poligoni` (historic land cover, 1853) and `2011_uso_suolo_ed2013` (land cover, 2011)
- record page: <https://geodati.gov.it/geoportal-catalog/rest/metadata/item/r_emiro%3A2016-04-01T154419/html>

The service answers over HTTPS with CORS, so it renders in the app as-is.

With the MCP server:

```
create_project(path="swipe-bug.geolibre.json", name="Swipe bug", center=[11, 44.6], zoom=8)
add_ogc_layer(path=..., name="Land cover 1853", url="https://servizigis.regione.emilia-romagna.it/wms/uso_del_suolo", layers="1853_uso_suolo_storico_poligoni")
add_ogc_layer(path=..., name="Land cover 2011", url="https://servizigis.regione.emilia-romagna.it/wms/uso_del_suolo", layers="2011_uso_suolo_ed2013")
add_swipe(path=..., left_layers=["Land cover 1853"], right_layers=["Land cover 2011"])
```

Or in Python, without the network, to see just what gets written:

```python
from geolibre import authoring, project

p = project.build_empty_project("Swipe bug")
endpoint = "https://servizigis.regione.emilia-romagna.it/wms/uso_del_suolo"
authoring.add_layer(p, project.wms_layer("Land cover 1853", endpoint, "1853_uso_suolo_storico_poligoni"))
authoring.add_layer(p, project.wms_layer("Land cover 2011", endpoint, "2011_uso_suolo_ed2013"))
left = authoring.find_layer(p, "Land cover 1853")["id"]
right = authoring.find_layer(p, "Land cover 2011")["id"]
print(authoring.add_swipe(p, left_layers=[left], right_layers=[right]))
```

Before the fix each side holds one id and the app shows the top layer on both halves:

```json
{"leftLayers": ["d5150e8d-…"], "rightLayers": ["ad34cb45-…"]}
```

After the fix:

```json
{"leftLayers": ["d5150e8d-…", "layer-d5150e8d-…-raster"],
 "rightLayers": ["ad34cb45-…", "layer-ad34cb45-…-raster"]}
```

## The fix

`add_swipe` now lists both ids for those layer types: the project layer id (what the panel checkboxes read) and the style layer id the control acts on. Layer types that draw through several style layers, such as GeoJSON, are left untouched.

`remove_layer` already dropped a removed layer's id from both sides; it now drops the style id as well, so no dangling reference survives.

## Verification

Same project opened in GeoLibre Desktop v2.8.0:

- before: both halves show the top layer, whichever way the sides are set;
- after: 1853 on the left, 2011 on the right, and the Layer Swipe panel shows the checkboxes ticked on opposite sides.

The state the patched `add_swipe` writes is byte-identical to the one I arrived at by hand in the app before finding the cause.

Three tests added in `python/tests/test_authoring.py` covering the raster case, the non-raster case, and the removal path. `pytest python/tests` passes (325 passed, 8 skipped), `ruff check` and `ruff format --check` are clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swipe controls for raster layers, including WMS, WMTS, XYZ, and raster sources.
  * Removing a raster layer now also cleans up its associated swipe references, including derived display layers.
  * Non-raster layers continue to behave unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->