### PR TITLE
Open dropped GeoLibre project files

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -78,6 +78,7 @@ import { useProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useProjectHistory } from "../../hooks/useProjectHistory";
 import {
   isRasterFileName,
+  isGeoLibreProjectFileName,
   isTauri,
   loadDroppedPhotoFiles,
   loadDroppedPhotoPaths,
@@ -90,6 +91,7 @@ import {
   isLoadedModel,
   loadDroppedVectorFiles,
   loadDroppedVectorPaths,
+  readLocalFileText,
   type DroppedRaster,
 } from "../../lib/tauri-io";
 import { buildKmlModelLayer } from "../../lib/kml-model-layer";
@@ -751,6 +753,8 @@ export function DesktopShell({
   // Browser panel, so their "open recent" calls coordinate their aborts (two
   // instances would race). Lifted here for the same reason as `collaboration`.
   const projectFiles = useProjectFileActions(mapControllerRef);
+  const projectFilesRef = useRef(projectFiles);
+  projectFilesRef.current = projectFiles;
   const notebookOpen = useAppStore((s) => s.ui.notebookOpen);
   const storymapPresenting = useAppStore((s) => s.ui.storymapPresenting);
   // A plugin panel docks at one of four positions beside the Layers/Style
@@ -1747,6 +1751,20 @@ export function DesktopShell({
 
           try {
             const paths = event.payload.paths;
+            const projectPaths = paths.filter(isGeoLibreProjectFileName);
+            if (projectPaths.length > 0) {
+              if (paths.length !== 1) {
+                throw new Error("Drop one GeoLibre project at a time, without other files.");
+              }
+              const projectPath = projectPaths[0];
+              if (!projectPath) return;
+              await projectFilesRef.current.handleDroppedProject(
+                await readLocalFileText(projectPath),
+                projectPath,
+              );
+              setDropMessage(null);
+              return;
+            }
             // OSM PBF files split into three layers, so they bypass the normal
             // single-FeatureCollection pipeline (which would otherwise route a
             // .pbf to DuckDB ST_Read and merge it).
@@ -1929,6 +1947,17 @@ export function DesktopShell({
 
       try {
         const allFiles = Array.from(event.dataTransfer.files);
+        const projectFilesInDrop = allFiles.filter((file) => isGeoLibreProjectFileName(file.name));
+        if (projectFilesInDrop.length > 0) {
+          if (allFiles.length !== 1) {
+            throw new Error("Drop one GeoLibre project at a time, without other files.");
+          }
+          const projectFile = projectFilesInDrop[0];
+          if (!projectFile) return;
+          await projectFilesRef.current.handleDroppedProject(await projectFile.text(), null);
+          setDropMessage(null);
+          return;
+        }
         // OSM PBF files produce three separate layers (points/lines/polygons),
         // so they bypass the single-FeatureCollection vector drop pipeline.
         // Handle them first, then run the rest through the normal pipeline —

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1753,8 +1753,11 @@ export function DesktopShell({
             const paths = event.payload.paths;
             const projectPaths = paths.filter(isGeoLibreProjectFileName);
             if (projectPaths.length > 0) {
+              if (!deploymentCapabilities.has("project:edit")) {
+                throw new Error(t("toolbar.error.projectDropNotAllowed"));
+              }
               if (paths.length !== 1) {
-                throw new Error("Drop one GeoLibre project at a time, without other files.");
+                throw new Error(t("toolbar.error.multipleProjectDrop"));
               }
               const projectPath = projectPaths[0];
               if (!projectPath) return;
@@ -1891,7 +1894,9 @@ export function DesktopShell({
     addDroppedRasters,
     addDroppedPhotos,
     addGeoJsonLayer,
+    deploymentCapabilities,
     dropDisabled,
+    t,
   ]);
 
   const handleDragEnter = useCallback(
@@ -1949,8 +1954,11 @@ export function DesktopShell({
         const allFiles = Array.from(event.dataTransfer.files);
         const projectFilesInDrop = allFiles.filter((file) => isGeoLibreProjectFileName(file.name));
         if (projectFilesInDrop.length > 0) {
+          if (!deploymentCapabilities.has("project:edit")) {
+            throw new Error(t("toolbar.error.projectDropNotAllowed"));
+          }
           if (allFiles.length !== 1) {
-            throw new Error("Drop one GeoLibre project at a time, without other files.");
+            throw new Error(t("toolbar.error.multipleProjectDrop"));
           }
           const projectFile = projectFilesInDrop[0];
           if (!projectFile) return;
@@ -2059,7 +2067,9 @@ export function DesktopShell({
       addDroppedRasters,
       addDroppedPhotos,
       addGeoJsonLayer,
+      deploymentCapabilities,
       dropDisabled,
+      t,
     ],
   );
 

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
@@ -57,6 +57,36 @@ export function ProjectFileDialogs({ projectFiles }: ProjectFileDialogsProps) {
   return (
     <>
       <Dialog
+        open={projectFiles.droppedProjectPrompt !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) void projectFiles.resolveDroppedProjectPrompt("cancel");
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("newProject.savePromptTitle")}</DialogTitle>
+            <DialogDescription>{t("newProject.savePromptDescription")}</DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => void projectFiles.resolveDroppedProjectPrompt("cancel")}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => void projectFiles.resolveDroppedProjectPrompt("discard")}
+            >
+              {t("newProject.doNotSave")}
+            </Button>
+            <Button onClick={() => void projectFiles.resolveDroppedProjectPrompt("save")}>
+              {t("common.save")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
         open={projectFiles.projectUrlDialogOpen}
         onOpenChange={projectFiles.handleProjectUrlDialogOpenChange}
       >

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
@@ -64,23 +64,28 @@ export function ProjectFileDialogs({ projectFiles }: ProjectFileDialogsProps) {
       >
         <DialogContent className="max-w-lg">
           <DialogHeader>
-            <DialogTitle>{t("newProject.savePromptTitle")}</DialogTitle>
-            <DialogDescription>{t("newProject.savePromptDescription")}</DialogDescription>
+            <DialogTitle>{t("toolbar.fileDrop.savePromptTitle")}</DialogTitle>
+            <DialogDescription>{t("toolbar.fileDrop.savePromptDescription")}</DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2">
             <Button
               variant="outline"
+              disabled={projectFiles.droppedProjectSaving}
               onClick={() => void projectFiles.resolveDroppedProjectPrompt("cancel")}
             >
               {t("common.cancel")}
             </Button>
             <Button
               variant="secondary"
+              disabled={projectFiles.droppedProjectSaving}
               onClick={() => void projectFiles.resolveDroppedProjectPrompt("discard")}
             >
               {t("newProject.doNotSave")}
             </Button>
-            <Button onClick={() => void projectFiles.resolveDroppedProjectPrompt("save")}>
+            <Button
+              disabled={projectFiles.droppedProjectSaving}
+              onClick={() => void projectFiles.resolveDroppedProjectPrompt("save")}
+            >
               {t("common.save")}
             </Button>
           </div>

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -79,6 +79,8 @@ export interface DroppedProjectPrompt {
   project: GeoLibreProject;
   path: string | null;
   text: string;
+  /** Project generation that opened the prompt. */
+  projectGeneration: number;
 }
 
 /**
@@ -347,8 +349,13 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     if (saveNamePrompt && saveNamePrompt.projectGeneration !== projectGeneration) {
       settleSaveNamePrompt(saveNamePrompt, null);
     }
+    if (droppedProjectPrompt && droppedProjectPrompt.projectGeneration !== projectGeneration) {
+      setDroppedProjectPrompt(null);
+      setDroppedProjectSaving(false);
+    }
   }, [
     credentialStripPrompt,
+    droppedProjectPrompt,
     embedVectorDataPrompt,
     projectGeneration,
     saveNamePrompt,
@@ -395,7 +402,12 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
 
   /** Parse and open a project supplied by either browser or native drag-and-drop. */
   const handleDroppedProject = async (text: string, path: string | null): Promise<boolean> => {
-    const candidate = { project: parseProject(text), path, text };
+    const candidate = {
+      project: parseProject(text),
+      path,
+      text,
+      projectGeneration: useAppStore.getState().projectGeneration,
+    };
     if (useAppStore.getState().isDirty) {
       setDroppedProjectPrompt(candidate);
       return false;

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -66,6 +66,7 @@ import {
 import { importArcgisProject, type ArcgisProjectImportWarning } from "../lib/arcgis-project-import";
 import type { MapControllerRef } from "../components/layout/toolbar/constants";
 import { IS_MAS_BUILD } from "../lib/build-flags";
+import { resolveDroppedProjectIfCurrent } from "../lib/dropped-project";
 
 /** A pending "strip credentials before saving?" prompt. */
 export interface CredentialStripPrompt {
@@ -81,6 +82,8 @@ export interface DroppedProjectPrompt {
   text: string;
   /** Project generation that opened the prompt. */
   projectGeneration: number;
+  /** Serialized workspace state covered by the open/discard decision. */
+  projectFingerprint: string;
 }
 
 /**
@@ -397,12 +400,31 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
   };
 
   const loadDroppedProject = async (candidate: DroppedProjectPrompt) => {
-    if (useAppStore.getState().projectGeneration !== candidate.projectGeneration) return false;
-    const project = await resolveProjectXyzLayers(candidate.project);
-    if (useAppStore.getState().projectGeneration !== candidate.projectGeneration) return false;
-    loadProject(project, candidate.path, { rememberRecent: isTauri() && candidate.path !== null });
-    if (candidate.path) rememberStartupProjectSnapshot(candidate.path, candidate.text);
-    return true;
+    return resolveDroppedProjectIfCurrent({
+      project: candidate.project,
+      projectGeneration: candidate.projectGeneration,
+      projectFingerprint: candidate.projectFingerprint,
+      getWorkspaceState: () => ({
+        projectGeneration: useAppStore.getState().projectGeneration,
+        projectFingerprint: serializeProject(projectFromStore(useAppStore.getState())),
+      }),
+      resolveProject: resolveProjectXyzLayers,
+      loadProject: (project) => {
+        loadProject(project, candidate.path, {
+          rememberRecent: isTauri() && candidate.path !== null,
+        });
+        if (candidate.path) rememberStartupProjectSnapshot(candidate.path, candidate.text);
+      },
+      workspaceChanged: (state) => {
+        const updated = {
+          ...candidate,
+          projectGeneration: state.projectGeneration,
+          projectFingerprint: state.projectFingerprint,
+        };
+        droppedProjectPromptRef.current = updated;
+        setDroppedProjectPrompt(updated);
+      },
+    });
   };
 
   /** Parse and open a project supplied by either browser or native drag-and-drop. */
@@ -413,6 +435,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
         path,
         text,
         projectGeneration: useAppStore.getState().projectGeneration,
+        projectFingerprint: serializeProject(projectFromStore(useAppStore.getState())),
       };
       if (useAppStore.getState().isDirty) {
         droppedProjectPromptRef.current = candidate;
@@ -449,6 +472,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     }
     droppedProjectPromptRef.current = null;
     setDroppedProjectPrompt(null);
+    candidate.projectFingerprint = serializeProject(projectFromStore(useAppStore.getState()));
     try {
       await loadDroppedProject(candidate);
     } catch (error) {

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -273,6 +273,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
   const [droppedProjectPrompt, setDroppedProjectPrompt] = useState<DroppedProjectPrompt | null>(
     null,
   );
+  const [droppedProjectSaving, setDroppedProjectSaving] = useState(false);
   const [qgisImportWarnings, setQgisImportWarnings] = useState<QgisProjectImportWarning[] | null>(
     null,
   );
@@ -404,13 +405,21 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
   };
 
   const resolveDroppedProjectPrompt = async (choice: "save" | "discard" | "cancel") => {
+    if (droppedProjectSaving) return;
     const candidate = droppedProjectPrompt;
     if (!candidate) return;
     if (choice === "cancel") {
       setDroppedProjectPrompt(null);
       return;
     }
-    if (choice === "save" && !(await saveProject())) return;
+    if (choice === "save") {
+      setDroppedProjectSaving(true);
+      try {
+        if (!(await saveProject())) return;
+      } finally {
+        setDroppedProjectSaving(false);
+      }
+    }
     setDroppedProjectPrompt(null);
     try {
       await loadDroppedProject(candidate);
@@ -1339,6 +1348,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     actionError,
     setActionError,
     droppedProjectPrompt,
+    droppedProjectSaving,
     resolveDroppedProjectPrompt,
     qgisImportWarnings,
     setQgisImportWarnings,

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -397,27 +397,29 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
   };
 
   const loadDroppedProject = async (candidate: DroppedProjectPrompt) => {
+    if (useAppStore.getState().projectGeneration !== candidate.projectGeneration) return false;
     const project = await resolveProjectXyzLayers(candidate.project);
+    if (useAppStore.getState().projectGeneration !== candidate.projectGeneration) return false;
     loadProject(project, candidate.path, { rememberRecent: isTauri() && candidate.path !== null });
     if (candidate.path) rememberStartupProjectSnapshot(candidate.path, candidate.text);
+    return true;
   };
 
   /** Parse and open a project supplied by either browser or native drag-and-drop. */
   const handleDroppedProject = async (text: string, path: string | null): Promise<boolean> => {
-    const candidate = {
-      project: parseProject(text),
-      path,
-      text,
-      projectGeneration: useAppStore.getState().projectGeneration,
-    };
-    if (useAppStore.getState().isDirty) {
-      droppedProjectPromptRef.current = candidate;
-      setDroppedProjectPrompt(candidate);
-      return false;
-    }
     try {
-      await loadDroppedProject(candidate);
-      return true;
+      const candidate = {
+        project: parseProject(text),
+        path,
+        text,
+        projectGeneration: useAppStore.getState().projectGeneration,
+      };
+      if (useAppStore.getState().isDirty) {
+        droppedProjectPromptRef.current = candidate;
+        setDroppedProjectPrompt(candidate);
+        return false;
+      }
+      return await loadDroppedProject(candidate);
     } catch (error) {
       console.error("Failed to open dropped project", error);
       setActionError(

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -83,7 +83,9 @@ export interface DroppedProjectPrompt {
   /** Project generation that opened the prompt. */
   projectGeneration: number;
   /** Serialized workspace state covered by the open/discard decision. */
-  projectFingerprint: string;
+  projectFingerprint: string | null;
+  /** Monotonic token ensuring the newest accepted drop wins. */
+  operationId: number;
 }
 
 /**
@@ -280,6 +282,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
   );
   const [droppedProjectSaving, setDroppedProjectSaving] = useState(false);
   const droppedProjectPromptRef = useRef<DroppedProjectPrompt | null>(null);
+  const droppedProjectOperationRef = useRef(0);
   const [qgisImportWarnings, setQgisImportWarnings] = useState<QgisProjectImportWarning[] | null>(
     null,
   );
@@ -404,9 +407,13 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       project: candidate.project,
       projectGeneration: candidate.projectGeneration,
       projectFingerprint: candidate.projectFingerprint,
+      isLatestOperation: () => droppedProjectOperationRef.current === candidate.operationId,
       getWorkspaceState: () => ({
         projectGeneration: useAppStore.getState().projectGeneration,
-        projectFingerprint: serializeProject(projectFromStore(useAppStore.getState())),
+        isDirty: useAppStore.getState().isDirty,
+        projectFingerprint: useAppStore.getState().isDirty
+          ? serializeProject(projectFromStore(useAppStore.getState()))
+          : null,
       }),
       resolveProject: resolveProjectXyzLayers,
       loadProject: (project) => {
@@ -415,9 +422,10 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
         });
         if (candidate.path) rememberStartupProjectSnapshot(candidate.path, candidate.text);
       },
-      workspaceChanged: (state) => {
+      workspaceChanged: (state, project) => {
         const updated = {
           ...candidate,
+          project,
           projectGeneration: state.projectGeneration,
           projectFingerprint: state.projectFingerprint,
         };
@@ -435,7 +443,10 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
         path,
         text,
         projectGeneration: useAppStore.getState().projectGeneration,
-        projectFingerprint: serializeProject(projectFromStore(useAppStore.getState())),
+        projectFingerprint: useAppStore.getState().isDirty
+          ? serializeProject(projectFromStore(useAppStore.getState()))
+          : null,
+        operationId: ++droppedProjectOperationRef.current,
       };
       if (useAppStore.getState().isDirty) {
         droppedProjectPromptRef.current = candidate;
@@ -463,8 +474,12 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     }
     if (choice === "save") {
       setDroppedProjectSaving(true);
+      setDroppedProjectPrompt(null);
       try {
-        if (!(await saveProject())) return;
+        if (!(await saveProject())) {
+          if (droppedProjectPromptRef.current === candidate) setDroppedProjectPrompt(candidate);
+          return;
+        }
       } finally {
         setDroppedProjectSaving(false);
       }
@@ -472,7 +487,9 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     }
     droppedProjectPromptRef.current = null;
     setDroppedProjectPrompt(null);
-    candidate.projectFingerprint = serializeProject(projectFromStore(useAppStore.getState()));
+    candidate.projectFingerprint = useAppStore.getState().isDirty
+      ? serializeProject(projectFromStore(useAppStore.getState()))
+      : null;
     try {
       await loadDroppedProject(candidate);
     } catch (error) {

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -276,6 +276,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     null,
   );
   const [droppedProjectSaving, setDroppedProjectSaving] = useState(false);
+  const droppedProjectPromptRef = useRef<DroppedProjectPrompt | null>(null);
   const [qgisImportWarnings, setQgisImportWarnings] = useState<QgisProjectImportWarning[] | null>(
     null,
   );
@@ -350,6 +351,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       settleSaveNamePrompt(saveNamePrompt, null);
     }
     if (droppedProjectPrompt && droppedProjectPrompt.projectGeneration !== projectGeneration) {
+      droppedProjectPromptRef.current = null;
       setDroppedProjectPrompt(null);
       setDroppedProjectSaving(false);
     }
@@ -409,11 +411,20 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       projectGeneration: useAppStore.getState().projectGeneration,
     };
     if (useAppStore.getState().isDirty) {
+      droppedProjectPromptRef.current = candidate;
       setDroppedProjectPrompt(candidate);
       return false;
     }
-    await loadDroppedProject(candidate);
-    return true;
+    try {
+      await loadDroppedProject(candidate);
+      return true;
+    } catch (error) {
+      console.error("Failed to open dropped project", error);
+      setActionError(
+        error instanceof Error ? error.message : t("toolbar.error.couldNotOpenProject"),
+      );
+      return false;
+    }
   };
 
   const resolveDroppedProjectPrompt = async (choice: "save" | "discard" | "cancel") => {
@@ -421,6 +432,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     const candidate = droppedProjectPrompt;
     if (!candidate) return;
     if (choice === "cancel") {
+      droppedProjectPromptRef.current = null;
       setDroppedProjectPrompt(null);
       return;
     }
@@ -431,7 +443,9 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       } finally {
         setDroppedProjectSaving(false);
       }
+      if (droppedProjectPromptRef.current !== candidate) return;
     }
+    droppedProjectPromptRef.current = null;
     setDroppedProjectPrompt(null);
     try {
       await loadDroppedProject(candidate);

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -407,7 +407,9 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       project: candidate.project,
       projectGeneration: candidate.projectGeneration,
       projectFingerprint: candidate.projectFingerprint,
-      isLatestOperation: () => droppedProjectOperationRef.current === candidate.operationId,
+      isCurrentOperation: () =>
+        droppedProjectOperationRef.current === candidate.operationId &&
+        useAppStore.getState().projectGeneration === candidate.projectGeneration,
       getWorkspaceState: () => ({
         projectGeneration: useAppStore.getState().projectGeneration,
         isDirty: useAppStore.getState().isDirty,
@@ -487,11 +489,14 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     }
     droppedProjectPromptRef.current = null;
     setDroppedProjectPrompt(null);
-    candidate.projectFingerprint = useAppStore.getState().isDirty
-      ? serializeProject(projectFromStore(useAppStore.getState()))
-      : null;
+    const decidedCandidate = {
+      ...candidate,
+      projectFingerprint: useAppStore.getState().isDirty
+        ? serializeProject(projectFromStore(useAppStore.getState()))
+        : null,
+    };
     try {
-      await loadDroppedProject(candidate);
+      await loadDroppedProject(decidedCandidate);
     } catch (error) {
       console.error("Failed to open dropped project", error);
       setActionError(

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_PROJECT_NAME,
   detachProjectCopy,
+  parseProject,
   projectFromStore,
   redactProjectCredentials,
   excludeHiddenFieldsFromProject,
@@ -72,6 +73,12 @@ export interface CredentialStripPrompt {
   /** Project generation that opened the prompt. */
   projectGeneration: number;
   resolve: (choice: "strip" | "keep" | "cancel") => void;
+}
+
+export interface DroppedProjectPrompt {
+  project: GeoLibreProject;
+  path: string | null;
+  text: string;
 }
 
 /**
@@ -263,6 +270,9 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
   const projectGeneration = useAppStore((s) => s.projectGeneration);
 
   const [actionError, setActionError] = useState<string | null>(null);
+  const [droppedProjectPrompt, setDroppedProjectPrompt] = useState<DroppedProjectPrompt | null>(
+    null,
+  );
   const [qgisImportWarnings, setQgisImportWarnings] = useState<QgisProjectImportWarning[] | null>(
     null,
   );
@@ -373,6 +383,42 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
           error instanceof Error ? error.message : t("toolbar.error.couldNotOpenProject"),
         );
       }
+    }
+  };
+
+  const loadDroppedProject = async (candidate: DroppedProjectPrompt) => {
+    const project = await resolveProjectXyzLayers(candidate.project);
+    loadProject(project, candidate.path, { rememberRecent: isTauri() && candidate.path !== null });
+    if (candidate.path) rememberStartupProjectSnapshot(candidate.path, candidate.text);
+  };
+
+  /** Parse and open a project supplied by either browser or native drag-and-drop. */
+  const handleDroppedProject = async (text: string, path: string | null): Promise<boolean> => {
+    const candidate = { project: parseProject(text), path, text };
+    if (useAppStore.getState().isDirty) {
+      setDroppedProjectPrompt(candidate);
+      return false;
+    }
+    await loadDroppedProject(candidate);
+    return true;
+  };
+
+  const resolveDroppedProjectPrompt = async (choice: "save" | "discard" | "cancel") => {
+    const candidate = droppedProjectPrompt;
+    if (!candidate) return;
+    if (choice === "cancel") {
+      setDroppedProjectPrompt(null);
+      return;
+    }
+    if (choice === "save" && !(await saveProject())) return;
+    setDroppedProjectPrompt(null);
+    try {
+      await loadDroppedProject(candidate);
+    } catch (error) {
+      console.error("Failed to open dropped project", error);
+      setActionError(
+        error instanceof Error ? error.message : t("toolbar.error.couldNotOpenProject"),
+      );
     }
   };
 
@@ -1292,6 +1338,8 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
   return {
     actionError,
     setActionError,
+    droppedProjectPrompt,
+    resolveDroppedProjectPrompt,
     qgisImportWarnings,
     setQgisImportWarnings,
     arcgisImportWarnings,
@@ -1318,6 +1366,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     submitSaveNamePrompt,
     cancelSaveNamePrompt,
     handleOpenFromFile,
+    handleDroppedProject,
     handleImportQgisProject,
     handleImportArcgisProject,
     handleOpenFromUrl,

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -3147,10 +3147,14 @@
       "bothRasterLayers_two": "{{count}} من الطبقات النقطية",
       "bothRasterLayers_few": "{{count}} طبقات نقطية",
       "bothRasterLayers_many": "{{count}} طبقةً نقطية",
-      "bothRasterLayers_other": "{{count}} طبقة نقطية"
+      "bothRasterLayers_other": "{{count}} طبقة نقطية",
+      "savePromptTitle": "هل تريد حفظ المشروع الحالي؟",
+      "savePromptDescription": "يحتوي المشروع الحالي على تغييرات غير محفوظة. هل تريد حفظها قبل فتح المشروع المُسقَط؟"
     },
     "error": {
       "couldNotOpenProject": "تعذر فتح المشروع.",
+      "multipleProjectDrop": "أسقط مشروع GeoLibre واحدًا في كل مرة، من دون ملفات أخرى.",
+      "projectDropNotAllowed": "لا يسمح هذا النشر بالتبديل بين المشاريع.",
       "couldNotImportQgisProject": "تعذّر استيراد مشروع QGIS.",
       "couldNotImportArcgisProject": "تعذّر استيراد مشروع ArcGIS Pro.",
       "invalidProjectUrl": "أدخل عنوان URL صالحًا للمشروع عبر HTTP أو HTTPS.",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} Vektorebene",
       "bothVectorLayers_other": "{{count}} Vektorebenen",
       "bothRasterLayers_one": "{{count}} Rasterebene",
-      "bothRasterLayers_other": "{{count}} Rasterebenen"
+      "bothRasterLayers_other": "{{count}} Rasterebenen",
+      "savePromptTitle": "Aktuelles Projekt speichern?",
+      "savePromptDescription": "Das aktuelle Projekt enthält ungespeicherte Änderungen. Möchten Sie sie speichern, bevor das abgelegte Projekt geöffnet wird?"
     },
     "error": {
       "couldNotOpenProject": "Projekt konnte nicht geöffnet werden.",
+      "multipleProjectDrop": "Legen Sie jeweils nur ein GeoLibre-Projekt ohne weitere Dateien ab.",
+      "projectDropNotAllowed": "Diese Bereitstellung erlaubt keinen Projektwechsel.",
       "couldNotImportQgisProject": "QGIS-Projekt konnte nicht importiert werden.",
       "couldNotImportArcgisProject": "ArcGIS-Pro-Projekt konnte nicht importiert werden.",
       "invalidProjectUrl": "Geben Sie eine gültige HTTP- oder HTTPS-Projekt-URL ein.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2955,10 +2955,14 @@
       "bothVectorLayers_one": "{{count}} vector layer",
       "bothVectorLayers_other": "{{count}} vector layers",
       "bothRasterLayers_one": "{{count}} raster layer",
-      "bothRasterLayers_other": "{{count}} raster layers"
+      "bothRasterLayers_other": "{{count}} raster layers",
+      "savePromptTitle": "Save current project?",
+      "savePromptDescription": "The current project has unsaved changes. Save them before opening the dropped project?"
     },
     "error": {
       "couldNotOpenProject": "Could not open project.",
+      "multipleProjectDrop": "Drop one GeoLibre project at a time, without other files.",
+      "projectDropNotAllowed": "This deployment does not allow switching projects.",
       "couldNotImportQgisProject": "Could not import QGIS project.",
       "couldNotImportArcgisProject": "Could not import ArcGIS Pro project.",
       "invalidProjectUrl": "Enter a valid HTTP or HTTPS project URL.",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} capa vectorial",
       "bothVectorLayers_other": "{{count}} capas vectoriales",
       "bothRasterLayers_one": "{{count}} capa ráster",
-      "bothRasterLayers_other": "{{count}} capas ráster"
+      "bothRasterLayers_other": "{{count}} capas ráster",
+      "savePromptTitle": "¿Guardar el proyecto actual?",
+      "savePromptDescription": "El proyecto actual tiene cambios sin guardar. ¿Desea guardarlos antes de abrir el proyecto soltado?"
     },
     "error": {
       "couldNotOpenProject": "No se pudo abrir el proyecto.",
+      "multipleProjectDrop": "Suelte un solo proyecto de GeoLibre a la vez, sin otros archivos.",
+      "projectDropNotAllowed": "Esta implementación no permite cambiar de proyecto.",
       "couldNotImportQgisProject": "No se pudo importar el proyecto de QGIS.",
       "couldNotImportArcgisProject": "No se pudo importar el proyecto de ArcGIS Pro.",
       "invalidProjectUrl": "Introduzca una URL de proyecto HTTP o HTTPS válida.",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} لایهٔ برداری",
       "bothVectorLayers_other": "{{count}} لایهٔ برداری",
       "bothRasterLayers_one": "{{count}} لایهٔ رستری",
-      "bothRasterLayers_other": "{{count}} لایهٔ رستری"
+      "bothRasterLayers_other": "{{count}} لایهٔ رستری",
+      "savePromptTitle": "پروژهٔ فعلی ذخیره شود؟",
+      "savePromptDescription": "پروژهٔ فعلی تغییرات ذخیره‌نشده دارد. آیا پیش از باز کردن پروژهٔ رهاشده آن‌ها را ذخیره می‌کنید؟"
     },
     "error": {
       "couldNotOpenProject": "باز کردن پروژه ممکن نشد.",
+      "multipleProjectDrop": "هر بار فقط یک پروژهٔ GeoLibre و بدون فایل‌های دیگر رها کنید.",
+      "projectDropNotAllowed": "این استقرار اجازهٔ جابه‌جایی بین پروژه‌ها را نمی‌دهد.",
       "couldNotImportQgisProject": "وارد کردن پروژهٔ QGIS ممکن نشد.",
       "couldNotImportArcgisProject": "وارد کردن پروژهٔ ArcGIS Pro ممکن نشد.",
       "invalidProjectUrl": "یک نشانی معتبر HTTP یا HTTPS برای پروژه وارد کنید.",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} couche vectorielle",
       "bothVectorLayers_other": "{{count}} couches vectorielles",
       "bothRasterLayers_one": "{{count}} couche raster",
-      "bothRasterLayers_other": "{{count}} couches raster"
+      "bothRasterLayers_other": "{{count}} couches raster",
+      "savePromptTitle": "Enregistrer le projet actuel ?",
+      "savePromptDescription": "Le projet actuel contient des modifications non enregistrées. Voulez-vous les enregistrer avant d’ouvrir le projet déposé ?"
     },
     "error": {
       "couldNotOpenProject": "Impossible d'ouvrir le projet.",
+      "multipleProjectDrop": "Déposez un seul projet GeoLibre à la fois, sans autres fichiers.",
+      "projectDropNotAllowed": "Ce déploiement n’autorise pas le changement de projet.",
       "couldNotImportQgisProject": "Impossible d'importer le projet QGIS.",
       "couldNotImportArcgisProject": "Impossible d'importer le projet ArcGIS Pro.",
       "invalidProjectUrl": "Entrez une URL de projet HTTP ou HTTPS valide.",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} वेक्टर लेयर",
       "bothVectorLayers_other": "{{count}} वेक्टर लेयर",
       "bothRasterLayers_one": "{{count}} रैस्टर लेयर",
-      "bothRasterLayers_other": "{{count}} रैस्टर लेयर"
+      "bothRasterLayers_other": "{{count}} रैस्टर लेयर",
+      "savePromptTitle": "वर्तमान प्रोजेक्ट सहेजें?",
+      "savePromptDescription": "वर्तमान प्रोजेक्ट में सहेजे नहीं गए बदलाव हैं। छोड़े गए प्रोजेक्ट को खोलने से पहले उन्हें सहेजें?"
     },
     "error": {
       "couldNotOpenProject": "प्रोजेक्ट नहीं खोला जा सका।",
+      "multipleProjectDrop": "एक बार में केवल एक GeoLibre प्रोजेक्ट छोड़ें, उसके साथ अन्य फ़ाइलें नहीं।",
+      "projectDropNotAllowed": "यह परिनियोजन प्रोजेक्ट बदलने की अनुमति नहीं देता।",
       "couldNotImportQgisProject": "QGIS प्रोजेक्ट आयात नहीं किया जा सका।",
       "couldNotImportArcgisProject": "ArcGIS Pro प्रोजेक्ट आयात नहीं किया जा सका।",
       "invalidProjectUrl": "एक मान्य HTTP या HTTPS प्रोजेक्ट URL दर्ज करें।",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -2883,10 +2883,14 @@
       "addedRasterLayers_other": "Menambahkan {{count}} layer raster ke panel Layer.",
       "addedBoth": "Menambahkan {{vector}} dan {{raster}} ke panel Layer.",
       "bothVectorLayers_other": "{{count}} layer vektor",
-      "bothRasterLayers_other": "{{count}} layer raster"
+      "bothRasterLayers_other": "{{count}} layer raster",
+      "savePromptTitle": "Simpan proyek saat ini?",
+      "savePromptDescription": "Proyek saat ini memiliki perubahan yang belum disimpan. Simpan sebelum membuka proyek yang dijatuhkan?"
     },
     "error": {
       "couldNotOpenProject": "Tidak dapat membuka proyek.",
+      "multipleProjectDrop": "Jatuhkan satu proyek GeoLibre saja dalam satu waktu, tanpa berkas lain.",
+      "projectDropNotAllowed": "Deployment ini tidak mengizinkan pergantian proyek.",
       "couldNotImportQgisProject": "Tidak dapat mengimpor proyek QGIS.",
       "couldNotImportArcgisProject": "Tidak dapat mengimpor proyek ArcGIS Pro.",
       "invalidProjectUrl": "Masukkan URL proyek HTTP atau HTTPS yang valid.",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -2938,7 +2938,7 @@
       "bothRasterLayers_one": "{{count}} livello raster",
       "bothRasterLayers_other": "{{count}} livelli raster",
       "savePromptTitle": "Salvare il progetto corrente?",
-      "savePromptDescription": "Il progetto corrente contiene modifiche non salvate. Salvarle prima di aprire il progetto rilasciato?"
+      "savePromptDescription": "Il progetto corrente contiene modifiche non salvate. Salvarle prima di aprire il progetto trascinato?"
     },
     "error": {
       "couldNotOpenProject": "Impossibile aprire il progetto.",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} livello vettoriale",
       "bothVectorLayers_other": "{{count}} livelli vettoriali",
       "bothRasterLayers_one": "{{count}} livello raster",
-      "bothRasterLayers_other": "{{count}} livelli raster"
+      "bothRasterLayers_other": "{{count}} livelli raster",
+      "savePromptTitle": "Salvare il progetto corrente?",
+      "savePromptDescription": "Il progetto corrente contiene modifiche non salvate. Salvarle prima di aprire il progetto rilasciato?"
     },
     "error": {
       "couldNotOpenProject": "Impossibile aprire il progetto.",
+      "multipleProjectDrop": "Rilascia un solo progetto GeoLibre alla volta, senza altri file.",
+      "projectDropNotAllowed": "Questa distribuzione non consente di cambiare progetto.",
       "couldNotImportQgisProject": "Impossibile importare il progetto QGIS.",
       "couldNotImportArcgisProject": "Impossibile importare il progetto ArcGIS Pro.",
       "invalidProjectUrl": "Inserisci un URL di progetto HTTP o HTTPS valido.",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -2883,10 +2883,14 @@
       "addedRasterLayers_other": "{{count}} 件のラスターレイヤーをレイヤーパネルに追加しました。",
       "addedBoth": "{{vector}} と {{raster}} をレイヤーパネルに追加しました。",
       "bothVectorLayers_other": "ベクターレイヤー {{count}} 件",
-      "bothRasterLayers_other": "ラスターレイヤー {{count}} 件"
+      "bothRasterLayers_other": "ラスターレイヤー {{count}} 件",
+      "savePromptTitle": "現在のプロジェクトを保存しますか？",
+      "savePromptDescription": "現在のプロジェクトには未保存の変更があります。ドロップしたプロジェクトを開く前に保存しますか？"
     },
     "error": {
       "couldNotOpenProject": "プロジェクトを開けませんでした。",
+      "multipleProjectDrop": "他のファイルを含めず、GeoLibre プロジェクトを一度に1つだけドロップしてください。",
+      "projectDropNotAllowed": "このデプロイではプロジェクトを切り替えられません。",
       "couldNotImportQgisProject": "QGIS プロジェクトをインポートできませんでした。",
       "couldNotImportArcgisProject": "ArcGIS Pro プロジェクトをインポートできませんでした。",
       "invalidProjectUrl": "有効な HTTP または HTTPS のプロジェクト URL を入力してください。",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} ვექტორული შრე",
       "bothVectorLayers_other": "{{count}} ვექტორული შრე",
       "bothRasterLayers_one": "{{count}} რასტრული შრე",
-      "bothRasterLayers_other": "{{count}} რასტრული შრე"
+      "bothRasterLayers_other": "{{count}} რასტრული შრე",
+      "savePromptTitle": "შეინახოს მიმდინარე პროექტი?",
+      "savePromptDescription": "მიმდინარე პროექტს შეუნახავი ცვლილებები აქვს. შეინახოს ისინი ჩამოგდებული პროექტის გახსნამდე?"
     },
     "error": {
       "couldNotOpenProject": "პროექტის გახსნა ვერ მოხერხდა.",
+      "multipleProjectDrop": "ერთ ჯერზე ჩამოაგდეთ მხოლოდ ერთი GeoLibre პროექტი, სხვა ფაილების გარეშე.",
+      "projectDropNotAllowed": "ეს განთავსება პროექტებს შორის გადართვას არ უშვებს.",
       "couldNotImportQgisProject": "QGIS პროექტის იმპორტი ვერ მოხერხდა.",
       "couldNotImportArcgisProject": "ArcGIS Pro პროექტის იმპორტი ვერ მოხერხდა.",
       "invalidProjectUrl": "შეიყვანეთ სწორი HTTP ან HTTPS პროექტის URL.",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -2883,10 +2883,14 @@
       "addedRasterLayers_other": "래스터 레이어 {{count}}개를 레이어 패널에 추가했습니다.",
       "addedBoth": "{{vector}}와(과) {{raster}}을(를) 레이어 패널에 추가했습니다.",
       "bothVectorLayers_other": "벡터 레이어 {{count}}개",
-      "bothRasterLayers_other": "래스터 레이어 {{count}}개"
+      "bothRasterLayers_other": "래스터 레이어 {{count}}개",
+      "savePromptTitle": "현재 프로젝트를 저장할까요?",
+      "savePromptDescription": "현재 프로젝트에 저장하지 않은 변경 사항이 있습니다. 드롭한 프로젝트를 열기 전에 저장할까요?"
     },
     "error": {
       "couldNotOpenProject": "프로젝트를 열 수 없습니다.",
+      "multipleProjectDrop": "다른 파일 없이 GeoLibre 프로젝트 하나만 드롭하세요.",
+      "projectDropNotAllowed": "이 배포에서는 프로젝트를 전환할 수 없습니다.",
       "couldNotImportQgisProject": "QGIS 프로젝트를 가져올 수 없습니다.",
       "couldNotImportArcgisProject": "ArcGIS Pro 프로젝트를 가져올 수 없습니다.",
       "invalidProjectUrl": "유효한 HTTP 또는 HTTPS 프로젝트 URL을 입력하세요.",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} vectorlaag",
       "bothVectorLayers_other": "{{count}} vectorlagen",
       "bothRasterLayers_one": "{{count}} rasterlaag",
-      "bothRasterLayers_other": "{{count}} rasterlagen"
+      "bothRasterLayers_other": "{{count}} rasterlagen",
+      "savePromptTitle": "Huidig project opslaan?",
+      "savePromptDescription": "Het huidige project bevat niet-opgeslagen wijzigingen. Wilt u die opslaan voordat het neergezette project wordt geopend?"
     },
     "error": {
       "couldNotOpenProject": "Het project kon niet worden geopend.",
+      "multipleProjectDrop": "Zet één GeoLibre-project tegelijk neer, zonder andere bestanden.",
+      "projectDropNotAllowed": "Deze implementatie staat wisselen van project niet toe.",
       "couldNotImportQgisProject": "Kon het QGIS-project niet importeren.",
       "couldNotImportArcgisProject": "Kon het ArcGIS Pro-project niet importeren.",
       "invalidProjectUrl": "Voer een geldige HTTP- of HTTPS-project-URL in.",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} camada vetorial",
       "bothVectorLayers_other": "{{count}} camadas vetoriais",
       "bothRasterLayers_one": "{{count}} camada raster",
-      "bothRasterLayers_other": "{{count}} camadas raster"
+      "bothRasterLayers_other": "{{count}} camadas raster",
+      "savePromptTitle": "Salvar o projeto atual?",
+      "savePromptDescription": "O projeto atual tem alterações não salvas. Deseja salvá-las antes de abrir o projeto solto?"
     },
     "error": {
       "couldNotOpenProject": "Não foi possível abrir o projeto.",
+      "multipleProjectDrop": "Solte um projeto GeoLibre de cada vez, sem outros arquivos.",
+      "projectDropNotAllowed": "Esta implantação não permite trocar de projeto.",
       "couldNotImportQgisProject": "Não foi possível importar o projeto do QGIS.",
       "couldNotImportArcgisProject": "Não foi possível importar o projeto do ArcGIS Pro.",
       "invalidProjectUrl": "Digite uma URL de projeto HTTP ou HTTPS válida.",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -3042,10 +3042,14 @@
       "bothRasterLayers_one": "{{count}} растровый слой",
       "bothRasterLayers_few": "{{count}} растровых слоя",
       "bothRasterLayers_many": "{{count}} растровых слоёв",
-      "bothRasterLayers_other": "{{count}} растрового слоя"
+      "bothRasterLayers_other": "{{count}} растрового слоя",
+      "savePromptTitle": "Сохранить текущий проект?",
+      "savePromptDescription": "В текущем проекте есть несохранённые изменения. Сохранить их перед открытием перетащенного проекта?"
     },
     "error": {
       "couldNotOpenProject": "Не удалось открыть проект.",
+      "multipleProjectDrop": "Перетаскивайте только один проект GeoLibre за раз, без других файлов.",
+      "projectDropNotAllowed": "В этом развёртывании переключение проектов запрещено.",
       "couldNotImportQgisProject": "Не удалось импортировать проект QGIS.",
       "couldNotImportArcgisProject": "Не удалось импортировать проект ArcGIS Pro.",
       "invalidProjectUrl": "Введите корректный URL проекта (HTTP или HTTPS).",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -2883,10 +2883,14 @@
       "addedRasterLayers_other": "เพิ่มเลเยอร์แรสเตอร์ {{count}} เลเยอร์ลงในแผงเลเยอร์แล้ว",
       "addedBoth": "เพิ่ม {{vector}} และ {{raster}} ลงในแผงเลเยอร์แล้ว",
       "bothVectorLayers_other": "เลเยอร์เวกเตอร์ {{count}} เลเยอร์",
-      "bothRasterLayers_other": "เลเยอร์แรสเตอร์ {{count}} เลเยอร์"
+      "bothRasterLayers_other": "เลเยอร์แรสเตอร์ {{count}} เลเยอร์",
+      "savePromptTitle": "บันทึกโปรเจกต์ปัจจุบันหรือไม่",
+      "savePromptDescription": "โปรเจกต์ปัจจุบันมีการเปลี่ยนแปลงที่ยังไม่ได้บันทึก ต้องการบันทึกก่อนเปิดโปรเจกต์ที่วางหรือไม่"
     },
     "error": {
       "couldNotOpenProject": "ไม่สามารถเปิดโปรเจกต์ได้",
+      "multipleProjectDrop": "วางโปรเจกต์ GeoLibre ครั้งละหนึ่งโปรเจกต์โดยไม่มีไฟล์อื่น",
+      "projectDropNotAllowed": "การปรับใช้นี้ไม่อนุญาตให้สลับโปรเจกต์",
       "couldNotImportQgisProject": "ไม่สามารถนำเข้าโปรเจกต์ QGIS ได้",
       "couldNotImportArcgisProject": "ไม่สามารถนำเข้าโปรเจกต์ ArcGIS Pro ได้",
       "invalidProjectUrl": "ป้อน URL ของโปรเจกต์แบบ HTTP หรือ HTTPS ที่ถูกต้อง",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -2936,10 +2936,14 @@
       "bothVectorLayers_one": "{{count}} vektör katmanı",
       "bothVectorLayers_other": "{{count}} vektör katmanı",
       "bothRasterLayers_one": "{{count}} raster katmanı",
-      "bothRasterLayers_other": "{{count}} raster katmanı"
+      "bothRasterLayers_other": "{{count}} raster katmanı",
+      "savePromptTitle": "Geçerli proje kaydedilsin mi?",
+      "savePromptDescription": "Geçerli projede kaydedilmemiş değişiklikler var. Bırakılan projeyi açmadan önce kaydetmek ister misiniz?"
     },
     "error": {
       "couldNotOpenProject": "Proje açılamadı.",
+      "multipleProjectDrop": "Başka dosya olmadan tek seferde bir GeoLibre projesi bırakın.",
+      "projectDropNotAllowed": "Bu dağıtım projeler arasında geçişe izin vermiyor.",
       "couldNotImportQgisProject": "QGIS projesi içe aktarılamadı.",
       "couldNotImportArcgisProject": "ArcGIS Pro projesi içe aktarılamadı.",
       "invalidProjectUrl": "Geçerli bir HTTP veya HTTPS proje URL'si girin.",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -2883,7 +2883,9 @@
       "overlayTitle": "__PH0__ lớp raster",
       "overlaySubtext": "Dữ liệu của bạn sẽ được thêm ngay vào bảng điều khiển Lớp.",
       "addedLayer": "Đã thêm \"{{name}}\" vào bảng điều khiển Lớp.",
-      "addedVectorLayers_other": "Đã thêm các lớp vectơ {{count}} vào bảng điều khiển Lớp."
+      "addedVectorLayers_other": "Đã thêm các lớp vectơ {{count}} vào bảng điều khiển Lớp.",
+      "savePromptTitle": "Lưu dự án hiện tại?",
+      "savePromptDescription": "Dự án hiện tại có thay đổi chưa lưu. Lưu trước khi mở dự án được thả vào?"
     },
     "error": {
       "couldNotOpenOsmPbf": "Không thể mở tệp OSM PBF.",
@@ -2894,6 +2896,8 @@
       "scenegraphOutOfRange": "Kinh độ phải nằm trong khoảng từ -180 đến 180 và vĩ độ nằm trong khoảng từ -90 đến 90.",
       "scenegraphNoPointFeatures": "GeoJSON không có tính năng điểm nào để đặt mô hình.",
       "couldNotOpenProject": "Không thể mở dự án.",
+      "multipleProjectDrop": "Chỉ thả một dự án GeoLibre mỗi lần, không kèm tệp khác.",
+      "projectDropNotAllowed": "Bản triển khai này không cho phép chuyển đổi dự án.",
       "couldNotImportQgisProject": "Không thể nhập dự án QGIS.",
       "couldNotImportArcgisProject": "Không thể nhập dự án ArcGIS Pro.",
       "invalidProjectUrl": "Nhập URL dự án HTTP hoặc HTTPS hợp lệ.",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -2883,10 +2883,14 @@
       "addedRasterLayers_other": "已将 {{count}} 个栅格图层添加到图层面板。",
       "addedBoth": "已将 {{vector}} 和 {{raster}} 添加到图层面板。",
       "bothVectorLayers_other": "{{count}} 个矢量图层",
-      "bothRasterLayers_other": "{{count}} 个栅格图层"
+      "bothRasterLayers_other": "{{count}} 个栅格图层",
+      "savePromptTitle": "保存当前项目？",
+      "savePromptDescription": "当前项目有未保存的更改。是否在打开拖放的项目之前保存？"
     },
     "error": {
       "couldNotOpenProject": "无法打开项目。",
+      "multipleProjectDrop": "请一次只拖放一个 GeoLibre 项目，不要同时拖放其他文件。",
+      "projectDropNotAllowed": "此部署不允许切换项目。",
       "couldNotImportQgisProject": "无法导入 QGIS 项目。",
       "couldNotImportArcgisProject": "无法导入 ArcGIS Pro 项目。",
       "invalidProjectUrl": "请输入有效的 HTTP 或 HTTPS 项目 URL。",

--- a/apps/geolibre-desktop/src/lib/dropped-project.ts
+++ b/apps/geolibre-desktop/src/lib/dropped-project.ts
@@ -10,7 +10,7 @@ interface ResolveDroppedProjectOptions {
   project: GeoLibreProject;
   projectGeneration: number;
   projectFingerprint: string | null;
-  isLatestOperation: () => boolean;
+  isCurrentOperation: () => boolean;
   getWorkspaceState: () => DroppedProjectWorkspaceState;
   resolveProject: (project: GeoLibreProject) => Promise<GeoLibreProject>;
   loadProject: (project: GeoLibreProject) => void;
@@ -22,17 +22,17 @@ export async function resolveDroppedProjectIfCurrent({
   project,
   projectGeneration,
   projectFingerprint,
-  isLatestOperation,
+  isCurrentOperation,
   getWorkspaceState,
   resolveProject,
   loadProject,
   workspaceChanged,
 }: ResolveDroppedProjectOptions): Promise<boolean> {
-  if (!isLatestOperation() || getWorkspaceState().projectGeneration !== projectGeneration)
-    return false;
+  if (!isCurrentOperation()) return false;
   const resolvedProject = await resolveProject(project);
+  if (!isCurrentOperation()) return false;
   const current = getWorkspaceState();
-  if (!isLatestOperation() || current.projectGeneration !== projectGeneration) return false;
+  if (current.projectGeneration !== projectGeneration) return false;
   const changed =
     projectFingerprint === null
       ? current.isDirty

--- a/apps/geolibre-desktop/src/lib/dropped-project.ts
+++ b/apps/geolibre-desktop/src/lib/dropped-project.ts
@@ -1,0 +1,38 @@
+import type { GeoLibreProject } from "@geolibre/core";
+
+export interface DroppedProjectWorkspaceState {
+  projectGeneration: number;
+  projectFingerprint: string;
+}
+
+interface ResolveDroppedProjectOptions {
+  project: GeoLibreProject;
+  projectGeneration: number;
+  projectFingerprint: string;
+  getWorkspaceState: () => DroppedProjectWorkspaceState;
+  resolveProject: (project: GeoLibreProject) => Promise<GeoLibreProject>;
+  loadProject: (project: GeoLibreProject) => void;
+  workspaceChanged: (state: DroppedProjectWorkspaceState) => void;
+}
+
+/** Resolve remote layers without replacing a project that changed while awaiting them. */
+export async function resolveDroppedProjectIfCurrent({
+  project,
+  projectGeneration,
+  projectFingerprint,
+  getWorkspaceState,
+  resolveProject,
+  loadProject,
+  workspaceChanged,
+}: ResolveDroppedProjectOptions): Promise<boolean> {
+  if (getWorkspaceState().projectGeneration !== projectGeneration) return false;
+  const resolvedProject = await resolveProject(project);
+  const current = getWorkspaceState();
+  if (current.projectGeneration !== projectGeneration) return false;
+  if (current.projectFingerprint !== projectFingerprint) {
+    workspaceChanged(current);
+    return false;
+  }
+  loadProject(resolvedProject);
+  return true;
+}

--- a/apps/geolibre-desktop/src/lib/dropped-project.ts
+++ b/apps/geolibre-desktop/src/lib/dropped-project.ts
@@ -2,17 +2,19 @@ import type { GeoLibreProject } from "@geolibre/core";
 
 export interface DroppedProjectWorkspaceState {
   projectGeneration: number;
-  projectFingerprint: string;
+  isDirty: boolean;
+  projectFingerprint: string | null;
 }
 
 interface ResolveDroppedProjectOptions {
   project: GeoLibreProject;
   projectGeneration: number;
-  projectFingerprint: string;
+  projectFingerprint: string | null;
+  isLatestOperation: () => boolean;
   getWorkspaceState: () => DroppedProjectWorkspaceState;
   resolveProject: (project: GeoLibreProject) => Promise<GeoLibreProject>;
   loadProject: (project: GeoLibreProject) => void;
-  workspaceChanged: (state: DroppedProjectWorkspaceState) => void;
+  workspaceChanged: (state: DroppedProjectWorkspaceState, project: GeoLibreProject) => void;
 }
 
 /** Resolve remote layers without replacing a project that changed while awaiting them. */
@@ -20,17 +22,23 @@ export async function resolveDroppedProjectIfCurrent({
   project,
   projectGeneration,
   projectFingerprint,
+  isLatestOperation,
   getWorkspaceState,
   resolveProject,
   loadProject,
   workspaceChanged,
 }: ResolveDroppedProjectOptions): Promise<boolean> {
-  if (getWorkspaceState().projectGeneration !== projectGeneration) return false;
+  if (!isLatestOperation() || getWorkspaceState().projectGeneration !== projectGeneration)
+    return false;
   const resolvedProject = await resolveProject(project);
   const current = getWorkspaceState();
-  if (current.projectGeneration !== projectGeneration) return false;
-  if (current.projectFingerprint !== projectFingerprint) {
-    workspaceChanged(current);
+  if (!isLatestOperation() || current.projectGeneration !== projectGeneration) return false;
+  const changed =
+    projectFingerprint === null
+      ? current.isDirty
+      : current.projectFingerprint !== projectFingerprint;
+  if (changed) {
+    workspaceChanged(current, resolvedProject);
     return false;
   }
   loadProject(resolvedProject);

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -155,6 +155,11 @@ const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
   },
 ];
 
+/** Project extension handled as a workspace switch by drag-and-drop. */
+export function isGeoLibreProjectFileName(path: string): boolean {
+  return path.toLowerCase().endsWith(".geolibre.json");
+}
+
 interface SaveTextFileOptions {
   defaultName: string;
   filters: FileDialogFilter[];
@@ -608,7 +613,7 @@ export async function readLocalFileBytes(path: string): Promise<Uint8Array<Array
  * @param path - Absolute local path to read.
  * @returns The file's decoded UTF-8 text.
  */
-async function readLocalFileText(path: string): Promise<string> {
+export async function readLocalFileText(path: string): Promise<string> {
   try {
     return await readTextFile(path);
   } catch (error) {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -157,7 +157,7 @@ const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
 
 /** Project extension handled as a workspace switch by drag-and-drop. */
 export function isGeoLibreProjectFileName(path: string): boolean {
-  const name = path.toLowerCase();
+  const name = browserSafeFileName(path).toLowerCase();
   return name.endsWith(".geolibre") || name.endsWith(".geolibre.json");
 }
 
@@ -444,13 +444,8 @@ function pathWithoutExtension(path: string): string {
   return path.replace(/\.[^.\\/]+$/, "");
 }
 
-function isGeoLibreProjectFile(path: string): boolean {
-  const name = browserSafeFileName(path).toLowerCase();
-  return name.endsWith(".geolibre") || name.endsWith(".geolibre.json");
-}
-
 function isVectorFileName(path: string): boolean {
-  if (isGeoLibreProjectFile(path)) return false;
+  if (isGeoLibreProjectFileName(path)) return false;
   if (browserSafeFileName(path).toLowerCase().endsWith(".shp.xml")) return false;
   // Rasters are handled by the raster drop path, not the DuckDB vector loader.
   if (isRasterFileName(path)) return false;

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -157,7 +157,8 @@ const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
 
 /** Project extension handled as a workspace switch by drag-and-drop. */
 export function isGeoLibreProjectFileName(path: string): boolean {
-  return path.toLowerCase().endsWith(".geolibre.json");
+  const name = path.toLowerCase();
+  return name.endsWith(".geolibre") || name.endsWith(".geolibre.json");
 }
 
 interface SaveTextFileOptions {

--- a/tests/project-file-drop.test.ts
+++ b/tests/project-file-drop.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { isGeoLibreProjectFileName } from "../apps/geolibre-desktop/src/lib/tauri-io";
+import { resolveDroppedProjectIfCurrent } from "../apps/geolibre-desktop/src/lib/dropped-project";
+import type { GeoLibreProject } from "@geolibre/core";
 
 test("recognizes GeoLibre project files dropped onto the app", () => {
   assert.equal(isGeoLibreProjectFileName("map.geolibre.json"), true);
@@ -15,4 +17,36 @@ test("does not divert ordinary JSON datasets into the project loader", () => {
   assert.equal(isGeoLibreProjectFileName("map.geojson"), false);
   assert.equal(isGeoLibreProjectFileName("map.geolibre.json.backup"), false);
   assert.equal(isGeoLibreProjectFileName("map.geolibre.backup"), false);
+});
+
+test("does not replace edits made while dropped project layers resolve", async () => {
+  const dropped = { version: 1, name: "Dropped", layers: [] } as unknown as GeoLibreProject;
+  let workspace = { projectGeneration: 4, projectFingerprint: "before-edit" };
+  let finishResolution: ((project: GeoLibreProject) => void) | undefined;
+  let loaded = false;
+  let prompted = false;
+
+  const loading = resolveDroppedProjectIfCurrent({
+    project: dropped,
+    projectGeneration: 4,
+    projectFingerprint: "before-edit",
+    getWorkspaceState: () => workspace,
+    resolveProject: () =>
+      new Promise((resolve) => {
+        finishResolution = resolve;
+      }),
+    loadProject: () => {
+      loaded = true;
+    },
+    workspaceChanged: () => {
+      prompted = true;
+    },
+  });
+
+  workspace = { ...workspace, projectFingerprint: "after-edit" };
+  finishResolution?.(dropped);
+
+  assert.equal(await loading, false);
+  assert.equal(loaded, false);
+  assert.equal(prompted, true);
 });

--- a/tests/project-file-drop.test.ts
+++ b/tests/project-file-drop.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isGeoLibreProjectFileName } from "../apps/geolibre-desktop/src/lib/tauri-io";
+
+test("recognizes GeoLibre project files dropped onto the app", () => {
+  assert.equal(isGeoLibreProjectFileName("map.geolibre.json"), true);
+  assert.equal(isGeoLibreProjectFileName("MAP.GEOLIBRE.JSON"), true);
+  assert.equal(isGeoLibreProjectFileName("/maps/map.geolibre.json"), true);
+});
+
+test("does not divert ordinary JSON datasets into the project loader", () => {
+  assert.equal(isGeoLibreProjectFileName("map.json"), false);
+  assert.equal(isGeoLibreProjectFileName("map.geojson"), false);
+  assert.equal(isGeoLibreProjectFileName("map.geolibre.json.backup"), false);
+});

--- a/tests/project-file-drop.test.ts
+++ b/tests/project-file-drop.test.ts
@@ -5,6 +5,7 @@ import { isGeoLibreProjectFileName } from "../apps/geolibre-desktop/src/lib/taur
 
 test("recognizes GeoLibre project files dropped onto the app", () => {
   assert.equal(isGeoLibreProjectFileName("map.geolibre.json"), true);
+  assert.equal(isGeoLibreProjectFileName("map.geolibre"), true);
   assert.equal(isGeoLibreProjectFileName("MAP.GEOLIBRE.JSON"), true);
   assert.equal(isGeoLibreProjectFileName("/maps/map.geolibre.json"), true);
 });
@@ -13,4 +14,5 @@ test("does not divert ordinary JSON datasets into the project loader", () => {
   assert.equal(isGeoLibreProjectFileName("map.json"), false);
   assert.equal(isGeoLibreProjectFileName("map.geojson"), false);
   assert.equal(isGeoLibreProjectFileName("map.geolibre.json.backup"), false);
+  assert.equal(isGeoLibreProjectFileName("map.geolibre.backup"), false);
 });

--- a/tests/project-file-drop.test.ts
+++ b/tests/project-file-drop.test.ts
@@ -21,7 +21,11 @@ test("does not divert ordinary JSON datasets into the project loader", () => {
 
 test("does not replace edits made while dropped project layers resolve", async () => {
   const dropped = { version: 1, name: "Dropped", layers: [] } as unknown as GeoLibreProject;
-  let workspace = { projectGeneration: 4, projectFingerprint: "before-edit" };
+  let workspace = {
+    projectGeneration: 4,
+    isDirty: true,
+    projectFingerprint: "before-edit",
+  };
   let finishResolution: ((project: GeoLibreProject) => void) | undefined;
   let loaded = false;
   let prompted = false;
@@ -30,6 +34,7 @@ test("does not replace edits made while dropped project layers resolve", async (
     project: dropped,
     projectGeneration: 4,
     projectFingerprint: "before-edit",
+    isLatestOperation: () => true,
     getWorkspaceState: () => workspace,
     resolveProject: () =>
       new Promise((resolve) => {
@@ -49,4 +54,34 @@ test("does not replace edits made while dropped project layers resolve", async (
   assert.equal(await loading, false);
   assert.equal(loaded, false);
   assert.equal(prompted, true);
+});
+
+test("does not let an older overlapping drop replace the latest one", async () => {
+  const dropped = { version: 1, name: "Older", layers: [] } as unknown as GeoLibreProject;
+  const workspace = { projectGeneration: 2, isDirty: false, projectFingerprint: null };
+  let latest = true;
+  let finishResolution: ((project: GeoLibreProject) => void) | undefined;
+  let loaded = false;
+
+  const loading = resolveDroppedProjectIfCurrent({
+    project: dropped,
+    projectGeneration: 2,
+    projectFingerprint: null,
+    isLatestOperation: () => latest,
+    getWorkspaceState: () => workspace,
+    resolveProject: () =>
+      new Promise((resolve) => {
+        finishResolution = resolve;
+      }),
+    loadProject: () => {
+      loaded = true;
+    },
+    workspaceChanged: () => undefined,
+  });
+
+  latest = false;
+  finishResolution?.(dropped);
+
+  assert.equal(await loading, false);
+  assert.equal(loaded, false);
 });

--- a/tests/project-file-drop.test.ts
+++ b/tests/project-file-drop.test.ts
@@ -34,7 +34,7 @@ test("does not replace edits made while dropped project layers resolve", async (
     project: dropped,
     projectGeneration: 4,
     projectFingerprint: "before-edit",
-    isLatestOperation: () => true,
+    isCurrentOperation: () => true,
     getWorkspaceState: () => workspace,
     resolveProject: () =>
       new Promise((resolve) => {
@@ -67,7 +67,7 @@ test("does not let an older overlapping drop replace the latest one", async () =
     project: dropped,
     projectGeneration: 2,
     projectFingerprint: null,
-    isLatestOperation: () => latest,
+    isCurrentOperation: () => latest,
     getWorkspaceState: () => workspace,
     resolveProject: () =>
       new Promise((resolve) => {


### PR DESCRIPTION
## Summary

- recognize `.geolibre.json` files before the vector and raster import pipeline
- open dropped projects from browser files and native desktop paths
- preserve the save, discard, or cancel prompt when the current project has unsaved changes
- surface project validation errors for malformed project files

## Verification

- `npm run test:frontend` (7,269 passed, 1 skipped)
- `npm run build -w geolibre-desktop`
- `conda run -n geo pre-commit run --files ...`
- Playwright browser verification in light and dark themes, including clean load, dirty-project cancel/discard, and malformed project handling

Fixes #2154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for opening `.geolibre` and `.geolibre.json` project files on desktop and in browsers.
  * Added prompts to save, discard, or cancel when unsaved changes exist.
  * Added validation for single-project drops and deployments that restrict project switching.

* **Bug Fixes**
  * Improved recognition of project files regardless of filename capitalization.

* **Localization**
  * Added translated prompts and validation messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->