### PR TITLE
Fix remote zipped Shapefiles in the web app

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1095,22 +1095,24 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
             }
           }
         }
-        // DuckDB-WASM cannot read `/vsizip//vsicurl/` in a browser. Download
-        // remote Shapefile archives first so maplibre-gl-vector receives the
-        // same File shape as a working local drop and can unzip/register its
-        // components itself. Leave every non-ZIP URL alone so formats such as
-        // GeoParquet retain their direct range-read path.
-        try {
-          const archive = await fetchBrowserShapefileZip(url, budget());
-          if (archive) return archive;
-        } catch (error) {
-          // GitHub's /raw route rejects browser CORS, so its existing guarded
-          // proxy gets one chance below. For every other origin, preserve the
-          // browser's real download/CORS failure instead of falling through to
-          // DuckDB's misleading "does not exist in the file system" error.
-          if (!githubRawVectorProxyUrl(url)) throw error;
-        }
         const proxyUrl = githubRawVectorProxyUrl(url);
+        if (!isTauriRuntime()) {
+          // DuckDB-WASM cannot read `/vsizip//vsicurl/` in a browser. Download
+          // remote Shapefile archives first so maplibre-gl-vector receives the
+          // same File shape as a working local drop and can unzip/register its
+          // components itself. Leave every non-ZIP URL alone so formats such as
+          // GeoParquet retain their direct range-read path.
+          try {
+            const archive = await fetchBrowserShapefileZip(url, budget());
+            if (archive) return archive;
+          } catch (error) {
+            // GitHub's /raw route rejects browser CORS, so its existing guarded
+            // proxy gets one chance below. For every other origin, preserve the
+            // browser's real download/CORS failure instead of falling through to
+            // DuckDB's misleading "does not exist in the file system" error.
+            if (!proxyUrl) throw error;
+          }
+        }
         if (!proxyUrl) return null;
         const response = await fetch(proxyUrl, { signal: budget() });
         if (!response.ok) {

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -129,6 +129,7 @@ import { openExternalLink } from "../lib/open-external";
 import { fetchUrlBytes } from "../lib/native-http";
 import {
   dedupeVectorUrlFetch,
+  fetchBrowserShapefileZip,
   isBlockedUrlError,
   vectorDownloadFileName,
 } from "../lib/vector-url-fetch";
@@ -1093,6 +1094,21 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
               // same guarded proxy used by the web build.
             }
           }
+        }
+        // DuckDB-WASM cannot read `/vsizip//vsicurl/` in a browser. Download
+        // remote Shapefile archives first so maplibre-gl-vector receives the
+        // same File shape as a working local drop and can unzip/register its
+        // components itself. Leave every non-ZIP URL alone so formats such as
+        // GeoParquet retain their direct range-read path.
+        try {
+          const archive = await fetchBrowserShapefileZip(url, budget());
+          if (archive) return archive;
+        } catch (error) {
+          // GitHub's /raw route rejects browser CORS, so its existing guarded
+          // proxy gets one chance below. For every other origin, preserve the
+          // browser's real download/CORS failure instead of falling through to
+          // DuckDB's misleading "does not exist in the file system" error.
+          if (!githubRawVectorProxyUrl(url)) throw error;
         }
         const proxyUrl = githubRawVectorProxyUrl(url);
         if (!proxyUrl) return null;

--- a/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
@@ -95,6 +95,46 @@ export function vectorDownloadFileName(url: string, fallback = "data"): string {
   return /\.[A-Za-z0-9]+$/.test(decoded) ? decoded : fallback;
 }
 
+/**
+ * Whether a remote vector URL names a zipped Shapefile archive.
+ *
+ * Query strings and fragments are ignored so signed/download URLs keep their
+ * format, while a `.zip` that appears only in a query value does not turn an
+ * unrelated endpoint into a Shapefile.
+ */
+export function isZippedShapefileUrl(value: string): boolean {
+  try {
+    return /\.zip$/i.test(new URL(value).pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Downloads a remote zipped Shapefile into a browser {@link File}.
+ *
+ * DuckDB-WASM cannot open GDAL's `/vsizip//vsicurl/` path in the browser. A
+ * local `File`, however, follows maplibre-gl-vector's working archive path: it
+ * unzips the archive in JavaScript and registers the Shapefile components with
+ * DuckDB individually. Non-ZIP URLs return null so GeoParquet and other remote
+ * formats retain their streaming/range-read path.
+ */
+export async function fetchBrowserShapefileZip(
+  url: string,
+  signal?: AbortSignal,
+  fetchImpl: typeof fetch = fetch,
+): Promise<File | null> {
+  if (!isZippedShapefileUrl(url)) return null;
+
+  const response = await fetchImpl(url, { signal });
+  if (!response.ok) {
+    throw new Error(
+      `Could not download zipped Shapefile: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  return new File([await response.blob()], vectorDownloadFileName(url));
+}
+
 function safeDecode(value: string): string {
   try {
     return decodeURIComponent(value);

--- a/tests/vector-url-fetch.test.ts
+++ b/tests/vector-url-fetch.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import {
   dedupeVectorUrlFetch,
+  fetchBrowserShapefileZip,
   isBlockedUrlError,
+  isZippedShapefileUrl,
   resetVectorUrlFetchDedupe,
   vectorDownloadFileName,
 } from "../apps/geolibre-desktop/src/lib/vector-url-fetch";
@@ -137,6 +139,59 @@ describe("vectorDownloadFileName", () => {
 
   it("falls back on an unparseable URL", () => {
     assert.equal(vectorDownloadFileName("not a url"), "data");
+  });
+});
+
+describe("remote zipped Shapefiles", () => {
+  const ZIP_URL = "https://example.com/data/roads.ZIP?download=1#archive";
+
+  it("recognizes a .zip pathname but not a query-string suffix", () => {
+    assert.equal(isZippedShapefileUrl(ZIP_URL), true);
+    assert.equal(isZippedShapefileUrl("https://example.com/download?file=roads.zip"), false);
+    assert.equal(isZippedShapefileUrl("https://example.com/roads.kmz"), false);
+    assert.equal(isZippedShapefileUrl("not a url"), false);
+  });
+
+  it("materializes a remote archive as a named File", async () => {
+    const fetchImpl: typeof fetch = async (input, init) => {
+      assert.equal(input, ZIP_URL);
+      assert.ok(init?.signal);
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      });
+    };
+
+    const file = await fetchBrowserShapefileZip(ZIP_URL, AbortSignal.timeout(1_000), fetchImpl);
+
+    assert.ok(file);
+    assert.equal(file.name, "roads.ZIP");
+    assert.equal(file.size, 3);
+  });
+
+  it("leaves non-ZIP URLs on their direct remote path", async () => {
+    let fetched = false;
+    const result = await fetchBrowserShapefileZip(
+      "https://example.com/roads.parquet",
+      undefined,
+      async () => {
+        fetched = true;
+        return new Response();
+      },
+    );
+    assert.equal(result, null);
+    assert.equal(fetched, false);
+  });
+
+  it("surfaces the real HTTP failure before DuckDB sees the URL", async () => {
+    await assert.rejects(
+      fetchBrowserShapefileZip(
+        ZIP_URL,
+        undefined,
+        async () => new Response(null, { status: 403, statusText: "Forbidden" }),
+      ),
+      /Could not download zipped Shapefile: HTTP 403 Forbidden/,
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #2153

## Summary

- download remote `.zip` Shapefiles in browser builds before vector ingestion
- hand the resulting `File` to the existing JavaScript unzip and DuckDB component-registration path
- preserve direct remote access for non-ZIP formats such as GeoParquet
- surface the real HTTP or CORS failure instead of DuckDB's misleading `/vsizip//vsicurl/` filesystem error

## Verification

- loaded the issue's Piedmont archive from its HTTPS URL as 189 features
- saved and reopened the resulting GeoLibre project successfully
- verified light and dark themes with Diagnostics at 0
- `node --import tsx --test tests/vector-url-fetch.test.ts`
- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/src/hooks/usePlugins.ts apps/geolibre-desktop/src/lib/vector-url-fetch.ts tests/vector-url-fetch.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote zipped Shapefiles can now be downloaded and loaded directly into the map.
  * ZIP URLs are recognized even when they include query parameters or fragments.
  * Downloads support cancellation and provide clear errors for failed requests.

* **Bug Fixes**
  * Preserved existing handling for non-ZIP vector URLs, including direct loading behavior.
  * Improved compatibility between remote zipped Shapefiles and local file-based map imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->