### PR TITLE
feat: dock first web service panels

### DIFF
--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3230,12 +3230,29 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
    their intrinsic minimum width, a long layer title expands the row after the
    host panel is resized and pushes the fixed-width Add button out of view. */
 .geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-results,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .plugin-control-content,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-body,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-category,
 .geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-category-layers,
 .geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-row,
 .geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-main,
 .geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-info,
 .geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-title {
   min-width: 0;
+}
+
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .plugin-control-content,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-body,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-results,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-category,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-category-layers {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .plugin-control-content {
+  overflow-x: hidden;
 }
 
 .geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-row {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3194,6 +3194,46 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   border-left-color: hsl(var(--popover));
 }
 
+/* Map-control-backed Web Services live in GeoLibre's dockable panel host. The
+   upstream packages position and size their panels as map overlays, so reset
+   that overlay geometry and let the host own the available width and height. */
+.geolibre-docked-map-control {
+  height: 100%;
+  overflow: auto;
+}
+
+.geolibre-docked-map-control > * {
+  width: 100%;
+  margin: 0;
+}
+
+.geolibre-docked-map-control .plugin-control-panel,
+.geolibre-docked-map-control .enviroatlas-panel,
+.geolibre-docked-map-control .national-map-panel,
+.geolibre-docked-map-control .vantor-panel {
+  position: static !important;
+  inset: auto !important;
+  width: 100% !important;
+  max-width: none !important;
+  max-height: none !important;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.geolibre-docked-map-control .plugin-control-toggle,
+.geolibre-docked-map-control .plugin-control-close,
+.geolibre-docked-map-control .enviroatlas-toggle,
+.geolibre-docked-map-control .enviroatlas-close,
+.geolibre-docked-map-control .national-map-toggle,
+.geolibre-docked-map-control .national-map-close,
+.geolibre-docked-map-control .vantor-panel__toggle,
+.geolibre-docked-map-control .plugin-control-resize-handle,
+.geolibre-docked-map-control .enviroatlas-resizer,
+.geolibre-docked-map-control .national-map-resizer,
+.geolibre-docked-map-control .vantor-panel__resize-handle {
+  display: none !important;
+}
+
 /* The Web Services controls (FEMA NFHL, NASA Earthdata, US EPA EnviroAtlas,
    USGS National Map) theme themselves from prefers-color-scheme (the OS
    setting), while GeoLibre themes from the .dark class on <html>. Each

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3216,8 +3216,13 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   width: 100% !important;
   max-width: none !important;
   max-height: none !important;
+  display: flex !important;
   border-radius: 0;
   box-shadow: none;
+}
+
+.geolibre-docked-map-control .vantor-panel__table-container {
+  max-height: none;
 }
 
 .geolibre-docked-map-control .plugin-control-toggle,
@@ -3229,6 +3234,7 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 .geolibre-docked-map-control .national-map-toggle,
 .geolibre-docked-map-control .national-map-header,
 .geolibre-docked-map-control .national-map-close,
+.geolibre-docked-map-control .vantor-panel__header,
 .geolibre-docked-map-control .vantor-panel__toggle,
 .geolibre-docked-map-control .plugin-control-resize-handle,
 .geolibre-docked-map-control .enviroatlas-resizer,

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3225,6 +3225,24 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   max-height: none;
 }
 
+/* NASA result rows contain several nested flex containers. Without resetting
+   their intrinsic minimum width, a long layer title expands the row after the
+   host panel is resized and pushes the fixed-width Add button out of view. */
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-results,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-category-layers,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-row,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-main,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-info,
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-title {
+  min-width: 0;
+}
+
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-row {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
 .geolibre-docked-map-control .plugin-control-toggle,
 .geolibre-docked-map-control .plugin-control-header,
 .geolibre-docked-map-control .plugin-control-close,

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3221,10 +3221,13 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 }
 
 .geolibre-docked-map-control .plugin-control-toggle,
+.geolibre-docked-map-control .plugin-control-header,
 .geolibre-docked-map-control .plugin-control-close,
 .geolibre-docked-map-control .enviroatlas-toggle,
+.geolibre-docked-map-control .enviroatlas-header,
 .geolibre-docked-map-control .enviroatlas-close,
 .geolibre-docked-map-control .national-map-toggle,
+.geolibre-docked-map-control .national-map-header,
 .geolibre-docked-map-control .national-map-close,
 .geolibre-docked-map-control .vantor-panel__toggle,
 .geolibre-docked-map-control .plugin-control-resize-handle,

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3200,6 +3200,7 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 .geolibre-docked-map-control {
   height: 100%;
   overflow: auto;
+  overflow-x: hidden;
 }
 
 .geolibre-docked-map-control > * {
@@ -3241,6 +3242,20 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
+}
+
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-info {
+  overflow: hidden;
+}
+
+.geolibre-docked-map-control .maplibre-gl-nasa-earthdata .nasa-layer-title {
+  display: block;
+  max-width: 100%;
 }
 
 .geolibre-docked-map-control .plugin-control-toggle,

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -106,6 +106,20 @@ it, so only the `line-pattern` entry is a mirror a test can guard; the other two
 rest on how MapLibre renders them. A class using any of them is not imported as
 black — it declines the stack.
 
+### Web Services control packages (`packages/plugins/package.json`)
+
+- **Docked panel DOM bridge.** `dockable-map-control.ts` adapts
+  `maplibre-gl-fema-wms`, `maplibre-gl-nasa-earthdata`,
+  `maplibre-gl-enviroatlas`, and `maplibre-gl-national-map` by calling the
+  control lifecycle directly and moving the panel element that `onAdd()`
+  appends to the map container into GeoLibre's native right-panel host. Vantor
+  returns a wrapper instead, so the bridge selects its `.vantor-panel`
+  descendant. The scoped CSS in `index.css` mirrors each package's panel,
+  header, toggle, close, and resize-handle class names. After bumping any of
+  these packages, activate every migrated Web Services plugin and verify that
+  its catalog renders, resizing the GeoLibre dock preserves the content, and
+  no vendor panel remains under the map container.
+
 ### `maplibre-gl-components` (`packages/plugins/package.json`)
 
 - **`MAP_PANEL_SELECTOR`**

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -475,9 +475,6 @@ export class PluginManager {
     };
     const collapseRestoredRightPanel = (panelId: string): void => {
       app.collapseRightPanel?.(panelId);
-      setTimeout(() => {
-        setTimeout(() => app.collapseRightPanel?.(panelId), 0);
-      }, 0);
     };
     // A plugin that persists its own collapsed state is exempt: the saved
     // project already says whether its panel should be open, and collapsing it
@@ -632,8 +629,11 @@ function scopeAppToPlugin(
           ? {
               ...panel,
               onClose: () => {
-                panel.onClose?.();
-                setTimeout(() => deactivatePlugin(pluginId), 0);
+                try {
+                  panel.onClose?.();
+                } finally {
+                  setTimeout(() => deactivatePlugin(pluginId), 0);
+                }
               },
             }
           : panel,

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -628,9 +628,9 @@ function scopeAppToPlugin(
         panel.deactivatePluginOnClose
           ? {
               ...panel,
-              onClose: () => {
+              onExplicitClose: () => {
                 try {
-                  panel.onClose?.();
+                  panel.onExplicitClose?.();
                 } finally {
                   setTimeout(() => deactivatePlugin(pluginId), 0);
                 }

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -473,6 +473,12 @@ export class PluginManager {
         setTimeout(() => collapsible.collapse?.(), 0);
       }, 0);
     };
+    const collapseRestoredRightPanel = (panelId: string): void => {
+      app.collapseRightPanel?.(panelId);
+      setTimeout(() => {
+        setTimeout(() => app.collapseRightPanel?.(panelId), 0);
+      }, 0);
+    };
     // A plugin that persists its own collapsed state is exempt: the saved
     // project already says whether its panel should be open, and collapsing it
     // here would both override that and (since collapse() mutates the control)
@@ -480,7 +486,10 @@ export class PluginManager {
     const scopeForRestore = (id: string): GeoLibreAppAPI =>
       this.plugins.get(id)?.restoresPanelCollapseState
         ? scopeAppToPlugin(app, id)
-        : scopeAppToPlugin(app, id, { onControlAdded: collapseRestoredPanel });
+        : scopeAppToPlugin(app, id, {
+            onControlAdded: collapseRestoredPanel,
+            onRightPanelOpened: collapseRestoredRightPanel,
+          });
 
     // Deactivate first so plugins that should be inactive tear down their live
     // controls before we touch positions or settings. This keeps the order of
@@ -586,6 +595,8 @@ interface ScopeAppOptions {
    * collapsed (#952).
    */
   onControlAdded?: (control: IControl) => void;
+  /** Called when a plugin opens a native right panel during project restore. */
+  onRightPanelOpened?: (panelId: string) => void;
 }
 
 function scopeAppToPlugin(
@@ -593,11 +604,13 @@ function scopeAppToPlugin(
   pluginId: string,
   options: ScopeAppOptions = {},
 ): GeoLibreAppAPI {
-  const { onControlAdded } = options;
+  const { onControlAdded, onRightPanelOpened } = options;
   const register = app.registerToolbarMenu;
+  const registerRightPanel = app.registerRightPanel;
   const activatePlugin = app.activatePlugin;
   const deactivatePlugin = app.deactivatePlugin;
-  if (!register && !onControlAdded && !activatePlugin && !deactivatePlugin) return app;
+  if (!register && !onControlAdded && !onRightPanelOpened && !activatePlugin && !deactivatePlugin)
+    return app;
 
   const scoped: GeoLibreAppAPI = { ...app };
 
@@ -612,12 +625,36 @@ function scopeAppToPlugin(
     scoped.registerToolbarMenu = (menu) => registerWithOwner(menu, pluginId);
   }
 
+  if (registerRightPanel && deactivatePlugin) {
+    scoped.registerRightPanel = (panel) =>
+      registerRightPanel(
+        panel.deactivatePluginOnClose
+          ? {
+              ...panel,
+              onClose: () => {
+                panel.onClose?.();
+                setTimeout(() => deactivatePlugin(pluginId), 0);
+              },
+            }
+          : panel,
+      );
+  }
+
   if (onControlAdded) {
     const addMapControl = app.addMapControl;
     scoped.addMapControl = (control, position) => {
       const added = addMapControl(control, position);
       if (added !== false) onControlAdded(control);
       return added;
+    };
+  }
+
+  if (onRightPanelOpened && app.openRightPanel) {
+    const openRightPanel = app.openRightPanel;
+    scoped.openRightPanel = (panelId) => {
+      const opened = openRightPanel(panelId);
+      if (opened) onRightPanelOpened(panelId);
+      return opened;
     };
   }
 

--- a/packages/plugins/src/plugins/dockable-map-control.ts
+++ b/packages/plugins/src/plugins/dockable-map-control.ts
@@ -12,10 +12,12 @@ export function mountMapControlInPanel(
   app: GeoLibreAppAPI,
   control: IControl,
   container: HTMLElement,
+  onMountFailure?: () => void,
 ): (() => void) | null {
   const map = app.getMap?.();
   if (!map) {
     console.warn("Could not mount docked map control: the map is not ready.");
+    onMountFailure?.();
     return null;
   }
 
@@ -41,14 +43,24 @@ export function mountMapControlInPanel(
   if (contentElements.length === 0) {
     console.warn("Could not mount docked map control: no panel content was created.");
     control.onRemove(map as MapLibreMap);
+    onMountFailure?.();
     return null;
   }
   container.classList.add("geolibre-docked-map-control");
   container.replaceChildren(...contentElements);
 
-  return () => {
+  let removed = false;
+  const cleanup = () => {
+    if (removed) return;
+    removed = true;
+    map.off("remove", cleanup);
     control.onRemove(map as MapLibreMap);
     container.replaceChildren();
     container.classList.remove("geolibre-docked-map-control");
   };
+  // Unlike a floating control this bridge is not in MapLibre's internal
+  // control list, so explicitly participate in map teardown as well as panel
+  // teardown. The idempotent cleanup handles either ordering.
+  map.on("remove", cleanup);
+  return cleanup;
 }

--- a/packages/plugins/src/plugins/dockable-map-control.ts
+++ b/packages/plugins/src/plugins/dockable-map-control.ts
@@ -14,7 +14,10 @@ export function mountMapControlInPanel(
   container: HTMLElement,
 ): (() => void) | null {
   const map = app.getMap?.();
-  if (!map) return null;
+  if (!map) {
+    console.warn("Could not mount docked map control: the map is not ready.");
+    return null;
+  }
 
   // Most MapLibre controls return their toolbar button from onAdd(), but the
   // Web Services controls append the actual floating panel as a sibling under
@@ -22,26 +25,7 @@ export function mountMapControlInPanel(
   // real UI instead of only the (hidden) toolbar toggle.
   const mapContainer = map.getContainer();
   const existingMapChildren = new Set(mapContainer.children);
-  // Floating controls install a document-level click/pointerdown listener in
-  // onAdd() solely to collapse themselves when the map is clicked. A native
-  // dock must not inherit that behavior: map clicks and host resize presses do
-  // not close dock content. Suppress only those synchronous registrations and
-  // immediately restore the platform method after the control mounts.
-  const nativeAddEventListener = document.addEventListener;
-  document.addEventListener = ((
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions,
-  ) => {
-    if (type === "click" || type === "pointerdown") return;
-    Reflect.apply(nativeAddEventListener, document, [type, listener, options]);
-  }) as typeof document.addEventListener;
-  let element: HTMLElement;
-  try {
-    element = control.onAdd(map as MapLibreMap);
-  } finally {
-    document.addEventListener = nativeAddEventListener;
-  }
+  const element = control.onAdd(map as MapLibreMap);
   const appendedElements = [...mapContainer.children].filter(
     (child): child is HTMLElement =>
       child instanceof HTMLElement && !existingMapChildren.has(child) && child !== element,
@@ -55,6 +39,7 @@ export function mountMapControlInPanel(
             : element.querySelector<HTMLElement>(".vantor-panel"),
         ].filter((candidate): candidate is HTMLElement => candidate !== null);
   if (contentElements.length === 0) {
+    console.warn("Could not mount docked map control: no panel content was created.");
     control.onRemove(map as MapLibreMap);
     return null;
   }

--- a/packages/plugins/src/plugins/dockable-map-control.ts
+++ b/packages/plugins/src/plugins/dockable-map-control.ts
@@ -1,6 +1,13 @@
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 import type { GeoLibreAppAPI } from "../types";
 
+const mountedControlCleanup = new WeakMap<IControl, () => void>();
+
+/** Synchronously unmount a bridged control if its docked panel is mounted. */
+export function unmountMapControlFromPanel(control: IControl): void {
+  mountedControlCleanup.get(control)?.();
+}
+
 /**
  * Mount only a MapLibre control's content inside a host-owned dockable panel.
  *
@@ -53,6 +60,7 @@ export function mountMapControlInPanel(
   const cleanup = () => {
     if (removed) return;
     removed = true;
+    if (mountedControlCleanup.get(control) === cleanup) mountedControlCleanup.delete(control);
     map.off("remove", cleanup);
     control.onRemove(map as MapLibreMap);
     container.replaceChildren();
@@ -62,5 +70,6 @@ export function mountMapControlInPanel(
   // control list, so explicitly participate in map teardown as well as panel
   // teardown. The idempotent cleanup handles either ordering.
   map.on("remove", cleanup);
+  mountedControlCleanup.set(control, cleanup);
   return cleanup;
 }

--- a/packages/plugins/src/plugins/dockable-map-control.ts
+++ b/packages/plugins/src/plugins/dockable-map-control.ts
@@ -1,0 +1,28 @@
+import type { IControl, Map as MapLibreMap } from "maplibre-gl";
+import type { GeoLibreAppAPI } from "../types";
+
+/**
+ * Mount a MapLibre control's existing DOM inside a host-owned dockable panel.
+ *
+ * Calling the control lifecycle directly preserves the third-party control's
+ * map integration while leaving layout, resizing, and close/collapse chrome to
+ * GeoLibre's panel host instead of MapLibre's floating control corners.
+ */
+export function mountMapControlInPanel(
+  app: GeoLibreAppAPI,
+  control: IControl,
+  container: HTMLElement,
+): (() => void) | null {
+  const map = app.getMap?.();
+  if (!map) return null;
+
+  const element = control.onAdd(map as MapLibreMap);
+  container.classList.add("geolibre-docked-map-control");
+  container.replaceChildren(element);
+
+  return () => {
+    control.onRemove(map as MapLibreMap);
+    container.replaceChildren();
+    container.classList.remove("geolibre-docked-map-control");
+  };
+}

--- a/packages/plugins/src/plugins/dockable-map-control.ts
+++ b/packages/plugins/src/plugins/dockable-map-control.ts
@@ -22,7 +22,26 @@ export function mountMapControlInPanel(
   // real UI instead of only the (hidden) toolbar toggle.
   const mapContainer = map.getContainer();
   const existingMapChildren = new Set(mapContainer.children);
-  const element = control.onAdd(map as MapLibreMap);
+  // Floating controls install a document-level click/pointerdown listener in
+  // onAdd() solely to collapse themselves when the map is clicked. A native
+  // dock must not inherit that behavior: map clicks and host resize presses do
+  // not close dock content. Suppress only those synchronous registrations and
+  // immediately restore the platform method after the control mounts.
+  const nativeAddEventListener = document.addEventListener;
+  document.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ) => {
+    if (type === "click" || type === "pointerdown") return;
+    Reflect.apply(nativeAddEventListener, document, [type, listener, options]);
+  }) as typeof document.addEventListener;
+  let element: HTMLElement;
+  try {
+    element = control.onAdd(map as MapLibreMap);
+  } finally {
+    document.addEventListener = nativeAddEventListener;
+  }
   const appendedElements = [...mapContainer.children].filter(
     (child): child is HTMLElement =>
       child instanceof HTMLElement && !existingMapChildren.has(child) && child !== element,

--- a/packages/plugins/src/plugins/dockable-map-control.ts
+++ b/packages/plugins/src/plugins/dockable-map-control.ts
@@ -2,11 +2,11 @@ import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 import type { GeoLibreAppAPI } from "../types";
 
 /**
- * Mount a MapLibre control's existing DOM inside a host-owned dockable panel.
+ * Mount only a MapLibre control's content inside a host-owned dockable panel.
  *
- * Calling the control lifecycle directly preserves the third-party control's
- * map integration while leaving layout, resizing, and close/collapse chrome to
- * GeoLibre's panel host instead of MapLibre's floating control corners.
+ * The control lifecycle remains an implementation bridge for its map and
+ * service logic, but its toolbar button and floating shell are not mounted.
+ * Layout, resizing, and close/collapse chrome belong exclusively to GeoLibre.
  */
 export function mountMapControlInPanel(
   app: GeoLibreAppAPI,
@@ -16,9 +16,31 @@ export function mountMapControlInPanel(
   const map = app.getMap?.();
   if (!map) return null;
 
+  // Most MapLibre controls return their toolbar button from onAdd(), but the
+  // Web Services controls append the actual floating panel as a sibling under
+  // the map container. Capture those new siblings so the dock receives the
+  // real UI instead of only the (hidden) toolbar toggle.
+  const mapContainer = map.getContainer();
+  const existingMapChildren = new Set(mapContainer.children);
   const element = control.onAdd(map as MapLibreMap);
+  const appendedElements = [...mapContainer.children].filter(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && !existingMapChildren.has(child) && child !== element,
+  );
+  const contentElements =
+    appendedElements.length > 0
+      ? appendedElements
+      : [
+          element.matches(".vantor-panel")
+            ? element
+            : element.querySelector<HTMLElement>(".vantor-panel"),
+        ].filter((candidate): candidate is HTMLElement => candidate !== null);
+  if (contentElements.length === 0) {
+    control.onRemove(map as MapLibreMap);
+    return null;
+  }
   container.classList.add("geolibre-docked-map-control");
-  container.replaceChildren(element);
+  container.replaceChildren(...contentElements);
 
   return () => {
     control.onRemove(map as MapLibreMap);

--- a/packages/plugins/src/plugins/maplibre-enviroatlas.ts
+++ b/packages/plugins/src/plugins/maplibre-enviroatlas.ts
@@ -162,7 +162,9 @@ export const maplibreEnviroAtlasPlugin: GeoLibrePlugin = {
         defaultWidth: 360,
         deactivatePluginOnClose: true,
         render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container);
+          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+            app.closeRightPanel?.(PANEL_ID),
+          );
           if (!unmount) return;
           enviroAtlasStoreSync.attach(activeControl);
           activeControl.expand();

--- a/packages/plugins/src/plugins/maplibre-enviroatlas.ts
+++ b/packages/plugins/src/plugins/maplibre-enviroatlas.ts
@@ -7,7 +7,8 @@ import {
   type ServiceRef,
 } from "maplibre-gl-enviroatlas";
 import type { GeoLibreLayer } from "@geolibre/core";
-import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+import { mountMapControlInPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -22,7 +23,7 @@ const SOURCE_KIND = "enviroatlas";
 // Matches the package's AddedLayer.bounds type, which is not exported.
 type LngLatBoundsArray = [number, number, number, number];
 
-let enviroAtlasPosition: GeoLibreMapControlPosition = "top-left";
+const PANEL_ID = "enviroatlas-panel";
 
 const ENVIROATLAS_OPTIONS = {
   collapsed: false,
@@ -36,6 +37,7 @@ const ENVIROATLAS_OPTIONS = {
 
 let enviroAtlasControl: EnviroAtlasControl | null = null;
 let controlEventHandler: EnviroAtlasControlEventHandler | null = null;
+let unregisterPanel: (() => void) | null = null;
 
 function isServiceRef(value: unknown): value is ServiceRef {
   if (!value || typeof value !== "object") return false;
@@ -150,38 +152,39 @@ export const maplibreEnviroAtlasPlugin: GeoLibrePlugin = {
       enviroAtlasControl = new EnviroAtlasControl(getEnviroAtlasControlOptions());
     }
 
-    const added = app.addMapControl(enviroAtlasControl, enviroAtlasPosition);
-    if (!added) {
-      enviroAtlasControl = null;
-      return false;
-    }
-    enviroAtlasStoreSync.attach(enviroAtlasControl);
-    setTimeout(() => enviroAtlasControl?.expand(), 0);
+    const activeControl = enviroAtlasControl;
+    unregisterPanel =
+      app.registerRightPanel?.({
+        id: PANEL_ID,
+        title: "US EPA EnviroAtlas",
+        dock: "replace-style",
+        defaultWidth: 360,
+        render: (container) => {
+          const unmount = mountMapControlInPanel(app, activeControl, container);
+          if (!unmount) return;
+          enviroAtlasStoreSync.attach(activeControl);
+          activeControl.expand();
+          return () => {
+            enviroAtlasStoreSync.detach();
+            unmount();
+          };
+        },
+      }) ?? null;
+    app.openRightPanel?.(PANEL_ID);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!enviroAtlasControl) return;
     enviroAtlasStoreSync.detach();
-    app.removeMapControl(enviroAtlasControl);
+    app.closeRightPanel?.(PANEL_ID);
+    unregisterPanel?.();
+    unregisterPanel = null;
     enviroAtlasControl = null;
-  },
-  getMapControlPosition: () => enviroAtlasPosition,
-  setMapControlPosition: (app: GeoLibreAppAPI, position: GeoLibreMapControlPosition) => {
-    enviroAtlasPosition = position;
-    if (!enviroAtlasControl) return;
-    app.removeMapControl(enviroAtlasControl);
-    const added = app.addMapControl(enviroAtlasControl, enviroAtlasPosition);
-    if (!added) {
-      enviroAtlasStoreSync.detach();
-      enviroAtlasControl = null;
-      return false;
-    }
-    setTimeout(() => enviroAtlasControl?.expand(), 0);
   },
 };
 
 function getEnviroAtlasControlOptions(): EnviroAtlasControlOptions {
   return {
     ...ENVIROATLAS_OPTIONS,
-    position: enviroAtlasPosition,
+    position: "top-left",
   };
 }

--- a/packages/plugins/src/plugins/maplibre-enviroatlas.ts
+++ b/packages/plugins/src/plugins/maplibre-enviroatlas.ts
@@ -148,6 +148,7 @@ export const maplibreEnviroAtlasPlugin: GeoLibrePlugin = {
   name: "US EPA EnviroAtlas",
   version: "0.1.1",
   activate: (app: GeoLibreAppAPI) => {
+    if (!app.getMap?.()) return false;
     if (!enviroAtlasControl) {
       enviroAtlasControl = new EnviroAtlasControl(getEnviroAtlasControlOptions());
     }
@@ -159,6 +160,7 @@ export const maplibreEnviroAtlasPlugin: GeoLibrePlugin = {
         title: "US EPA EnviroAtlas",
         dock: "replace-style",
         defaultWidth: 360,
+        deactivatePluginOnClose: true,
         render: (container) => {
           const unmount = mountMapControlInPanel(app, activeControl, container);
           if (!unmount) return;

--- a/packages/plugins/src/plugins/maplibre-enviroatlas.ts
+++ b/packages/plugins/src/plugins/maplibre-enviroatlas.ts
@@ -8,7 +8,7 @@ import {
 } from "maplibre-gl-enviroatlas";
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
-import { mountMapControlInPanel } from "./dockable-map-control";
+import { mountMapControlInPanel, unmountMapControlFromPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -183,6 +183,7 @@ export const maplibreEnviroAtlasPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     if (!enviroAtlasControl) return;
     enviroAtlasStoreSync.detach();
+    unmountMapControlFromPanel(enviroAtlasControl);
     app.closeRightPanel?.(PANEL_ID);
     unregisterPanel?.();
     unregisterPanel = null;

--- a/packages/plugins/src/plugins/maplibre-enviroatlas.ts
+++ b/packages/plugins/src/plugins/maplibre-enviroatlas.ts
@@ -148,33 +148,37 @@ export const maplibreEnviroAtlasPlugin: GeoLibrePlugin = {
   name: "US EPA EnviroAtlas",
   version: "0.1.1",
   activate: (app: GeoLibreAppAPI) => {
-    if (!app.getMap?.()) return false;
+    if (!app.getMap?.() || !app.registerRightPanel || !app.openRightPanel) return false;
     if (!enviroAtlasControl) {
       enviroAtlasControl = new EnviroAtlasControl(getEnviroAtlasControlOptions());
     }
 
     const activeControl = enviroAtlasControl;
-    unregisterPanel =
-      app.registerRightPanel?.({
-        id: PANEL_ID,
-        title: "US EPA EnviroAtlas",
-        dock: "replace-style",
-        defaultWidth: 360,
-        deactivatePluginOnClose: true,
-        render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
-            app.closeRightPanel?.(PANEL_ID),
-          );
-          if (!unmount) return;
-          enviroAtlasStoreSync.attach(activeControl);
-          activeControl.expand();
-          return () => {
-            enviroAtlasStoreSync.detach();
-            unmount();
-          };
-        },
-      }) ?? null;
-    app.openRightPanel?.(PANEL_ID);
+    unregisterPanel = app.registerRightPanel({
+      id: PANEL_ID,
+      title: "US EPA EnviroAtlas",
+      dock: "replace-style",
+      defaultWidth: 360,
+      deactivatePluginOnClose: true,
+      render: (container) => {
+        const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+          app.closeRightPanel?.(PANEL_ID),
+        );
+        if (!unmount) return;
+        enviroAtlasStoreSync.attach(activeControl);
+        activeControl.expand();
+        return () => {
+          enviroAtlasStoreSync.detach();
+          unmount();
+        };
+      },
+    });
+    if (!app.openRightPanel(PANEL_ID)) {
+      unregisterPanel();
+      unregisterPanel = null;
+      enviroAtlasControl = null;
+      return false;
+    }
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!enviroAtlasControl) return;

--- a/packages/plugins/src/plugins/maplibre-fema-wms.ts
+++ b/packages/plugins/src/plugins/maplibre-fema-wms.ts
@@ -116,33 +116,37 @@ export const maplibreFemaWmsPlugin: GeoLibrePlugin = {
   name: "FEMA NFHL",
   version: "0.1.2",
   activate: (app: GeoLibreAppAPI) => {
-    if (!app.getMap?.()) return false;
+    if (!app.getMap?.() || !app.registerRightPanel || !app.openRightPanel) return false;
     if (!femaWmsControl) {
       femaWmsControl = new FemaWmsControl(getFemaWmsControlOptions());
     }
 
     const activeControl = femaWmsControl;
-    unregisterPanel =
-      app.registerRightPanel?.({
-        id: PANEL_ID,
-        title: "FEMA NFHL",
-        dock: "replace-style",
-        defaultWidth: 340,
-        deactivatePluginOnClose: true,
-        render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
-            app.closeRightPanel?.(PANEL_ID),
-          );
-          if (!unmount) return;
-          femaWmsStoreSync.attach(activeControl);
-          activeControl.expand();
-          return () => {
-            femaWmsStoreSync.detach();
-            unmount();
-          };
-        },
-      }) ?? null;
-    app.openRightPanel?.(PANEL_ID);
+    unregisterPanel = app.registerRightPanel({
+      id: PANEL_ID,
+      title: "FEMA NFHL",
+      dock: "replace-style",
+      defaultWidth: 340,
+      deactivatePluginOnClose: true,
+      render: (container) => {
+        const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+          app.closeRightPanel?.(PANEL_ID),
+        );
+        if (!unmount) return;
+        femaWmsStoreSync.attach(activeControl);
+        activeControl.expand();
+        return () => {
+          femaWmsStoreSync.detach();
+          unmount();
+        };
+      },
+    });
+    if (!app.openRightPanel(PANEL_ID)) {
+      unregisterPanel();
+      unregisterPanel = null;
+      femaWmsControl = null;
+      return false;
+    }
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!femaWmsControl) return;

--- a/packages/plugins/src/plugins/maplibre-fema-wms.ts
+++ b/packages/plugins/src/plugins/maplibre-fema-wms.ts
@@ -6,7 +6,7 @@ import {
 } from "maplibre-gl-fema-wms";
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
-import { mountMapControlInPanel } from "./dockable-map-control";
+import { mountMapControlInPanel, unmountMapControlFromPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -151,6 +151,7 @@ export const maplibreFemaWmsPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     if (!femaWmsControl) return;
     femaWmsStoreSync.detach();
+    unmountMapControlFromPanel(femaWmsControl);
     app.closeRightPanel?.(PANEL_ID);
     unregisterPanel?.();
     unregisterPanel = null;

--- a/packages/plugins/src/plugins/maplibre-fema-wms.ts
+++ b/packages/plugins/src/plugins/maplibre-fema-wms.ts
@@ -116,6 +116,7 @@ export const maplibreFemaWmsPlugin: GeoLibrePlugin = {
   name: "FEMA NFHL",
   version: "0.1.2",
   activate: (app: GeoLibreAppAPI) => {
+    if (!app.getMap?.()) return false;
     if (!femaWmsControl) {
       femaWmsControl = new FemaWmsControl(getFemaWmsControlOptions());
     }
@@ -127,6 +128,7 @@ export const maplibreFemaWmsPlugin: GeoLibrePlugin = {
         title: "FEMA NFHL",
         dock: "replace-style",
         defaultWidth: 340,
+        deactivatePluginOnClose: true,
         render: (container) => {
           const unmount = mountMapControlInPanel(app, activeControl, container);
           if (!unmount) return;

--- a/packages/plugins/src/plugins/maplibre-fema-wms.ts
+++ b/packages/plugins/src/plugins/maplibre-fema-wms.ts
@@ -130,7 +130,9 @@ export const maplibreFemaWmsPlugin: GeoLibrePlugin = {
         defaultWidth: 340,
         deactivatePluginOnClose: true,
         render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container);
+          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+            app.closeRightPanel?.(PANEL_ID),
+          );
           if (!unmount) return;
           femaWmsStoreSync.attach(activeControl);
           activeControl.expand();

--- a/packages/plugins/src/plugins/maplibre-fema-wms.ts
+++ b/packages/plugins/src/plugins/maplibre-fema-wms.ts
@@ -5,7 +5,8 @@ import {
   type FemaWmsEventHandler,
 } from "maplibre-gl-fema-wms";
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
-import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+import { mountMapControlInPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -19,7 +20,7 @@ const SOURCE_KIND = "fema-wms";
 // Matches the control's native source/layer id scheme (`fema-wms-<name>`).
 const NATIVE_ID_PREFIX = "fema-wms-";
 
-let femaWmsPosition: GeoLibreMapControlPosition = "top-left";
+const PANEL_ID = "fema-wms-panel";
 
 const FEMA_WMS_OPTIONS = {
   collapsed: false,
@@ -30,6 +31,7 @@ const FEMA_WMS_OPTIONS = {
 
 let femaWmsControl: FemaWmsControl | null = null;
 let controlEventHandler: FemaWmsEventHandler | null = null;
+let unregisterPanel: (() => void) | null = null;
 
 function layerNameFromStoreLayer(layer: GeoLibreLayer): string | undefined {
   const fromMetadata = stringMetadata(layer.metadata.femaLayerName);
@@ -118,38 +120,39 @@ export const maplibreFemaWmsPlugin: GeoLibrePlugin = {
       femaWmsControl = new FemaWmsControl(getFemaWmsControlOptions());
     }
 
-    const added = app.addMapControl(femaWmsControl, femaWmsPosition);
-    if (!added) {
-      femaWmsControl = null;
-      return false;
-    }
-    femaWmsStoreSync.attach(femaWmsControl);
-    setTimeout(() => femaWmsControl?.expand(), 0);
+    const activeControl = femaWmsControl;
+    unregisterPanel =
+      app.registerRightPanel?.({
+        id: PANEL_ID,
+        title: "FEMA NFHL",
+        dock: "replace-style",
+        defaultWidth: 340,
+        render: (container) => {
+          const unmount = mountMapControlInPanel(app, activeControl, container);
+          if (!unmount) return;
+          femaWmsStoreSync.attach(activeControl);
+          activeControl.expand();
+          return () => {
+            femaWmsStoreSync.detach();
+            unmount();
+          };
+        },
+      }) ?? null;
+    app.openRightPanel?.(PANEL_ID);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!femaWmsControl) return;
     femaWmsStoreSync.detach();
-    app.removeMapControl(femaWmsControl);
+    app.closeRightPanel?.(PANEL_ID);
+    unregisterPanel?.();
+    unregisterPanel = null;
     femaWmsControl = null;
-  },
-  getMapControlPosition: () => femaWmsPosition,
-  setMapControlPosition: (app: GeoLibreAppAPI, position: GeoLibreMapControlPosition) => {
-    femaWmsPosition = position;
-    if (!femaWmsControl) return;
-    app.removeMapControl(femaWmsControl);
-    const added = app.addMapControl(femaWmsControl, femaWmsPosition);
-    if (!added) {
-      femaWmsStoreSync.detach();
-      femaWmsControl = null;
-      return false;
-    }
-    setTimeout(() => femaWmsControl?.expand(), 0);
   },
 };
 
 function getFemaWmsControlOptions(): Partial<FemaWmsControlOptions> {
   return {
     ...FEMA_WMS_OPTIONS,
-    position: femaWmsPosition,
+    position: "top-left",
   };
 }

--- a/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
+++ b/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
@@ -8,7 +8,7 @@ import {
 } from "maplibre-gl-nasa-earthdata";
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
-import { mountMapControlInPanel } from "./dockable-map-control";
+import { mountMapControlInPanel, unmountMapControlFromPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -192,6 +192,7 @@ export const maplibreNasaEarthdataPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     if (!nasaEarthdataControl) return;
     nasaEarthdataStoreSync.detach();
+    unmountMapControlFromPanel(nasaEarthdataControl);
     app.closeRightPanel?.(PANEL_ID);
     unregisterPanel?.();
     unregisterPanel = null;

--- a/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
+++ b/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
@@ -171,7 +171,9 @@ export const maplibreNasaEarthdataPlugin: GeoLibrePlugin = {
         defaultWidth: 360,
         deactivatePluginOnClose: true,
         render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container);
+          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+            app.closeRightPanel?.(PANEL_ID),
+          );
           if (!unmount) return;
           nasaEarthdataStoreSync.attach(activeControl);
           activeControl.expand();

--- a/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
+++ b/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
@@ -157,6 +157,7 @@ export const maplibreNasaEarthdataPlugin: GeoLibrePlugin = {
   name: "NASA Earthdata",
   version: "0.1.4",
   activate: (app: GeoLibreAppAPI) => {
+    if (!app.getMap?.()) return false;
     if (!nasaEarthdataControl) {
       nasaEarthdataControl = new NasaEarthdataControl(getNasaEarthdataControlOptions());
     }
@@ -168,6 +169,7 @@ export const maplibreNasaEarthdataPlugin: GeoLibrePlugin = {
         title: "NASA Earthdata",
         dock: "replace-style",
         defaultWidth: 360,
+        deactivatePluginOnClose: true,
         render: (container) => {
           const unmount = mountMapControlInPanel(app, activeControl, container);
           if (!unmount) return;

--- a/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
+++ b/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
@@ -157,33 +157,37 @@ export const maplibreNasaEarthdataPlugin: GeoLibrePlugin = {
   name: "NASA Earthdata",
   version: "0.1.4",
   activate: (app: GeoLibreAppAPI) => {
-    if (!app.getMap?.()) return false;
+    if (!app.getMap?.() || !app.registerRightPanel || !app.openRightPanel) return false;
     if (!nasaEarthdataControl) {
       nasaEarthdataControl = new NasaEarthdataControl(getNasaEarthdataControlOptions());
     }
 
     const activeControl = nasaEarthdataControl;
-    unregisterPanel =
-      app.registerRightPanel?.({
-        id: PANEL_ID,
-        title: "NASA Earthdata",
-        dock: "replace-style",
-        defaultWidth: 360,
-        deactivatePluginOnClose: true,
-        render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
-            app.closeRightPanel?.(PANEL_ID),
-          );
-          if (!unmount) return;
-          nasaEarthdataStoreSync.attach(activeControl);
-          activeControl.expand();
-          return () => {
-            nasaEarthdataStoreSync.detach();
-            unmount();
-          };
-        },
-      }) ?? null;
-    app.openRightPanel?.(PANEL_ID);
+    unregisterPanel = app.registerRightPanel({
+      id: PANEL_ID,
+      title: "NASA Earthdata",
+      dock: "replace-style",
+      defaultWidth: 360,
+      deactivatePluginOnClose: true,
+      render: (container) => {
+        const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+          app.closeRightPanel?.(PANEL_ID),
+        );
+        if (!unmount) return;
+        nasaEarthdataStoreSync.attach(activeControl);
+        activeControl.expand();
+        return () => {
+          nasaEarthdataStoreSync.detach();
+          unmount();
+        };
+      },
+    });
+    if (!app.openRightPanel(PANEL_ID)) {
+      unregisterPanel();
+      unregisterPanel = null;
+      nasaEarthdataControl = null;
+      return false;
+    }
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!nasaEarthdataControl) return;

--- a/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
+++ b/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
@@ -7,7 +7,8 @@ import {
   type NasaEarthdataEventHandler,
 } from "maplibre-gl-nasa-earthdata";
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
-import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+import { mountMapControlInPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -21,7 +22,7 @@ const SOURCE_KIND = "nasa-earthdata";
 // Matches the control's native source/layer id scheme (`nasa-gibs-<key>`).
 const NATIVE_ID_PREFIX = "nasa-gibs-";
 
-let nasaEarthdataPosition: GeoLibreMapControlPosition = "top-left";
+const PANEL_ID = "nasa-earthdata-panel";
 
 const NASA_EARTHDATA_OPTIONS = {
   collapsed: false,
@@ -32,6 +33,7 @@ const NASA_EARTHDATA_OPTIONS = {
 
 let nasaEarthdataControl: NasaEarthdataControl | null = null;
 let controlEventHandler: NasaEarthdataEventHandler | null = null;
+let unregisterPanel: (() => void) | null = null;
 
 // GIBS catalog entries seen in layeradd events, keyed by GIBS layer id. The
 // control state alone does not carry the catalog data needed to rebuild
@@ -159,38 +161,39 @@ export const maplibreNasaEarthdataPlugin: GeoLibrePlugin = {
       nasaEarthdataControl = new NasaEarthdataControl(getNasaEarthdataControlOptions());
     }
 
-    const added = app.addMapControl(nasaEarthdataControl, nasaEarthdataPosition);
-    if (!added) {
-      nasaEarthdataControl = null;
-      return false;
-    }
-    nasaEarthdataStoreSync.attach(nasaEarthdataControl);
-    setTimeout(() => nasaEarthdataControl?.expand(), 0);
+    const activeControl = nasaEarthdataControl;
+    unregisterPanel =
+      app.registerRightPanel?.({
+        id: PANEL_ID,
+        title: "NASA Earthdata",
+        dock: "replace-style",
+        defaultWidth: 360,
+        render: (container) => {
+          const unmount = mountMapControlInPanel(app, activeControl, container);
+          if (!unmount) return;
+          nasaEarthdataStoreSync.attach(activeControl);
+          activeControl.expand();
+          return () => {
+            nasaEarthdataStoreSync.detach();
+            unmount();
+          };
+        },
+      }) ?? null;
+    app.openRightPanel?.(PANEL_ID);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!nasaEarthdataControl) return;
     nasaEarthdataStoreSync.detach();
-    app.removeMapControl(nasaEarthdataControl);
+    app.closeRightPanel?.(PANEL_ID);
+    unregisterPanel?.();
+    unregisterPanel = null;
     nasaEarthdataControl = null;
-  },
-  getMapControlPosition: () => nasaEarthdataPosition,
-  setMapControlPosition: (app: GeoLibreAppAPI, position: GeoLibreMapControlPosition) => {
-    nasaEarthdataPosition = position;
-    if (!nasaEarthdataControl) return;
-    app.removeMapControl(nasaEarthdataControl);
-    const added = app.addMapControl(nasaEarthdataControl, nasaEarthdataPosition);
-    if (!added) {
-      nasaEarthdataStoreSync.detach();
-      nasaEarthdataControl = null;
-      return false;
-    }
-    setTimeout(() => nasaEarthdataControl?.expand(), 0);
   },
 };
 
 function getNasaEarthdataControlOptions(): NasaEarthdataControlOptions {
   return {
     ...NASA_EARTHDATA_OPTIONS,
-    position: nasaEarthdataPosition,
+    position: "top-left",
   };
 }

--- a/packages/plugins/src/plugins/maplibre-national-map.ts
+++ b/packages/plugins/src/plugins/maplibre-national-map.ts
@@ -130,33 +130,37 @@ export const maplibreNationalMapPlugin: GeoLibrePlugin = {
   name: "USGS National Map",
   version: "0.1.1",
   activate: (app: GeoLibreAppAPI) => {
-    if (!app.getMap?.()) return false;
+    if (!app.getMap?.() || !app.registerRightPanel || !app.openRightPanel) return false;
     if (!nationalMapControl) {
       nationalMapControl = new NationalMapControl(getNationalMapControlOptions());
     }
 
     const activeControl = nationalMapControl;
-    unregisterPanel =
-      app.registerRightPanel?.({
-        id: PANEL_ID,
-        title: "USGS National Map",
-        dock: "replace-style",
-        defaultWidth: 340,
-        deactivatePluginOnClose: true,
-        render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
-            app.closeRightPanel?.(PANEL_ID),
-          );
-          if (!unmount) return;
-          nationalMapStoreSync.attach(activeControl);
-          activeControl.expand();
-          return () => {
-            nationalMapStoreSync.detach();
-            unmount();
-          };
-        },
-      }) ?? null;
-    app.openRightPanel?.(PANEL_ID);
+    unregisterPanel = app.registerRightPanel({
+      id: PANEL_ID,
+      title: "USGS National Map",
+      dock: "replace-style",
+      defaultWidth: 340,
+      deactivatePluginOnClose: true,
+      render: (container) => {
+        const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+          app.closeRightPanel?.(PANEL_ID),
+        );
+        if (!unmount) return;
+        nationalMapStoreSync.attach(activeControl);
+        activeControl.expand();
+        return () => {
+          nationalMapStoreSync.detach();
+          unmount();
+        };
+      },
+    });
+    if (!app.openRightPanel(PANEL_ID)) {
+      unregisterPanel();
+      unregisterPanel = null;
+      nationalMapControl = null;
+      return false;
+    }
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!nationalMapControl) return;

--- a/packages/plugins/src/plugins/maplibre-national-map.ts
+++ b/packages/plugins/src/plugins/maplibre-national-map.ts
@@ -130,6 +130,7 @@ export const maplibreNationalMapPlugin: GeoLibrePlugin = {
   name: "USGS National Map",
   version: "0.1.1",
   activate: (app: GeoLibreAppAPI) => {
+    if (!app.getMap?.()) return false;
     if (!nationalMapControl) {
       nationalMapControl = new NationalMapControl(getNationalMapControlOptions());
     }
@@ -141,6 +142,7 @@ export const maplibreNationalMapPlugin: GeoLibrePlugin = {
         title: "USGS National Map",
         dock: "replace-style",
         defaultWidth: 340,
+        deactivatePluginOnClose: true,
         render: (container) => {
           const unmount = mountMapControlInPanel(app, activeControl, container);
           if (!unmount) return;

--- a/packages/plugins/src/plugins/maplibre-national-map.ts
+++ b/packages/plugins/src/plugins/maplibre-national-map.ts
@@ -6,7 +6,7 @@ import {
 } from "maplibre-gl-national-map";
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
-import { mountMapControlInPanel } from "./dockable-map-control";
+import { mountMapControlInPanel, unmountMapControlFromPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -165,6 +165,7 @@ export const maplibreNationalMapPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     if (!nationalMapControl) return;
     nationalMapStoreSync.detach();
+    unmountMapControlFromPanel(nationalMapControl);
     app.closeRightPanel?.(PANEL_ID);
     unregisterPanel?.();
     unregisterPanel = null;

--- a/packages/plugins/src/plugins/maplibre-national-map.ts
+++ b/packages/plugins/src/plugins/maplibre-national-map.ts
@@ -144,7 +144,9 @@ export const maplibreNationalMapPlugin: GeoLibrePlugin = {
         defaultWidth: 340,
         deactivatePluginOnClose: true,
         render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container);
+          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+            app.closeRightPanel?.(PANEL_ID),
+          );
           if (!unmount) return;
           nationalMapStoreSync.attach(activeControl);
           activeControl.expand();

--- a/packages/plugins/src/plugins/maplibre-national-map.ts
+++ b/packages/plugins/src/plugins/maplibre-national-map.ts
@@ -5,7 +5,8 @@ import {
   type NationalMapControlOptions,
 } from "maplibre-gl-national-map";
 import type { GeoLibreLayer } from "@geolibre/core";
-import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+import { mountMapControlInPanel } from "./dockable-map-control";
 import {
   createWebServiceStoreSync,
   layerTypeForTiles,
@@ -17,7 +18,7 @@ import {
 
 const SOURCE_KIND = "national-map";
 
-let nationalMapPosition: GeoLibreMapControlPosition = "top-left";
+const PANEL_ID = "national-map-panel";
 
 const NATIONAL_MAP_OPTIONS = {
   collapsed: false,
@@ -28,6 +29,7 @@ const NATIONAL_MAP_OPTIONS = {
 
 let nationalMapControl: NationalMapControl | null = null;
 let controlEventHandler: NationalMapControlEventHandler | null = null;
+let unregisterPanel: (() => void) | null = null;
 
 function serviceId(entry: WebServiceLayerEntry): string | undefined {
   return stringMetadata(entry.metadata?.nationalMapServiceId);
@@ -132,38 +134,39 @@ export const maplibreNationalMapPlugin: GeoLibrePlugin = {
       nationalMapControl = new NationalMapControl(getNationalMapControlOptions());
     }
 
-    const added = app.addMapControl(nationalMapControl, nationalMapPosition);
-    if (!added) {
-      nationalMapControl = null;
-      return false;
-    }
-    nationalMapStoreSync.attach(nationalMapControl);
-    setTimeout(() => nationalMapControl?.expand(), 0);
+    const activeControl = nationalMapControl;
+    unregisterPanel =
+      app.registerRightPanel?.({
+        id: PANEL_ID,
+        title: "USGS National Map",
+        dock: "replace-style",
+        defaultWidth: 340,
+        render: (container) => {
+          const unmount = mountMapControlInPanel(app, activeControl, container);
+          if (!unmount) return;
+          nationalMapStoreSync.attach(activeControl);
+          activeControl.expand();
+          return () => {
+            nationalMapStoreSync.detach();
+            unmount();
+          };
+        },
+      }) ?? null;
+    app.openRightPanel?.(PANEL_ID);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!nationalMapControl) return;
     nationalMapStoreSync.detach();
-    app.removeMapControl(nationalMapControl);
+    app.closeRightPanel?.(PANEL_ID);
+    unregisterPanel?.();
+    unregisterPanel = null;
     nationalMapControl = null;
-  },
-  getMapControlPosition: () => nationalMapPosition,
-  setMapControlPosition: (app: GeoLibreAppAPI, position: GeoLibreMapControlPosition) => {
-    nationalMapPosition = position;
-    if (!nationalMapControl) return;
-    app.removeMapControl(nationalMapControl);
-    const added = app.addMapControl(nationalMapControl, nationalMapPosition);
-    if (!added) {
-      nationalMapStoreSync.detach();
-      nationalMapControl = null;
-      return false;
-    }
-    setTimeout(() => nationalMapControl?.expand(), 0);
   },
 };
 
 function getNationalMapControlOptions(): NationalMapControlOptions {
   return {
     ...NATIONAL_MAP_OPTIONS,
-    position: nationalMapPosition,
+    position: "top-left",
   };
 }

--- a/packages/plugins/src/plugins/maplibre-vantor.ts
+++ b/packages/plugins/src/plugins/maplibre-vantor.ts
@@ -39,26 +39,30 @@ export const maplibreVantorPlugin: GeoLibrePlugin = {
   name: "Vantor Open Data",
   version: "0.2.1",
   activate: (app: GeoLibreAppAPI) => {
-    if (!app.getMap?.()) return false;
+    if (!app.getMap?.() || !app.registerRightPanel || !app.openRightPanel) return false;
     control ??= createControl(app);
     const activeControl = control;
-    unregisterPanel =
-      app.registerRightPanel?.({
-        id: PANEL_ID,
-        title: "Vantor Open Data",
-        dock: "replace-style",
-        defaultWidth: 380,
-        deactivatePluginOnClose: true,
-        render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
-            app.closeRightPanel?.(PANEL_ID),
-          );
-          if (!unmount) return;
-          activeControl.expand();
-          return unmount;
-        },
-      }) ?? null;
-    app.openRightPanel?.(PANEL_ID);
+    unregisterPanel = app.registerRightPanel({
+      id: PANEL_ID,
+      title: "Vantor Open Data",
+      dock: "replace-style",
+      defaultWidth: 380,
+      deactivatePluginOnClose: true,
+      render: (container) => {
+        const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+          app.closeRightPanel?.(PANEL_ID),
+        );
+        if (!unmount) return;
+        activeControl.expand();
+        return unmount;
+      },
+    });
+    if (!app.openRightPanel(PANEL_ID)) {
+      unregisterPanel();
+      unregisterPanel = null;
+      control = null;
+      return false;
+    }
 
     unsubscribeLocale ??=
       app.onLocaleChange?.(() =>

--- a/packages/plugins/src/plugins/maplibre-vantor.ts
+++ b/packages/plugins/src/plugins/maplibre-vantor.ts
@@ -1,10 +1,12 @@
 import { VantorControl } from "./vantor/control";
-import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+import { mountMapControlInPanel } from "./dockable-map-control";
 
 export const VANTOR_PLUGIN_ID = "maplibre-gl-vantor";
 
 let control: VantorControl | null = null;
-let position: GeoLibreMapControlPosition = "top-left";
+const PANEL_ID = "vantor-panel";
+let unregisterPanel: (() => void) | null = null;
 let themeObserver: MutationObserver | null = null;
 let unsubscribeLocale: (() => void) | null = null;
 
@@ -38,16 +40,21 @@ export const maplibreVantorPlugin: GeoLibrePlugin = {
   version: "0.2.1",
   activate: (app: GeoLibreAppAPI) => {
     control ??= createControl(app);
-    const added = app.addMapControl(control, position);
-    if (!added) {
-      control = null;
-      return false;
-    }
-
     const activeControl = control;
-    setTimeout(() => {
-      if (control === activeControl) activeControl.expand();
-    }, 0);
+    unregisterPanel =
+      app.registerRightPanel?.({
+        id: PANEL_ID,
+        title: "Vantor Open Data",
+        dock: "replace-style",
+        defaultWidth: 380,
+        render: (container) => {
+          const unmount = mountMapControlInPanel(app, activeControl, container);
+          if (!unmount) return;
+          activeControl.expand();
+          return unmount;
+        },
+      }) ?? null;
+    app.openRightPanel?.(PANEL_ID);
 
     unsubscribeLocale ??=
       app.onLocaleChange?.(() =>
@@ -74,18 +81,9 @@ export const maplibreVantorPlugin: GeoLibrePlugin = {
     unsubscribeLocale?.();
     unsubscribeLocale = null;
     if (!control) return;
-    app.removeMapControl(control);
+    app.closeRightPanel?.(PANEL_ID);
+    unregisterPanel?.();
+    unregisterPanel = null;
     control = null;
-  },
-  getMapControlPosition: () => position,
-  setMapControlPosition: (app: GeoLibreAppAPI, nextPosition: GeoLibreMapControlPosition) => {
-    position = nextPosition;
-    if (!control) return;
-    app.removeMapControl(control);
-    const added = app.addMapControl(control, position);
-    if (!added) {
-      control = null;
-      return false;
-    }
   },
 };

--- a/packages/plugins/src/plugins/maplibre-vantor.ts
+++ b/packages/plugins/src/plugins/maplibre-vantor.ts
@@ -39,6 +39,7 @@ export const maplibreVantorPlugin: GeoLibrePlugin = {
   name: "Vantor Open Data",
   version: "0.2.1",
   activate: (app: GeoLibreAppAPI) => {
+    if (!app.getMap?.()) return false;
     control ??= createControl(app);
     const activeControl = control;
     unregisterPanel =
@@ -47,6 +48,7 @@ export const maplibreVantorPlugin: GeoLibrePlugin = {
         title: "Vantor Open Data",
         dock: "replace-style",
         defaultWidth: 380,
+        deactivatePluginOnClose: true,
         render: (container) => {
           const unmount = mountMapControlInPanel(app, activeControl, container);
           if (!unmount) return;

--- a/packages/plugins/src/plugins/maplibre-vantor.ts
+++ b/packages/plugins/src/plugins/maplibre-vantor.ts
@@ -1,6 +1,6 @@
 import { VantorControl } from "./vantor/control";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
-import { mountMapControlInPanel } from "./dockable-map-control";
+import { mountMapControlInPanel, unmountMapControlFromPanel } from "./dockable-map-control";
 
 export const VANTOR_PLUGIN_ID = "maplibre-gl-vantor";
 
@@ -89,6 +89,7 @@ export const maplibreVantorPlugin: GeoLibrePlugin = {
     unsubscribeLocale?.();
     unsubscribeLocale = null;
     if (!control) return;
+    unmountMapControlFromPanel(control);
     app.closeRightPanel?.(PANEL_ID);
     unregisterPanel?.();
     unregisterPanel = null;

--- a/packages/plugins/src/plugins/maplibre-vantor.ts
+++ b/packages/plugins/src/plugins/maplibre-vantor.ts
@@ -50,7 +50,9 @@ export const maplibreVantorPlugin: GeoLibrePlugin = {
         defaultWidth: 380,
         deactivatePluginOnClose: true,
         render: (container) => {
-          const unmount = mountMapControlInPanel(app, activeControl, container);
+          const unmount = mountMapControlInPanel(app, activeControl, container, () =>
+            app.closeRightPanel?.(PANEL_ID),
+          );
           if (!unmount) return;
           activeControl.expand();
           return unmount;

--- a/packages/plugins/src/plugins/vantor/styles.css
+++ b/packages/plugins/src/plugins/vantor/styles.css
@@ -316,10 +316,12 @@
 
 /* Select & Input styling. MapLibre ships `.maplibregl-ctrl select { color: #000
    !important }`, which would force black text on the dark-theme dropdowns in a
-   host like GeoLibre. Match its `!important` and beat it on specificity (the
-   extra `.maplibregl-ctrl-vantor` class) so the theme's text color wins. */
+   host like GeoLibre. Match its `!important` and cover both the original map
+   control wrapper and GeoLibre's native dock-panel wrapper. */
 .maplibregl-ctrl-vantor .vantor-panel select,
-.maplibregl-ctrl-vantor .vantor-panel input[type="text"] {
+.maplibregl-ctrl-vantor .vantor-panel input[type="text"],
+.geolibre-docked-map-control .vantor-panel select,
+.geolibre-docked-map-control .vantor-panel input[type="text"] {
   width: 100%;
   padding: 6px 8px;
   border: 1px solid var(--vantor-border);

--- a/packages/plugins/src/right-panel-registry.ts
+++ b/packages/plugins/src/right-panel-registry.ts
@@ -127,7 +127,7 @@ function emit(): void {
 
 function runHook(
   id: string,
-  hookName: "onOpen" | "onCollapse" | "onClose",
+  hookName: "onOpen" | "onCollapse" | "onClose" | "onExplicitClose",
   hook: (() => void) | undefined,
 ): void {
   if (!hook) return;
@@ -250,17 +250,20 @@ export function collapseRightPanel(id: string): void {
  * Close the active panel. No-op unless `id` is active.
  */
 export function closeRightPanel(id: string): void {
+  const panel = registry.get(id);
   if (!visibleIds.delete(id)) return;
   panelDocks.delete(id);
   if (activeId !== id) {
     emit();
+    runHook(id, "onExplicitClose", panel?.onExplicitClose);
     return;
   }
   activeId = null;
   collapsed = false;
   activeDock = null;
   emit();
-  runHook(id, "onClose", registry.get(id)?.onClose);
+  runHook(id, "onClose", panel?.onClose);
+  runHook(id, "onExplicitClose", panel?.onExplicitClose);
 }
 
 /**

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -975,7 +975,8 @@ export interface GeoLibreRightPanelRegistration {
   /**
    * Deactivate the owning plugin when the user closes this panel. Use for a
    * plugin whose panel is its entire UI, so panel and Plugins-menu state stay
-   * in sync. The host defers deactivation until after `onClose` returns.
+   * in sync. The host defers deactivation until after `onExplicitClose`
+   * returns; displacement by another panel does not deactivate the plugin.
    */
   deactivatePluginOnClose?: boolean;
   /**

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -991,6 +991,8 @@ export interface GeoLibreRightPanelRegistration {
   onCollapse?: () => void;
   /** Called after the panel closes (releases the workspace). */
   onClose?: () => void;
+  /** Called only when explicitly closed, not when another panel displaces it. */
+  onExplicitClose?: () => void;
 }
 
 export interface GeoLibrePlugin {

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -973,6 +973,12 @@ export interface GeoLibreRightPanelRegistration {
    */
   defaultWidth?: number;
   /**
+   * Deactivate the owning plugin when the user closes this panel. Use for a
+   * plugin whose panel is its entire UI, so panel and Plugins-menu state stay
+   * in sync. The host defers deactivation until after `onClose` returns.
+   */
+  deactivatePluginOnClose?: boolean;
+  /**
    * Populate the panel body. Called once with an empty container when the panel
    * first becomes active; the plugin appends its own DOM. The container is kept
    * mounted across collapse so plugin state persists. May return a cleanup

--- a/tests/dockable-map-control.test.ts
+++ b/tests/dockable-map-control.test.ts
@@ -20,6 +20,20 @@ function installDom() {
   return document;
 }
 
+function fakeMap(mapContainer: HTMLElement) {
+  let removeListener: (() => void) | null = null;
+  return {
+    getContainer: () => mapContainer,
+    on: (type: string, listener: () => void) => {
+      if (type === "remove") removeListener = listener;
+    },
+    off: (type: string, listener: () => void) => {
+      if (type === "remove" && removeListener === listener) removeListener = null;
+    },
+    emitRemove: () => removeListener?.(),
+  };
+}
+
 describe("mountMapControlInPanel", () => {
   it("moves an appended vendor panel into the native host and cleans it up", () => {
     const document = installDom();
@@ -39,7 +53,8 @@ describe("mountMapControlInPanel", () => {
         removed = true;
       },
     };
-    const app = { getMap: () => ({ getContainer: () => mapContainer }) } as GeoLibreAppAPI;
+    const map = fakeMap(mapContainer);
+    const app = { getMap: () => map } as unknown as GeoLibreAppAPI;
 
     const cleanup = mountMapControlInPanel(app, control as never, host);
 
@@ -66,12 +81,61 @@ describe("mountMapControlInPanel", () => {
       },
       onRemove: () => undefined,
     };
-    const app = { getMap: () => ({ getContainer: () => mapContainer }) } as GeoLibreAppAPI;
+    const map = fakeMap(mapContainer);
+    const app = { getMap: () => map } as unknown as GeoLibreAppAPI;
 
     const cleanup = mountMapControlInPanel(app, control as never, host);
 
     assert.ok(cleanup);
     assert.equal(host.firstElementChild?.className, "vantor-panel");
     cleanup();
+  });
+
+  it("cleans up the control when MapLibre removes the map", () => {
+    const document = installDom();
+    const mapContainer = document.querySelector<HTMLElement>("#map")!;
+    const host = document.createElement("div");
+    let removeCalls = 0;
+    const control = {
+      onAdd: () => {
+        const toggle = document.createElement("button");
+        const panel = document.createElement("section");
+        mapContainer.appendChild(panel);
+        return toggle;
+      },
+      onRemove: () => {
+        removeCalls += 1;
+      },
+    };
+    const map = fakeMap(mapContainer);
+    const app = { getMap: () => map } as unknown as GeoLibreAppAPI;
+
+    const cleanup = mountMapControlInPanel(app, control as never, host);
+    assert.ok(cleanup);
+    map.emitRemove();
+    cleanup();
+
+    assert.equal(removeCalls, 1);
+    assert.equal(host.childElementCount, 0);
+  });
+
+  it("reports a vendor panel mount failure to the caller", () => {
+    const document = installDom();
+    const mapContainer = document.querySelector<HTMLElement>("#map")!;
+    const host = document.createElement("div");
+    let failed = false;
+    const control = {
+      onAdd: () => document.createElement("button"),
+      onRemove: () => undefined,
+    };
+    const map = fakeMap(mapContainer);
+    const app = { getMap: () => map } as unknown as GeoLibreAppAPI;
+
+    const cleanup = mountMapControlInPanel(app, control as never, host, () => {
+      failed = true;
+    });
+
+    assert.equal(cleanup, null);
+    assert.equal(failed, true);
   });
 });

--- a/tests/dockable-map-control.test.ts
+++ b/tests/dockable-map-control.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { parseHTML } from "linkedom";
+import { mountMapControlInPanel } from "../packages/plugins/src/plugins/dockable-map-control";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
+
+const originalDocument = globalThis.document;
+const originalHTMLElement = globalThis.HTMLElement;
+
+afterEach(() => {
+  Object.assign(globalThis, {
+    document: originalDocument,
+    HTMLElement: originalHTMLElement,
+  });
+});
+
+function installDom() {
+  const { document, window } = parseHTML("<html><body><main id='map'></main></body></html>");
+  Object.assign(globalThis, { document, HTMLElement: window.HTMLElement });
+  return document;
+}
+
+describe("mountMapControlInPanel", () => {
+  it("moves an appended vendor panel into the native host and cleans it up", () => {
+    const document = installDom();
+    const mapContainer = document.querySelector<HTMLElement>("#map")!;
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    let removed = false;
+    const control = {
+      onAdd: () => {
+        const toggle = document.createElement("button");
+        const panel = document.createElement("section");
+        panel.className = "national-map-panel";
+        mapContainer.appendChild(panel);
+        return toggle;
+      },
+      onRemove: () => {
+        removed = true;
+      },
+    };
+    const app = { getMap: () => ({ getContainer: () => mapContainer }) } as GeoLibreAppAPI;
+
+    const cleanup = mountMapControlInPanel(app, control as never, host);
+
+    assert.ok(cleanup);
+    assert.equal(host.querySelectorAll(".national-map-panel").length, 1);
+    assert.equal(mapContainer.querySelectorAll(".national-map-panel").length, 0);
+    cleanup();
+    assert.equal(removed, true);
+    assert.equal(host.childElementCount, 0);
+  });
+
+  it("extracts Vantor's nested panel from the returned control wrapper", () => {
+    const document = installDom();
+    const mapContainer = document.querySelector<HTMLElement>("#map")!;
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const control = {
+      onAdd: () => {
+        const wrapper = document.createElement("div");
+        const panel = document.createElement("section");
+        panel.className = "vantor-panel";
+        wrapper.appendChild(panel);
+        return wrapper;
+      },
+      onRemove: () => undefined,
+    };
+    const app = { getMap: () => ({ getContainer: () => mapContainer }) } as GeoLibreAppAPI;
+
+    const cleanup = mountMapControlInPanel(app, control as never, host);
+
+    assert.ok(cleanup);
+    assert.equal(host.firstElementChild?.className, "vantor-panel");
+    cleanup();
+  });
+});

--- a/tests/dockable-map-control.test.ts
+++ b/tests/dockable-map-control.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { parseHTML } from "linkedom";
-import { mountMapControlInPanel } from "../packages/plugins/src/plugins/dockable-map-control";
+import {
+  mountMapControlInPanel,
+  unmountMapControlFromPanel,
+} from "../packages/plugins/src/plugins/dockable-map-control";
 import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 
 const originalDocument = globalThis.document;
@@ -113,6 +116,34 @@ describe("mountMapControlInPanel", () => {
     const cleanup = mountMapControlInPanel(app, control as never, host);
     assert.ok(cleanup);
     map.emitRemove();
+    cleanup();
+
+    assert.equal(removeCalls, 1);
+    assert.equal(host.childElementCount, 0);
+  });
+
+  it("supports synchronous plugin teardown before the panel effect unmounts", () => {
+    const document = installDom();
+    const mapContainer = document.querySelector<HTMLElement>("#map")!;
+    const host = document.createElement("div");
+    let removeCalls = 0;
+    const control = {
+      onAdd: () => {
+        const toggle = document.createElement("button");
+        const panel = document.createElement("section");
+        mapContainer.appendChild(panel);
+        return toggle;
+      },
+      onRemove: () => {
+        removeCalls += 1;
+      },
+    };
+    const map = fakeMap(mapContainer);
+    const app = { getMap: () => map } as unknown as GeoLibreAppAPI;
+
+    const cleanup = mountMapControlInPanel(app, control as never, host);
+    assert.ok(cleanup);
+    unmountMapControlFromPanel(control as never);
     cleanup();
 
     assert.equal(removeCalls, 1);

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -974,6 +974,41 @@ describe("PluginManager panel auto-expand on restore", () => {
     assert.equal(manager.isActive("close-with-panel"), false);
   });
 
+  it("deactivates an opted-in plugin when its panel close hook throws", async () => {
+    const manager = new PluginManager();
+    let registeredPanel: Parameters<NonNullable<GeoLibreAppAPI["registerRightPanel"]>>[0] | null =
+      null;
+    const mockApp = {
+      registerRightPanel: (panel: NonNullable<typeof registeredPanel>) => {
+        registeredPanel = panel;
+        return () => undefined;
+      },
+      deactivatePlugin: (id: string) => manager.deactivate(id, mockApp as GeoLibreAppAPI),
+    } as unknown as GeoLibreAppAPI;
+    manager.register(
+      testPlugin({
+        id: "throwing-close-panel",
+        activate: (api) => {
+          api.registerRightPanel?.({
+            id: "throwing-close-panel-content",
+            title: "Throwing close panel",
+            deactivatePluginOnClose: true,
+            render: () => undefined,
+            onClose: () => {
+              throw new Error("close failed");
+            },
+          });
+        },
+      }),
+    );
+
+    manager.activate("throwing-close-panel", mockApp);
+    assert.ok(registeredPanel);
+    assert.throws(() => registeredPanel.onClose?.(), /close failed/);
+    await flushTimers(1);
+    assert.equal(manager.isActive("throwing-close-panel"), false);
+  });
+
   it("leaves a plugin that persists its own collapsed state expanded", async () => {
     const manager = new PluginManager();
     const control = fakeControl();

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -904,6 +904,76 @@ describe("PluginManager panel auto-expand on restore", () => {
     );
   });
 
+  it("keeps restored native right panels collapsed", async () => {
+    const manager = new PluginManager();
+    let collapsed = false;
+    const mockApp = {
+      registerRightPanel: () => () => undefined,
+      openRightPanel: () => true,
+      collapseRightPanel: () => {
+        collapsed = true;
+      },
+    } as unknown as GeoLibreAppAPI;
+    manager.register(
+      testPlugin({
+        id: "native-panel",
+        activate: (api) => {
+          api.registerRightPanel?.({
+            id: "native-panel-content",
+            title: "Native panel",
+            render: () => undefined,
+          });
+          api.openRightPanel?.("native-panel-content");
+        },
+      }),
+    );
+
+    manager.restoreProjectState(
+      {
+        manifestUrls: [],
+        activePluginIds: ["native-panel"],
+        mapControlPositions: {},
+        settings: {},
+      },
+      mockApp,
+    );
+
+    await flushTimers();
+    assert.equal(collapsed, true, "a restored native right panel must remain collapsed");
+  });
+
+  it("deactivates an opted-in plugin when its native panel closes", async () => {
+    const manager = new PluginManager();
+    let registeredPanel: Parameters<NonNullable<GeoLibreAppAPI["registerRightPanel"]>>[0] | null =
+      null;
+    const mockApp = {
+      registerRightPanel: (panel: NonNullable<typeof registeredPanel>) => {
+        registeredPanel = panel;
+        return () => undefined;
+      },
+      deactivatePlugin: (id: string) => manager.deactivate(id, mockApp as GeoLibreAppAPI),
+    } as unknown as GeoLibreAppAPI;
+    manager.register(
+      testPlugin({
+        id: "close-with-panel",
+        activate: (api) => {
+          api.registerRightPanel?.({
+            id: "close-with-panel-content",
+            title: "Close with panel",
+            deactivatePluginOnClose: true,
+            render: () => undefined,
+          });
+        },
+      }),
+    );
+
+    manager.activate("close-with-panel", mockApp);
+    assert.ok(registeredPanel);
+    registeredPanel.onClose?.();
+    await flushTimers(1);
+    assert.equal(manager.isActive("close-with-panel"), false);
+  });
+
   it("leaves a plugin that persists its own collapsed state expanded", async () => {
     const manager = new PluginManager();
     const control = fakeControl();

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -971,6 +971,9 @@ describe("PluginManager panel auto-expand on restore", () => {
     assert.ok(registeredPanel);
     registeredPanel.onClose?.();
     await flushTimers(1);
+    assert.equal(manager.isActive("close-with-panel"), true);
+    registeredPanel.onExplicitClose?.();
+    await flushTimers(1);
     assert.equal(manager.isActive("close-with-panel"), false);
   });
 
@@ -994,7 +997,7 @@ describe("PluginManager panel auto-expand on restore", () => {
             title: "Throwing close panel",
             deactivatePluginOnClose: true,
             render: () => undefined,
-            onClose: () => {
+            onExplicitClose: () => {
               throw new Error("close failed");
             },
           });
@@ -1004,7 +1007,7 @@ describe("PluginManager panel auto-expand on restore", () => {
 
     manager.activate("throwing-close-panel", mockApp);
     assert.ok(registeredPanel);
-    assert.throws(() => registeredPanel.onClose?.(), /close failed/);
+    assert.throws(() => registeredPanel.onExplicitClose?.(), /close failed/);
     await flushTimers(1);
     assert.equal(manager.isActive("throwing-close-panel"), false);
   });

--- a/tests/right-panel-registry.test.ts
+++ b/tests/right-panel-registry.test.ts
@@ -49,6 +49,7 @@ describe("right-panel registry", () => {
         onOpen: () => calls.push("open"),
         onCollapse: () => calls.push("collapse"),
         onClose: () => calls.push("close"),
+        onExplicitClose: () => calls.push("explicit-close"),
       }),
     );
 
@@ -67,7 +68,7 @@ describe("right-panel registry", () => {
     closeRightPanel("workbench");
     assert.equal(getActiveRightPanel(), null);
 
-    assert.deepEqual(calls, ["open", "collapse", "close"]);
+    assert.deepEqual(calls, ["open", "collapse", "close", "explicit-close"]);
   });
 
   it("returns false and warns when opening an unregistered id", () => {
@@ -104,6 +105,20 @@ describe("right-panel registry", () => {
     openRightPanel("b");
     assert.equal(getActiveRightPanel(), "b");
     assert.deepEqual(calls, ["a:close", "b:open"]);
+  });
+
+  it("does not fire onExplicitClose when another panel takes over", () => {
+    const calls: string[] = [];
+    registerRightPanel(
+      testPanel({ id: "a", title: "A", onExplicitClose: () => calls.push("a:explicit") }),
+    );
+    registerRightPanel(testPanel({ id: "b", title: "B" }));
+    openRightPanel("a");
+    openRightPanel("b");
+    assert.deepEqual(calls, []);
+
+    closeRightPanel("a");
+    assert.deepEqual(calls, ["a:explicit"]);
   });
 
   it("keeps displaced panels visible in their rails until explicitly closed", () => {

--- a/tests/vantor-plugin.test.ts
+++ b/tests/vantor-plugin.test.ts
@@ -65,8 +65,9 @@ describe("Vantor Open Data built-in plugin", () => {
     assert.equal(pluginTier(VANTOR_PLUGIN_ID), "advanced");
   });
 
-  it("defaults to the top-left map-control position", () => {
-    assert.equal(maplibreVantorPlugin.getMapControlPosition?.(), "top-left");
+  it("registers as a dockable panel rather than a positioned map control", () => {
+    assert.equal(maplibreVantorPlugin.getMapControlPosition, undefined);
+    assert.equal(maplibreVantorPlugin.setMapControlPosition, undefined);
   });
 
   it("uses the GPU renderer by default and allows selecting WASM", async () => {

--- a/tests/vantor-plugin.test.ts
+++ b/tests/vantor-plugin.test.ts
@@ -14,6 +14,7 @@ import { PanelUI } from "../packages/plugins/src/plugins/vantor/panel";
 import { StacClient } from "../packages/plugins/src/plugins/vantor/stac-client";
 import { WEB_SERVICE_PLUGIN_IDS } from "../packages/plugins/src/plugins/web-service-sync";
 import { pluginTier } from "../apps/geolibre-desktop/src/lib/ui-profile";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 
 describe("Vantor Open Data built-in plugin", () => {
   const item = (id: string, href = "https://example.com/vantor.tif") =>
@@ -68,6 +69,20 @@ describe("Vantor Open Data built-in plugin", () => {
   it("registers as a dockable panel rather than a positioned map control", () => {
     assert.equal(maplibreVantorPlugin.getMapControlPosition, undefined);
     assert.equal(maplibreVantorPlugin.setMapControlPosition, undefined);
+  });
+
+  it("refuses activation when the native panel cannot open", () => {
+    let unregistered = false;
+    const app = {
+      getMap: () => ({}),
+      registerRightPanel: () => () => {
+        unregistered = true;
+      },
+      openRightPanel: () => false,
+    } as unknown as GeoLibreAppAPI;
+
+    assert.equal(maplibreVantorPlugin.activate(app), false);
+    assert.equal(unregistered, true);
   });
 
   it("uses the GPU renderer by default and allows selecting WASM", async () => {


### PR DESCRIPTION
## Summary
- move FEMA NFHL, NASA Earthdata, US EPA EnviroAtlas, USGS National Map, and Vantor Open Data into GeoLibre's dockable panel host
- preserve each control's MapLibre lifecycle and layer synchronization through a shared mounting adapter
- reset upstream floating-panel geometry so dock resizing and host controls work consistently

## Test plan
- [x] Run the scoped pre-commit checks for all changed files
- [x] Build the production web application
- [x] Run ESLint on the changed TypeScript files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map controls for EnviroAtlas, FEMA NFHL, NASA Earthdata, USGS National Map, and Vantor now open in dockable right-side panels.
  * Panels provide dedicated space for service controls while keeping the map visible.
* **Improvements**
  * Docked panels are restored cleanly when reopening projects.
  * Closing a panel now keeps plugin state synchronized.
* **Style**
  * Docked controls use the available panel width and support scrolling.
  * Overlay styling and unnecessary controls are hidden for a cleaner integrated appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->