### PR TITLE
fix: route desktop WMS tiles through native fetch

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -482,7 +482,8 @@ export async function applyServiceEntry(
       if (!params.layers.trim()) {
         throw new Error("This service has no layers.");
       }
-      addLayer(buildWmsLayer(params), beforeLayerId);
+      const { routeWmsLayerThroughNativeProtocol } = await import("../../../lib/xyz-url");
+      addLayer(routeWmsLayerThroughNativeProtocol(buildWmsLayer(params)), beforeLayerId);
       return;
     }
     case "wmts": {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -16,6 +16,7 @@ import {
   wmsVersionFromEndpoint,
   type WmsLayerOption,
 } from "../helpers";
+import { routeWmsLayerThroughNativeProtocol } from "../../../../lib/xyz-url";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import { serviceFieldBoolean, serviceFieldString, type ServiceFields } from "../service-library";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
@@ -214,16 +215,18 @@ export function WmsSource({
     // GetCapabilities URL), normalizes the version, and credits known keyless
     // services (e.g. GEBCO) in the map's attribution control.
     source.addAndClose(
-      buildWmsLayer({
-        name,
-        endpoint: wmsEndpoint,
-        layers: wmsLayers,
-        styles: wmsStyles,
-        format: wmsFormat,
-        transparent: wmsTransparent,
-        tileSize: wmsTileSize,
-        version: wmsVersion,
-      }),
+      routeWmsLayerThroughNativeProtocol(
+        buildWmsLayer({
+          name,
+          endpoint: wmsEndpoint,
+          layers: wmsLayers,
+          styles: wmsStyles,
+          format: wmsFormat,
+          transparent: wmsTransparent,
+          tileSize: wmsTileSize,
+          version: wmsVersion,
+        }),
+      ),
     );
   });
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -17,6 +17,7 @@ import {
   type WmsLayerOption,
 } from "../helpers";
 import { routeWmsLayerThroughNativeProtocol } from "../../../../lib/xyz-url";
+import { isHttpWmsUrl } from "../../../../lib/native-wms-url";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import { serviceFieldBoolean, serviceFieldString, type ServiceFields } from "../service-library";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
@@ -126,7 +127,7 @@ export function WmsSource({
 
   const handleRetrieveLayers = async () => {
     const endpoint = wmsEndpoint.trim();
-    if (!endpoint) {
+    if (!isHttpWmsUrl(endpoint)) {
       setRetrieveError(t("addData.wms.errorUrl"));
       return;
     }
@@ -207,7 +208,7 @@ export function WmsSource({
 
   const handleSubmit = source.runSubmit(() => {
     const name = source.layerName.trim() || t("addData.wms.defaultName");
-    if (!wmsEndpoint.trim()) throw new Error(t("addData.wms.errorUrl"));
+    if (!isHttpWmsUrl(wmsEndpoint.trim())) throw new Error(t("addData.wms.errorUrl"));
     if (!wmsLayers.trim()) {
       throw new Error(t("addData.wms.errorLayers"));
     }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -4,6 +4,7 @@ import {
   useAppStore,
 } from "@geolibre/core";
 import { buildProjectEgressSnapshot } from "../lib/build-project-snapshot";
+import { nativeWmsTileUrl } from "../lib/xyz-url";
 import {
   addRasterToMap,
   setRasterRenderEngine,
@@ -918,7 +919,7 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
         name,
         {
           type: "wms",
-          tiles: [tileUrl],
+          tiles: [isTauriRuntime() ? nativeWmsTileUrl(tileUrl) : tileUrl],
           url,
           // Persist the WMS request parameters so the layer round-trips through
           // a saved project, mirroring the Add Data dialog's WMS source.

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -4,7 +4,7 @@ import {
   useAppStore,
 } from "@geolibre/core";
 import { buildProjectEgressSnapshot } from "../lib/build-project-snapshot";
-import { nativeWmsTileUrl } from "../lib/xyz-url";
+import { nativeWmsTileUrl } from "../lib/native-wms-url";
 import {
   addRasterToMap,
   setRasterRenderEngine,

--- a/apps/geolibre-desktop/src/lib/native-wms-url.ts
+++ b/apps/geolibre-desktop/src/lib/native-wms-url.ts
@@ -2,6 +2,9 @@ export const WMS_TILE_PROTOCOL = "geolibre-wms";
 
 export function nativeWmsTileUrl(url: string): string {
   if (url.startsWith(`${WMS_TILE_PROTOCOL}://`)) return url;
+  if (!/^https?:\/\//i.test(url)) {
+    throw new Error("Invalid WMS tile URL.");
+  }
   // Leave MapLibre's WMS placeholder visible so it expands the bounding box
   // before handing the concrete request URL to the custom protocol.
   const encoded = encodeURIComponent(url).replaceAll("%7Bbbox-epsg-3857%7D", "{bbox-epsg-3857}");

--- a/apps/geolibre-desktop/src/lib/native-wms-url.ts
+++ b/apps/geolibre-desktop/src/lib/native-wms-url.ts
@@ -1,0 +1,9 @@
+export const WMS_TILE_PROTOCOL = "geolibre-wms";
+
+export function nativeWmsTileUrl(url: string): string {
+  if (url.startsWith(`${WMS_TILE_PROTOCOL}://`)) return url;
+  // Leave MapLibre's WMS placeholder visible so it expands the bounding box
+  // before handing the concrete request URL to the custom protocol.
+  const encoded = encodeURIComponent(url).replaceAll("%7Bbbox-epsg-3857%7D", "{bbox-epsg-3857}");
+  return `${WMS_TILE_PROTOCOL}://tile?url=${encoded}`;
+}

--- a/apps/geolibre-desktop/src/lib/native-wms-url.ts
+++ b/apps/geolibre-desktop/src/lib/native-wms-url.ts
@@ -1,8 +1,17 @@
 export const WMS_TILE_PROTOCOL = "geolibre-wms";
 
+export function isHttpWmsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function nativeWmsTileUrl(url: string): string {
   if (url.startsWith(`${WMS_TILE_PROTOCOL}://`)) return url;
-  if (!/^https?:\/\//i.test(url)) {
+  if (!isHttpWmsUrl(url)) {
     throw new Error("Invalid WMS tile URL.");
   }
   // Leave MapLibre's WMS placeholder visible so it expands the bounding box

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -2,10 +2,10 @@ import type { GeoLibreLayer, GeoLibreProject } from "@geolibre/core";
 import { invoke } from "@tauri-apps/api/core";
 import { addProtocol, type RequestParameters } from "maplibre-gl";
 import { resolveUrlRedirect } from "./native-http";
+import { nativeWmsTileUrl, WMS_TILE_PROTOCOL } from "./native-wms-url";
 import { isTauri } from "./tauri-io";
 
 const XYZ_TILE_PROTOCOL = "geolibre-xyz";
-const WMS_TILE_PROTOCOL = "geolibre-wms";
 
 let protocolRegistered = false;
 
@@ -157,14 +157,6 @@ export function routeWmsLayerThroughNativeProtocol(layer: GeoLibreLayer): GeoLib
       ),
     },
   };
-}
-
-export function nativeWmsTileUrl(url: string): string {
-  if (url.startsWith(`${WMS_TILE_PROTOCOL}://`)) return url;
-  // Leave MapLibre's WMS placeholder visible so it expands the bounding box
-  // before handing the concrete request URL to the custom protocol.
-  const encoded = encodeURIComponent(url).replaceAll("%7Bbbox-epsg-3857%7D", "{bbox-epsg-3857}");
-  return `${WMS_TILE_PROTOCOL}://tile?url=${encoded}`;
 }
 
 function getSavedXyzUrl(layer: GeoLibreLayer): string | null {

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -205,7 +205,7 @@ function parseXyzTileRequest(request: RequestParameters): string {
 
 function parseWmsTileRequest(request: RequestParameters): string {
   const url = new URL(request.url).searchParams.get("url");
-  if (!url || !/^https?:\/\//i.test(url)) {
+  if (!url || !isHttpUrl(url)) {
     throw new Error("Invalid WMS tile URL.");
   }
   return url;

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -5,6 +5,7 @@ import { resolveUrlRedirect } from "./native-http";
 import { isTauri } from "./tauri-io";
 
 const XYZ_TILE_PROTOCOL = "geolibre-xyz";
+const WMS_TILE_PROTOCOL = "geolibre-wms";
 
 let protocolRegistered = false;
 
@@ -73,22 +74,22 @@ export async function resolveXyzTileUrlTemplate(
 export function registerXyzTileProtocol(): void {
   if (protocolRegistered || !isTauri()) return;
 
-  addProtocol(XYZ_TILE_PROTOCOL, async (request) => {
-    const url = parseXyzTileRequest(request);
-    // This handler runs once per tile, so — unlike the one-shot native calls
-    // routed through native-http — it deliberately calls `invoke` directly and
-    // is NOT recorded in diagnostics: a fast pan over a tile server's coverage
-    // edge returns 404s in bulk, and recording each would re-render the panel
-    // per tile and evict more relevant entries from the 500-record ring buffer.
-    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
-      url,
-    });
-    const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-    return {
-      data: array.buffer.slice(array.byteOffset, array.byteOffset + array.byteLength),
-    };
-  });
+  addProtocol(XYZ_TILE_PROTOCOL, (request) => fetchNativeTile(parseXyzTileRequest(request)));
+  addProtocol(WMS_TILE_PROTOCOL, (request) => fetchNativeTile(parseWmsTileRequest(request)));
   protocolRegistered = true;
+}
+
+async function fetchNativeTile(url: string): Promise<{ data: ArrayBuffer }> {
+  // This handler runs once per tile, so — unlike the one-shot native calls
+  // routed through native-http — it deliberately calls `invoke` directly and
+  // is NOT recorded in diagnostics: a fast pan over a tile server's coverage
+  // edge returns 404s in bulk, and recording each would re-render the panel
+  // per tile and evict more relevant entries from the 500-record ring buffer.
+  const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
+    url,
+  });
+  const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  return { data: Uint8Array.from(array).buffer };
 }
 
 export async function resolveProjectXyzLayers(
@@ -112,6 +113,7 @@ async function resolveProjectXyzLayer(
   layer: GeoLibreLayer,
   signal?: AbortSignal,
 ): Promise<GeoLibreLayer> {
+  if (layer.type === "wms") return routeWmsLayerThroughNativeProtocol(layer);
   if (layer.type !== "xyz") return layer;
 
   const url = getSavedXyzUrl(layer);
@@ -141,6 +143,28 @@ async function resolveProjectXyzLayer(
       sourceKind: layer.metadata.sourceKind ?? "xyz-url",
     },
   };
+}
+
+/** Route a WMS layer through Tauri's CORS-exempt HTTP client on desktop. */
+export function routeWmsLayerThroughNativeProtocol(layer: GeoLibreLayer): GeoLibreLayer {
+  if (!isTauri() || layer.type !== "wms" || !Array.isArray(layer.source.tiles)) return layer;
+  return {
+    ...layer,
+    source: {
+      ...layer.source,
+      tiles: layer.source.tiles.map((tile) =>
+        typeof tile === "string" ? nativeWmsTileUrl(tile) : tile,
+      ),
+    },
+  };
+}
+
+export function nativeWmsTileUrl(url: string): string {
+  if (url.startsWith(`${WMS_TILE_PROTOCOL}://`)) return url;
+  // Leave MapLibre's WMS placeholder visible so it expands the bounding box
+  // before handing the concrete request URL to the custom protocol.
+  const encoded = encodeURIComponent(url).replaceAll("%7Bbbox-epsg-3857%7D", "{bbox-epsg-3857}");
+  return `${WMS_TILE_PROTOCOL}://tile?url=${encoded}`;
 }
 
 function getSavedXyzUrl(layer: GeoLibreLayer): string | null {
@@ -185,6 +209,14 @@ function parseXyzTileRequest(request: RequestParameters): string {
     .replace(/\{z\}/g, parts[0])
     .replace(/\{x\}/g, parts[1])
     .replace(/\{y\}/g, parts[2]);
+}
+
+function parseWmsTileRequest(request: RequestParameters): string {
+  const url = new URL(request.url).searchParams.get("url");
+  if (!url || !/^https?:\/\//i.test(url)) {
+    throw new Error("Invalid WMS tile URL.");
+  }
+  return url;
 }
 
 function isHttpUrl(url: string): boolean {

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -74,8 +74,8 @@ export async function resolveXyzTileUrlTemplate(
 export function registerXyzTileProtocol(): void {
   if (protocolRegistered || !isTauri()) return;
 
-  addProtocol(XYZ_TILE_PROTOCOL, (request) => fetchNativeTile(parseXyzTileRequest(request)));
-  addProtocol(WMS_TILE_PROTOCOL, (request) => fetchNativeTile(parseWmsTileRequest(request)));
+  addProtocol(XYZ_TILE_PROTOCOL, async (request) => fetchNativeTile(parseXyzTileRequest(request)));
+  addProtocol(WMS_TILE_PROTOCOL, async (request) => fetchNativeTile(parseWmsTileRequest(request)));
   protocolRegistered = true;
 }
 

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -2,7 +2,7 @@ import type { GeoLibreLayer, GeoLibreProject } from "@geolibre/core";
 import { invoke } from "@tauri-apps/api/core";
 import { addProtocol, type RequestParameters } from "maplibre-gl";
 import { resolveUrlRedirect } from "./native-http";
-import { nativeWmsTileUrl, WMS_TILE_PROTOCOL } from "./native-wms-url";
+import { isHttpWmsUrl, nativeWmsTileUrl, WMS_TILE_PROTOCOL } from "./native-wms-url";
 import { isTauri } from "./tauri-io";
 
 const XYZ_TILE_PROTOCOL = "geolibre-xyz";
@@ -205,7 +205,7 @@ function parseXyzTileRequest(request: RequestParameters): string {
 
 function parseWmsTileRequest(request: RequestParameters): string {
   const url = new URL(request.url).searchParams.get("url");
-  if (!url || !isHttpUrl(url)) {
+  if (!url || !isHttpWmsUrl(url)) {
     throw new Error("Invalid WMS tile URL.");
   }
   return url;

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -89,7 +89,7 @@ async function fetchNativeTile(url: string): Promise<{ data: ArrayBuffer }> {
     url,
   });
   const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-  return { data: Uint8Array.from(array).buffer };
+  return { data: array.slice().buffer };
 }
 
 export async function resolveProjectXyzLayers(

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1726,7 +1726,9 @@ function portableWmsTileUrl(tile: unknown): unknown {
   if (typeof tile !== "string" || !tile.startsWith("geolibre-wms://")) return tile;
   try {
     const url = new URL(tile).searchParams.get("url");
-    return url && /^https?:\/\//i.test(url) ? url : tile;
+    if (!url) return tile;
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : tile;
   } catch {
     return tile;
   }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1723,6 +1723,8 @@ function prepareLayerForSave(layer: GeoLibreLayer): GeoLibreLayer {
 }
 
 function portableWmsTileUrl(tile: unknown): unknown {
+  // Keep this protocol prefix in sync with WMS_TILE_PROTOCOL in the desktop
+  // app, which packages/core cannot import without reversing dependencies.
   if (typeof tile !== "string" || !tile.startsWith("geolibre-wms://")) return tile;
   try {
     const url = new URL(tile).searchParams.get("url");

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1689,6 +1689,15 @@ function prepareLayerForSave(layer: GeoLibreLayer): GeoLibreLayer {
     layer = rest;
   }
 
+  if (layer.type === "wms") {
+    const tiles = layer.source.tiles;
+    if (!Array.isArray(tiles)) return layer;
+    const portableTiles = tiles.map((tile) => portableWmsTileUrl(tile));
+    return portableTiles.some((tile, index) => tile !== tiles[index])
+      ? { ...layer, source: { ...layer.source, tiles: portableTiles } }
+      : layer;
+  }
+
   if (layer.type !== "xyz") return layer;
 
   const originalUrl =
@@ -1711,6 +1720,16 @@ function prepareLayerForSave(layer: GeoLibreLayer): GeoLibreLayer {
     },
     metadata,
   };
+}
+
+function portableWmsTileUrl(tile: unknown): unknown {
+  if (typeof tile !== "string" || !tile.startsWith("geolibre-wms://")) return tile;
+  try {
+    const url = new URL(tile).searchParams.get("url");
+    return url && /^https?:\/\//i.test(url) ? url : tile;
+  } catch {
+    return tile;
+  }
 }
 
 export function applyProjectToStore(project: GeoLibreProject): {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1414,9 +1414,7 @@ function getWebServiceTiles(layer: GeoLibreLayer): string[] {
   return tiles.map((tile) =>
     // Skip already proxied templates so repeated sync passes cannot nest
     // proxy URLs.
-    tile.includes("{bbox-epsg-3857}") && !tile.startsWith(WMS_PROXY_PATH)
-      ? proxyWmsTileUrl(tile)
-      : tile,
+    tile.includes("{bbox-epsg-3857}") && /^https?:\/\//i.test(tile) ? proxyWmsTileUrl(tile) : tile,
   );
 }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -2990,7 +2990,7 @@ function syncImageLayer(map: maplibregl.Map, layer: GeoLibreLayer, beforeId?: st
 function getRenderableRasterTiles(layer: GeoLibreLayer): string[] {
   const tiles = (layer.source.tiles as string[]) ?? [];
   if (layer.type !== "wms" || !isViteDevServer()) return tiles;
-  return tiles.map(proxyWmsTileUrl);
+  return tiles.map((tile) => (/^https?:\/\//i.test(tile) ? proxyWmsTileUrl(tile) : tile));
 }
 
 function isViteDevServer(): boolean {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -49,6 +49,28 @@ describe("project parsing", () => {
     assert.equal(layer.source.tiles[0], routed);
   });
 
+  it("does not save an invalid URL extracted from a desktop WMS route", () => {
+    const routed = "geolibre-wms://tile?url=https%3A%2F%2F";
+    const layer = {
+      ...geojsonLayer({ id: "wms" }),
+      type: "wms" as const,
+      source: { type: "raster" as const, tiles: [routed] },
+      geojson: undefined,
+    };
+    const saved = projectFromStore({
+      projectName: "Invalid routed WMS",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [layer],
+      preferences: createEmptyProject().preferences,
+      metadata: {},
+    });
+
+    assert.equal(saved.layers[0].source.tiles?.[0], routed);
+  });
+
   it("preserves layer style fields missing from a legacy top-level style", () => {
     const base = createEmptyProject("Partial legacy style");
     const layer = geojsonLayer({

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -21,6 +21,34 @@ import {
 import { geojsonLayer } from "./helpers/layer-fixtures";
 
 describe("project parsing", () => {
+  it("restores portable WMS URLs when saving a desktop-routed layer", () => {
+    const tile = "https://example.com/wms?BBOX={bbox-epsg-3857}";
+    const routed = `geolibre-wms://tile?url=${encodeURIComponent(tile).replaceAll(
+      "%7Bbbox-epsg-3857%7D",
+      "{bbox-epsg-3857}",
+    )}`;
+    const layer = {
+      ...geojsonLayer({ id: "wms" }),
+      type: "wms" as const,
+      source: { type: "raster" as const, tiles: [routed] },
+      geojson: undefined,
+    };
+
+    const saved = projectFromStore({
+      projectName: "Portable WMS",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [layer],
+      preferences: createEmptyProject().preferences,
+      metadata: {},
+    });
+
+    assert.equal(saved.layers[0].source.tiles?.[0], tile);
+    assert.equal(layer.source.tiles[0], routed);
+  });
+
   it("preserves layer style fields missing from a legacy top-level style", () => {
     const base = createEmptyProject("Partial legacy style");
     const layer = geojsonLayer({

--- a/tests/native-wms-url.test.ts
+++ b/tests/native-wms-url.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GeoLibreLayer } from "@geolibre/core";
+import {
+  nativeWmsTileUrl,
+  routeWmsLayerThroughNativeProtocol,
+} from "../apps/geolibre-desktop/src/lib/xyz-url";
+
+test("nativeWmsTileUrl preserves the MapLibre bbox placeholder", () => {
+  const tile =
+    "https://example.com/wms?SERVICE=WMS&LAYERS=roads&BBOX={bbox-epsg-3857}&FORMAT=image%2Fpng";
+  const routed = nativeWmsTileUrl(tile);
+
+  assert.match(routed, /^geolibre-wms:\/\/tile\?url=/);
+  assert.match(routed, /\{bbox-epsg-3857\}/);
+  assert.equal(new URL(routed).searchParams.get("url"), tile);
+});
+
+test("nativeWmsTileUrl does not wrap an already routed URL", () => {
+  const routed = "geolibre-wms://tile?url=https%3A%2F%2Fexample.com%2Fwms";
+  assert.equal(nativeWmsTileUrl(routed), routed);
+});
+
+test("routeWmsLayerThroughNativeProtocol only changes desktop WMS tiles", () => {
+  const globals = globalThis as typeof globalThis & { window?: unknown };
+  const previousWindow = globals.window;
+  const tile = "https://example.com/wms?BBOX={bbox-epsg-3857}";
+  const layer = {
+    id: "wms",
+    name: "WMS",
+    type: "wms",
+    source: { type: "raster", tiles: [tile] },
+    metadata: {},
+  } as GeoLibreLayer;
+
+  try {
+    globals.window = {};
+    assert.equal(routeWmsLayerThroughNativeProtocol(layer), layer);
+
+    globals.window = { __TAURI_INTERNALS__: {} };
+    const routed = routeWmsLayerThroughNativeProtocol(layer);
+    assert.notEqual(routed, layer);
+    assert.match(String(routed.source.tiles?.[0]), /^geolibre-wms:/);
+    assert.equal(layer.source.tiles?.[0], tile);
+  } finally {
+    if (previousWindow === undefined) delete globals.window;
+    else globals.window = previousWindow;
+  }
+});

--- a/tests/native-wms-url.test.ts
+++ b/tests/native-wms-url.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { GeoLibreLayer } from "@geolibre/core";
 import { routeWmsLayerThroughNativeProtocol } from "../apps/geolibre-desktop/src/lib/xyz-url";
-import { nativeWmsTileUrl } from "../apps/geolibre-desktop/src/lib/native-wms-url";
+import { isHttpWmsUrl, nativeWmsTileUrl } from "../apps/geolibre-desktop/src/lib/native-wms-url";
 
 test("nativeWmsTileUrl preserves the MapLibre bbox placeholder", () => {
   const tile =
@@ -21,6 +21,15 @@ test("nativeWmsTileUrl does not wrap an already routed URL", () => {
 
 test("nativeWmsTileUrl rejects non-HTTP tile URLs", () => {
   assert.throws(() => nativeWmsTileUrl("file:///tmp/tile.png"), /Invalid WMS tile URL/);
+  assert.throws(() => nativeWmsTileUrl("https://"), /Invalid WMS tile URL/);
+});
+
+test("isHttpWmsUrl accepts only syntactically valid HTTP(S) URLs", () => {
+  assert.equal(isHttpWmsUrl("https://example.com/wms"), true);
+  assert.equal(isHttpWmsUrl("http://example.com/wms"), true);
+  assert.equal(isHttpWmsUrl("example.com/wms"), false);
+  assert.equal(isHttpWmsUrl("https://"), false);
+  assert.equal(isHttpWmsUrl("file:///tmp/tile.png"), false);
 });
 
 test("routeWmsLayerThroughNativeProtocol only changes desktop WMS tiles", () => {

--- a/tests/native-wms-url.test.ts
+++ b/tests/native-wms-url.test.ts
@@ -1,10 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { GeoLibreLayer } from "@geolibre/core";
-import {
-  nativeWmsTileUrl,
-  routeWmsLayerThroughNativeProtocol,
-} from "../apps/geolibre-desktop/src/lib/xyz-url";
+import { routeWmsLayerThroughNativeProtocol } from "../apps/geolibre-desktop/src/lib/xyz-url";
+import { nativeWmsTileUrl } from "../apps/geolibre-desktop/src/lib/native-wms-url";
 
 test("nativeWmsTileUrl preserves the MapLibre bbox placeholder", () => {
   const tile =

--- a/tests/native-wms-url.test.ts
+++ b/tests/native-wms-url.test.ts
@@ -19,6 +19,10 @@ test("nativeWmsTileUrl does not wrap an already routed URL", () => {
   assert.equal(nativeWmsTileUrl(routed), routed);
 });
 
+test("nativeWmsTileUrl rejects non-HTTP tile URLs", () => {
+  assert.throws(() => nativeWmsTileUrl("file:///tmp/tile.png"), /Invalid WMS tile URL/);
+});
+
 test("routeWmsLayerThroughNativeProtocol only changes desktop WMS tiles", () => {
   const globals = globalThis as typeof globalThis & { window?: unknown };
   const previousWindow = globals.window;


### PR DESCRIPTION
## Summary

- route desktop WMS GetMap tiles through the existing CORS-exempt native byte fetch
- preserve MapLibre bounding-box substitution before native requests
- keep browser behavior unchanged and avoid the Vite WMS proxy rewrapping native protocol URLs
- add focused native WMS URL tests

## Verification

- reproduced the missing and duplicate CORS header failures with the five-layer project from the issue
- verified concrete FVG GetMap URLs reach the native protocol after MapLibre expands the bounding box
- verified the supplied project in light and dark themes
- `npm run test:frontend` (7,397 passed, 1 skipped)
- `npm run build`
- `npm run check:rust`
- pre-commit on changed files

Fixes #2166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native WMS tile support in the desktop app.
  * WMS layers and plugin-added layers now use native protocol routing where available.
  * WMS URLs are converted to portable URLs when projects are saved.
* **Bug Fixes**
  * Prevented already-routed, local, and data URLs from unnecessary proxying.
  * Preserved WMS bounding-box placeholders during URL handling.
  * Preserved original layer configurations during routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->