### PR TITLE
Keep click selection active for multiple features

### DIFF
--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -47,6 +47,7 @@ import {
   featuresIntersectingPolygon,
   keepsFeatureSelectionActive,
   selectionModeFromModifiers,
+  suspendedCameraHandlers,
   type FeatureSelectionRequest,
   type FeatureSelectionShape,
 } from "./feature-selection";
@@ -94,17 +95,6 @@ const DOUBLE_CLICK_VERTEX_TOLERANCE = 2;
  * tab; Select by expression and Select by location handle the bigger jobs.
  */
 const MAX_SELECTION_SCAN_FEATURES = 250_000;
-/** The camera interactions a drawing gesture suspends while it is running. */
-const CAMERA_HANDLERS = [
-  "dragPan",
-  "boxZoom",
-  "doubleClickZoom",
-  "scrollZoom",
-  "keyboard",
-  "dragRotate",
-  "touchZoomRotate",
-  "touchPitch",
-] as const;
 
 export interface MapCanvasProps {
   controllerRef?: React.MutableRefObject<MapController | null>;
@@ -1809,18 +1799,14 @@ export const MapCanvas = memo(function MapCanvas({
       container.append(overlay);
       cleanups.push(() => overlay.remove());
 
-      // Freeze every camera interaction for the gesture, not only the ones that
-      // would fight the drag. Vertices are recorded in screen space and are
-      // unprojected once, at finish(); a scroll-wheel zoom or an arrow-key pan
-      // placed between two polygon clicks would leave the earlier vertices
-      // pointing at different ground than the user aimed at.
-      if (request.shape !== "single") {
-        for (const name of CAMERA_HANDLERS) {
-          const handler = map[name];
-          if (!handler.isEnabled()) continue;
-          handler.disable();
-          cleanups.push(() => handler.enable());
-        }
+      // A drawn shape freezes the camera outright; click selection keeps it
+      // live but still gives up box zoom, which would otherwise swallow every
+      // Shift+click. See suspendedCameraHandlers() for why.
+      for (const name of suspendedCameraHandlers(request.shape)) {
+        const handler = map[name];
+        if (!handler.isEnabled()) continue;
+        handler.disable();
+        cleanups.push(() => handler.enable());
       }
       canvas.style.cursor = "crosshair";
       cleanups.push(() => {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -45,6 +45,7 @@ import {
 import {
   FEATURE_SELECTION_EVENT,
   featuresIntersectingPolygon,
+  keepsFeatureSelectionActive,
   selectionModeFromModifiers,
   type FeatureSelectionRequest,
   type FeatureSelectionShape,
@@ -1937,7 +1938,12 @@ export const MapCanvas = memo(function MapCanvas({
           matched,
           selectionModeFromModifiers(Boolean(event.shiftKey), Boolean(event.altKey), request.mode),
         );
-        cancelFeatureSelection.current?.();
+        // Click selection is a continuous map tool: keep its handler and
+        // crosshair armed so the next click can add, remove, or intersect via
+        // modifiers. Drawn shapes remain one-shot because their completed
+        // geometry is the whole interaction. Escape and any newly-started map
+        // tool still run the shared teardown.
+        if (!keepsFeatureSelectionActive(request.shape)) cancelFeatureSelection.current?.();
       };
       const onMouseDown = (event: maplibregl.MapMouseEvent) => {
         if (request.shape === "polygon" || request.shape === "single") return;

--- a/packages/map/src/feature-selection.ts
+++ b/packages/map/src/feature-selection.ts
@@ -12,13 +12,18 @@ export interface FeatureSelectionRequest {
 
 export const FEATURE_SELECTION_EVENT = "geolibre:select-features-on-map";
 
-/** Start a one-shot map selection interaction. */
+/** Start a map selection interaction. Click selection stays active until cancelled. */
 export function startFeatureSelection(request: FeatureSelectionRequest): void {
   window.dispatchEvent(
     new CustomEvent<FeatureSelectionRequest>(FEATURE_SELECTION_EVENT, {
       detail: request,
     }),
   );
+}
+
+/** Whether a completed gesture should stay armed for another selection. */
+export function keepsFeatureSelectionActive(shape: FeatureSelectionShape): boolean {
+  return shape === "single";
 }
 
 /** QGIS-style keyboard modifiers for a spatial selection gesture. */

--- a/packages/map/src/feature-selection.ts
+++ b/packages/map/src/feature-selection.ts
@@ -26,6 +26,41 @@ export function keepsFeatureSelectionActive(shape: FeatureSelectionShape): boole
   return shape === "single";
 }
 
+/** The MapLibre camera interactions a selection gesture can suspend. */
+export const CAMERA_HANDLERS = [
+  "dragPan",
+  "boxZoom",
+  "doubleClickZoom",
+  "scrollZoom",
+  "keyboard",
+  "dragRotate",
+  "touchZoomRotate",
+  "touchPitch",
+] as const;
+
+export type CameraHandlerName = (typeof CAMERA_HANDLERS)[number];
+
+/**
+ * The camera interactions a gesture suspends while it runs.
+ *
+ * A drawn shape freezes the camera outright: its vertices are recorded in
+ * screen space and unprojected once, at the end, so a scroll-wheel zoom or an
+ * arrow-key pan placed between two polygon clicks would leave the earlier
+ * vertices pointing at different ground than the user aimed at.
+ *
+ * Click selection stays armed across clicks, so it keeps the camera live for
+ * panning and zooming between picks — all but box zoom, which claims every
+ * Shift+left-drag and calls `DOM.suppressClick()` on release. That fires even
+ * for a Shift+click that never moved, swallowing the `click` this tool listens
+ * for and making the Shift ("add") and Shift+Alt ("intersect") modifiers
+ * silently do nothing.
+ */
+export function suspendedCameraHandlers(
+  shape: FeatureSelectionShape,
+): readonly CameraHandlerName[] {
+  return shape === "single" ? ["boxZoom"] : CAMERA_HANDLERS;
+}
+
 /** QGIS-style keyboard modifiers for a spatial selection gesture. */
 export function selectionModeFromModifiers(
   shiftKey: boolean,

--- a/tests/feature-selection.test.ts
+++ b/tests/feature-selection.test.ts
@@ -12,8 +12,10 @@ import { matchFeaturesByLocation } from "../packages/processing/src/vector-tools
 import { applyMatchedSelection } from "../apps/geolibre-desktop/src/lib/selection-actions";
 import {
   featuresIntersectingPolygon,
+  CAMERA_HANDLERS,
   keepsFeatureSelectionActive,
   selectionModeFromModifiers,
+  suspendedCameraHandlers,
 } from "../packages/map/src/feature-selection";
 
 const point = (
@@ -265,6 +267,23 @@ describe("map feature selection", () => {
     assert.equal(keepsFeatureSelectionActive("polygon"), false);
     assert.equal(keepsFeatureSelectionActive("freehand"), false);
     assert.equal(keepsFeatureSelectionActive("radius"), false);
+  });
+
+  it("suspends box zoom during click selection so Shift reaches the tool", () => {
+    // MapLibre's box-zoom handler claims every Shift+left-drag and suppresses
+    // the trailing `click` even when the pointer never moved. Leaving it
+    // enabled swallowed Shift+click and Shift+Alt+click outright, so "add" and
+    // "intersect" could never fire.
+    assert.deepEqual(suspendedCameraHandlers("single"), ["boxZoom"]);
+    // The camera still pans and zooms between clicks — the tool stays armed.
+    assert.ok(!suspendedCameraHandlers("single").includes("dragPan"));
+    assert.ok(!suspendedCameraHandlers("single").includes("scrollZoom"));
+  });
+
+  it("freezes the whole camera while a shape is being drawn", () => {
+    for (const shape of ["rectangle", "polygon", "freehand", "radius"] as const) {
+      assert.deepEqual(suspendedCameraHandlers(shape), CAMERA_HANDLERS);
+    }
   });
 
   it("maps QGIS-style modifiers to selection modes", () => {

--- a/tests/feature-selection.test.ts
+++ b/tests/feature-selection.test.ts
@@ -12,6 +12,7 @@ import { matchFeaturesByLocation } from "../packages/processing/src/vector-tools
 import { applyMatchedSelection } from "../apps/geolibre-desktop/src/lib/selection-actions";
 import {
   featuresIntersectingPolygon,
+  keepsFeatureSelectionActive,
   selectionModeFromModifiers,
 } from "../packages/map/src/feature-selection";
 
@@ -258,6 +259,14 @@ describe("applyMatchedSelection", () => {
 });
 
 describe("map feature selection", () => {
+  it("keeps click selection armed while drawn shapes remain one-shot", () => {
+    assert.equal(keepsFeatureSelectionActive("single"), true);
+    assert.equal(keepsFeatureSelectionActive("rectangle"), false);
+    assert.equal(keepsFeatureSelectionActive("polygon"), false);
+    assert.equal(keepsFeatureSelectionActive("freehand"), false);
+    assert.equal(keepsFeatureSelectionActive("radius"), false);
+  });
+
   it("maps QGIS-style modifiers to selection modes", () => {
     assert.equal(selectionModeFromModifiers(false, false), "new");
     assert.equal(selectionModeFromModifiers(true, false), "add");


### PR DESCRIPTION
## Summary

- keep Select features by click armed after each map click
- preserve Shift, Alt, and Shift+Alt modifier behavior across consecutive clicks
- keep drawn selection shapes one-shot and retain Escape cancellation

## Verification

- tested with `us_cities.geojson` in light and dark themes
- confirmed the crosshair remains active after selection and Escape cancels the tool
- `node --import tsx --test tests/feature-selection.test.ts`
- `npm run build`
- `pre-commit run --files packages/map/src/MapCanvas.tsx packages/map/src/feature-selection.ts tests/feature-selection.test.ts`

Addresses https://github.com/opengeos/GeoLibre/discussions/2152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click-based feature selection now remains active after each selection, allowing additional clicks to add, remove, or intersect features using modifiers.
  * Rectangle, radius, polygon, and freehand selection tools continue to deactivate after one completed interaction.
  * Escape and switching to another map tool still cancel the active selection.
  * Camera navigation remains available during click selection while box zoom is temporarily disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->