### PR TITLE
Fix marker styles when loading partial project styles

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1738,10 +1738,14 @@ export function applyProjectToStore(project: GeoLibreProject): {
   comments: ProjectComment[];
   metadata: Record<string, unknown>;
 } {
+  // Legacy and externally-authored projects can carry a partial top-level
+  // style alongside newer fields on the layer itself. Preserve those layer
+  // fields while keeping the top-level copy authoritative where it explicitly
+  // supplies a value.
   const layers = project.layers.map((layer) => ({
     ...layer,
     style: project.styles[layer.id]
-      ? { ...DEFAULT_LAYER_STYLE, ...project.styles[layer.id] }
+      ? { ...DEFAULT_LAYER_STYLE, ...layer.style, ...project.styles[layer.id] }
       : { ...DEFAULT_LAYER_STYLE, ...layer.style },
   }));
   // Re-normalize here (even though `parseProject` already did) because

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -21,6 +21,33 @@ import {
 import { geojsonLayer } from "./helpers/layer-fixtures";
 
 describe("project parsing", () => {
+  it("preserves layer style fields missing from a legacy top-level style", () => {
+    const base = createEmptyProject("Partial legacy style");
+    const layer = geojsonLayer({
+      id: "cities",
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        markerEnabled: true,
+        markerShape: "triangle",
+        markerColor: "#ef4444",
+        markerSize: 24,
+      },
+    });
+    const applied = applyProjectToStore({
+      ...base,
+      layers: [layer],
+      styles: {
+        cities: { fillColor: "#22c55e" } as typeof DEFAULT_LAYER_STYLE,
+      },
+    });
+
+    assert.equal(applied.layers[0].style.fillColor, "#22c55e");
+    assert.equal(applied.layers[0].style.markerEnabled, true);
+    assert.equal(applied.layers[0].style.markerShape, "triangle");
+    assert.equal(applied.layers[0].style.markerColor, "#ef4444");
+    assert.equal(applied.layers[0].style.markerSize, 24);
+  });
+
   it("round-trips a custom blank background color and defaults legacy projects", () => {
     const base = createEmptyProject("Blank background");
     const customized = parseProject(serializeProject({ ...base, blankBackgroundColor: "#1f2937" }));


### PR DESCRIPTION
Fixes #2164

## Summary
- preserve layer style fields when a legacy or externally authored top-level style is partial
- keep explicitly supplied top-level style fields authoritative
- add a regression test for marker settings surviving project restoration

## Verification
- `node --import tsx --test tests/core-project.test.ts`
- `npm run build`
- `pre-commit run --files packages/core/src/project.ts tests/core-project.test.ts`
- loaded a saved GeoJSON project with partial top-level styles and confirmed triangle markers render immediately in light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved layer-specific styling when applying projects with legacy or partial shared style settings.
  * Ensured top-level style values, such as fill color, continue to take precedence where provided.
  * Preserved marker settings, including visibility, shape, color, and size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->