### PR TITLE
fix: prevent photo imports from blocking desktop startup

### DIFF
--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1637,6 +1637,7 @@ dependencies = [
 name = "geolibre-desktop"
 version = "2.8.0"
 dependencies = [
+ "bincode",
  "chrono",
  "duckdb",
  "flate2",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -67,6 +67,7 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+bincode = "1"
 # OS CSPRNG for the per-launch Jupyter token (already an indirect dep).
 getrandom = "0.4"
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -724,16 +724,25 @@ fn read_selected_image(
 ) -> Result<tauri::ipc::Response, String> {
     let path = PathBuf::from(path);
     let selected = app.state::<SelectedImagePaths>();
-    let mut allowed = selected
-        .0
-        .lock()
-        .map_err(|_| "Could not lock the selected-image allowlist".to_string())?;
-    if !allowed.contains(&path) {
-        return Err("Refusing to read an image that was not selected".to_string());
+    {
+        let mut allowed = selected
+            .0
+            .lock()
+            .map_err(|_| "Could not lock the selected-image allowlist".to_string())?;
+        if !allowed.remove(&path) {
+            return Err("Refusing to read an image that was not selected".to_string());
+        }
     }
-    let bytes = fs::read(&path).map_err(|error| format!("Could not read selected image: {error}"))?;
-    allowed.remove(&path);
-    Ok(tauri::ipc::Response::new(bytes))
+    match fs::read(&path) {
+        Ok(bytes) => Ok(tauri::ipc::Response::new(bytes)),
+        Err(error) => {
+            // Preserve retry behavior without holding the mutex during I/O.
+            if let Ok(mut allowed) = selected.0.lock() {
+                allowed.insert(path);
+            }
+            Err(format!("Could not read selected image: {error}"))
+        }
+    }
 }
 
 /// Add one GeoTIFF to the asset-protocol scope. The filesystem and asset scopes

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -84,13 +84,17 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tauri_plugin_dialog::DialogExt;
 
 const PERSISTED_SCOPE_FILES: [&str; 2] = [".persisted-scope", ".persisted-scope-asset"];
-const PERSISTED_PHOTO_EXTENSIONS: [&str; 5] = [".jpg", ".jpeg", ".webp", ".heic", ".heif"];
+const PERSISTED_PHOTO_EXTENSIONS: [&str; 6] =
+    [".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif"];
 
 #[derive(Deserialize, Serialize)]
 struct PersistedScopeState {
     allowed_paths: Vec<String>,
     forbidden_patterns: Vec<String>,
 }
+
+#[derive(Default)]
+struct SelectedImagePaths(Mutex<HashSet<PathBuf>>);
 
 fn is_persisted_image_file(path: &str) -> bool {
     let lower = path.to_ascii_lowercase();
@@ -339,6 +343,7 @@ pub fn run() {
 
     let builder = builder
         .manage(pending_project_paths)
+        .manage(SelectedImagePaths::default())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         // Runs before persisted-scope's setup hook so legacy photo grants are
@@ -400,6 +405,7 @@ pub fn run() {
             native_duckdb::load_native_vector_file,
             load_external_plugin_bundles,
             pick_image_paths,
+            read_selected_image,
             read_admin_profile,
             read_env_vars,
             take_pending_project_paths,
@@ -670,12 +676,9 @@ fn read_local_file(path: String) -> Result<tauri::ipc::Response, String> {
         .map_err(|error| format!("Could not read local file: {error}"))
 }
 
-/// Pick images while granting only their containing directories to Tauri's
-/// filesystem scope. The stock dialog command grants every selected file to
-/// both persisted scopes, so a large photo import can make the next desktop
-/// launch spend minutes replaying thousands of entries before creating a
-/// window. Geotagged-photo imports consume the bytes immediately, making one
-/// non-recursive directory grant sufficient.
+/// Pick images without adding them to Tauri's filesystem or asset scopes. The
+/// returned paths enter a short-lived native allowlist and can only be consumed
+/// by `read_selected_image`.
 #[tauri::command]
 async fn pick_image_paths(app: tauri::AppHandle) -> Result<Vec<String>, String> {
     const IMAGE_EXTENSIONS: [&str; 8] =
@@ -693,25 +696,44 @@ async fn pick_image_paths(app: tauri::AppHandle) -> Result<Vec<String>, String> 
     .map_err(|error| format!("Could not open the image picker: {error}"))?
     .unwrap_or_default();
 
-    let mut directories = HashSet::new();
     let mut paths = Vec::with_capacity(selected.len());
     for file in selected {
         let path = file
             .into_path()
             .map_err(|error| format!("Could not resolve a selected image path: {error}"))?;
-        if let Some(parent) = path.parent() {
-            directories.insert(parent.to_path_buf());
-        }
-        paths.push(path.to_string_lossy().into_owned());
+        paths.push(path);
     }
-    for directory in directories {
-        app.fs_scope()
-            .allow_directory(directory, false)
-            .map_err(|error| {
-                format!("Could not authorize the selected image directory: {error}")
-            })?;
+    app.state::<SelectedImagePaths>()
+        .0
+        .lock()
+        .map_err(|_| "Could not lock the selected-image allowlist".to_string())?
+        .extend(paths.iter().cloned());
+    Ok(paths
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect())
+}
+
+/// Read one image explicitly selected by `pick_image_paths`, then remove its
+/// path from the allowlist. This avoids both persistent grants and access to
+/// unselected sibling files.
+#[tauri::command]
+fn read_selected_image(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<tauri::ipc::Response, String> {
+    let path = PathBuf::from(path);
+    let selected = app.state::<SelectedImagePaths>();
+    let mut allowed = selected
+        .0
+        .lock()
+        .map_err(|_| "Could not lock the selected-image allowlist".to_string())?;
+    if !allowed.contains(&path) {
+        return Err("Refusing to read an image that was not selected".to_string());
     }
-    Ok(paths)
+    let bytes = fs::read(&path).map_err(|error| format!("Could not read selected image: {error}"))?;
+    allowed.remove(&path);
+    Ok(tauri::ipc::Response::new(bytes))
 }
 
 /// Add one GeoTIFF to the asset-protocol scope. The filesystem and asset scopes

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -86,6 +86,8 @@ use tauri_plugin_dialog::DialogExt;
 const PERSISTED_SCOPE_FILES: [&str; 2] = [".persisted-scope", ".persisted-scope-asset"];
 const PERSISTED_PHOTO_EXTENSIONS: [&str; 6] =
     [".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif"];
+const IMAGE_PICKER_EXTENSIONS: [&str; 8] =
+    ["jpg", "jpeg", "png", "webp", "heic", "heif", "tif", "tiff"];
 
 #[derive(Deserialize, Serialize)]
 struct PersistedScopeState {
@@ -101,6 +103,16 @@ fn is_persisted_image_file(path: &str) -> bool {
     PERSISTED_PHOTO_EXTENSIONS
         .iter()
         .any(|extension| lower.ends_with(extension))
+}
+
+fn is_image_picker_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            IMAGE_PICKER_EXTENSIONS
+                .iter()
+                .any(|allowed| extension.eq_ignore_ascii_case(allowed))
+        })
 }
 
 /// Remove legacy per-image grants before persisted-scope synchronously replays
@@ -681,15 +693,12 @@ fn read_local_file(path: String) -> Result<tauri::ipc::Response, String> {
 /// by `read_selected_image`.
 #[tauri::command]
 async fn pick_image_paths(app: tauri::AppHandle) -> Result<Vec<String>, String> {
-    const IMAGE_EXTENSIONS: [&str; 8] =
-        ["jpg", "jpeg", "png", "webp", "heic", "heif", "tif", "tiff"];
-
     let dialog_app = app.clone();
     let selected = tauri::async_runtime::spawn_blocking(move || {
         dialog_app
             .dialog()
             .file()
-            .add_filter("Images", &IMAGE_EXTENSIONS)
+            .add_filter("Images", &IMAGE_PICKER_EXTENSIONS)
             .blocking_pick_files()
     })
     .await
@@ -701,7 +710,9 @@ async fn pick_image_paths(app: tauri::AppHandle) -> Result<Vec<String>, String> 
         let path = file
             .into_path()
             .map_err(|error| format!("Could not resolve a selected image path: {error}"))?;
-        paths.push(path);
+        if is_image_picker_path(&path) {
+            paths.push(path);
+        }
     }
     app.state::<SelectedImagePaths>()
         .0
@@ -733,16 +744,9 @@ fn read_selected_image(
             return Err("Refusing to read an image that was not selected".to_string());
         }
     }
-    match fs::read(&path) {
-        Ok(bytes) => Ok(tauri::ipc::Response::new(bytes)),
-        Err(error) => {
-            // Preserve retry behavior without holding the mutex during I/O.
-            if let Ok(mut allowed) = selected.0.lock() {
-                allowed.insert(path);
-            }
-            Err(format!("Could not read selected image: {error}"))
-        }
-    }
+    fs::read(&path)
+        .map(tauri::ipc::Response::new)
+        .map_err(|error| format!("Could not read selected image: {error}"))
 }
 
 /// Add one GeoTIFF to the asset-protocol scope. The filesystem and asset scopes
@@ -4437,7 +4441,7 @@ mod tests {
     use super::{
         client_cert_is_pkcs12, client_cert_password_without_path, ensure_fetchable_url,
         is_allowed_local_vector_path, is_allowed_project_path, is_disallowed_ip,
-        is_persisted_image_file,
+        is_image_picker_path, is_persisted_image_file,
         is_safe_absolute_path, is_ssrf_guard_error, path_is_under, project_path_string,
         project_paths_from_args, resolve_fetch_timeout_secs, tcp_table_port,
         MAX_FETCH_TIMEOUT_SECS, REMOTE_TILE_TIMEOUT_SECS, SSRF_BLOCKED_MESSAGE,
@@ -5298,6 +5302,19 @@ mod tests {
         assert!(!is_persisted_image_file(r"X:\survey\photos\**"));
         assert!(!is_persisted_image_file(r"X:\survey\map.geolibre"));
         assert!(!is_persisted_image_file(r"X:\survey\points.geojson"));
+    }
+
+    #[test]
+    fn native_image_picker_rejects_paths_outside_its_filter() {
+        assert!(is_image_picker_path(std::path::Path::new(
+            r"X:\survey\PHOTO.JPEG"
+        )));
+        assert!(is_image_picker_path(std::path::Path::new(
+            r"X:\survey\ortho.tiff"
+        )));
+        assert!(!is_image_picker_path(std::path::Path::new(
+            r"X:\survey\notes.txt"
+        )));
     }
 
     // The image-path guard is what keeps the reaper from killing a Jupyter the

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -63,9 +63,7 @@ use flate2::read::{GzDecoder, ZlibDecoder};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-#[cfg(not(feature = "mas"))]
-use std::collections::HashSet;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::env;
 #[cfg(not(feature = "mas"))]
 use std::ffi::OsStr;
@@ -83,6 +81,53 @@ use std::process::{Child, Command, Stdio};
 #[cfg(not(feature = "mas"))]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
+use tauri_plugin_dialog::DialogExt;
+
+const PERSISTED_SCOPE_FILES: [&str; 2] = [".persisted-scope", ".persisted-scope-asset"];
+const PERSISTED_IMAGE_EXTENSIONS: [&str; 8] = [
+    ".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif", ".tif", ".tiff",
+];
+
+#[derive(Deserialize, Serialize)]
+struct PersistedScopeState {
+    allowed_paths: Vec<String>,
+    forbidden_patterns: Vec<String>,
+}
+
+fn is_persisted_image_file(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    PERSISTED_IMAGE_EXTENSIONS
+        .iter()
+        .any(|extension| lower.ends_with(extension))
+}
+
+/// Remove legacy per-image grants before persisted-scope synchronously replays
+/// them. Photo workflows consume or embed image bytes during the current
+/// session, so these grants are not needed after restart.
+fn prune_persisted_image_scopes(app: &tauri::AppHandle) {
+    let Ok(app_data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    for file_name in PERSISTED_SCOPE_FILES {
+        let path = app_data_dir.join(file_name);
+        let Ok(bytes) = fs::read(&path) else {
+            continue;
+        };
+        let Ok(mut state) = bincode::deserialize::<PersistedScopeState>(&bytes) else {
+            continue;
+        };
+        let original_len = state.allowed_paths.len();
+        state
+            .allowed_paths
+            .retain(|allowed| !is_persisted_image_file(allowed));
+        if state.allowed_paths.len() == original_len {
+            continue;
+        }
+        if let Ok(compacted) = bincode::serialize(&state) {
+            let _ = fs::write(path, compacted);
+        }
+    }
+}
 #[cfg(not(feature = "mas"))]
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -298,6 +343,16 @@ pub fn run() {
         .manage(pending_project_paths)
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        // Runs before persisted-scope's setup hook so legacy photo grants are
+        // removed before its synchronous restore can delay window creation.
+        .plugin(
+            tauri::plugin::Builder::<tauri::Wry>::new("photo-scope-cleanup")
+                .setup(|app, _api| {
+                    prune_persisted_image_scopes(app);
+                    Ok(())
+                })
+                .build(),
+        )
         // Must init after the fs plugin: it restores previously-granted fs
         // scope (e.g. Browser-panel pinned folders) so they survive a restart.
         //
@@ -346,6 +401,7 @@ pub fn run() {
             install_external_plugin_archive,
             native_duckdb::load_native_vector_file,
             load_external_plugin_bundles,
+            pick_image_paths,
             read_admin_profile,
             read_env_vars,
             take_pending_project_paths,
@@ -614,6 +670,50 @@ fn read_local_file(path: String) -> Result<tauri::ipc::Response, String> {
     fs::read(&path)
         .map(tauri::ipc::Response::new)
         .map_err(|error| format!("Could not read local file: {error}"))
+}
+
+/// Pick images while granting only their containing directories to Tauri's
+/// filesystem scope. The stock dialog command grants every selected file to
+/// both persisted scopes, so a large photo import can make the next desktop
+/// launch spend minutes replaying thousands of entries before creating a
+/// window. Geotagged-photo imports consume the bytes immediately, making one
+/// non-recursive directory grant sufficient.
+#[tauri::command]
+async fn pick_image_paths(app: tauri::AppHandle) -> Result<Vec<String>, String> {
+    const IMAGE_EXTENSIONS: [&str; 8] =
+        ["jpg", "jpeg", "png", "webp", "heic", "heif", "tif", "tiff"];
+
+    let dialog_app = app.clone();
+    let selected = tauri::async_runtime::spawn_blocking(move || {
+        dialog_app
+            .dialog()
+            .file()
+            .add_filter("Images", &IMAGE_EXTENSIONS)
+            .blocking_pick_files()
+    })
+    .await
+    .map_err(|error| format!("Could not open the image picker: {error}"))?
+    .unwrap_or_default();
+
+    let mut directories = HashSet::new();
+    let mut paths = Vec::with_capacity(selected.len());
+    for file in selected {
+        let path = file
+            .into_path()
+            .map_err(|error| format!("Could not resolve a selected image path: {error}"))?;
+        if let Some(parent) = path.parent() {
+            directories.insert(parent.to_path_buf());
+        }
+        paths.push(path.to_string_lossy().into_owned());
+    }
+    for directory in directories {
+        app.fs_scope()
+            .allow_directory(directory, false)
+            .map_err(|error| {
+                format!("Could not authorize the selected image directory: {error}")
+            })?;
+    }
+    Ok(paths)
 }
 
 /// Add one GeoTIFF to the asset-protocol scope. The filesystem and asset scopes
@@ -4308,6 +4408,7 @@ mod tests {
     use super::{
         client_cert_is_pkcs12, client_cert_password_without_path, ensure_fetchable_url,
         is_allowed_local_vector_path, is_allowed_project_path, is_disallowed_ip,
+        is_persisted_image_file,
         is_safe_absolute_path, is_ssrf_guard_error, path_is_under, project_path_string,
         project_paths_from_args, resolve_fetch_timeout_secs, tcp_table_port,
         MAX_FETCH_TIMEOUT_SECS, REMOTE_TILE_TIMEOUT_SECS, SSRF_BLOCKED_MESSAGE,
@@ -5152,6 +5253,19 @@ mod tests {
             resolve_fetch_timeout_secs(Some(u64::MAX)),
             MAX_FETCH_TIMEOUT_SECS
         );
+    }
+
+    #[test]
+    fn recognizes_only_persisted_image_file_grants() {
+        assert!(is_persisted_image_file(
+            r"\\?\UNC\server\drone photos\IMG_0042.JPEG"
+        ));
+        assert!(is_persisted_image_file(r"X:\survey\ortho.tif"));
+        // Directory patterns must survive even when their names contain an
+        // image-looking segment, as must unrelated project and vector grants.
+        assert!(!is_persisted_image_file(r"X:\survey\photos\**"));
+        assert!(!is_persisted_image_file(r"X:\survey\map.geolibre"));
+        assert!(!is_persisted_image_file(r"X:\survey\points.geojson"));
     }
 
     // The image-path guard is what keeps the reaper from killing a Jupyter the

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -84,9 +84,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tauri_plugin_dialog::DialogExt;
 
 const PERSISTED_SCOPE_FILES: [&str; 2] = [".persisted-scope", ".persisted-scope-asset"];
-const PERSISTED_IMAGE_EXTENSIONS: [&str; 8] = [
-    ".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif", ".tif", ".tiff",
-];
+const PERSISTED_PHOTO_EXTENSIONS: [&str; 5] = [".jpg", ".jpeg", ".webp", ".heic", ".heif"];
 
 #[derive(Deserialize, Serialize)]
 struct PersistedScopeState {
@@ -96,7 +94,7 @@ struct PersistedScopeState {
 
 fn is_persisted_image_file(path: &str) -> bool {
     let lower = path.to_ascii_lowercase();
-    PERSISTED_IMAGE_EXTENSIONS
+    PERSISTED_PHOTO_EXTENSIONS
         .iter()
         .any(|extension| lower.ends_with(extension))
 }
@@ -5260,7 +5258,10 @@ mod tests {
         assert!(is_persisted_image_file(
             r"\\?\UNC\server\drone photos\IMG_0042.JPEG"
         ));
-        assert!(is_persisted_image_file(r"X:\survey\ortho.tif"));
+        // TIFF grants may belong to persistent GeoTIFF raster layers, so the
+        // startup migration must leave them intact even though the photo
+        // importer also accepts TIFF images.
+        assert!(!is_persisted_image_file(r"X:\survey\ortho.tif"));
         // Directory patterns must survive even when their names contain an
         // image-looking segment, as must unrelated project and vector grants.
         assert!(!is_persisted_image_file(r"X:\survey\photos\**"));

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -56,6 +56,7 @@ import { PHOTO_IMAGE_EXTENSIONS, isPhotoDropFileName, isPhotoFileName } from "./
 import { projectedGeoJsonCrs } from "./crs-utils";
 import { nativeFileDialogFilters, type FileDialogFilter } from "./file-dialog-filters";
 import { parseGpxLayer } from "./gpx";
+import { isMobile } from "./is-mobile";
 import { isTauri } from "./is-tauri";
 import { SHAPEFILE_COMPANION_EXTENSIONS, shapefileCompanionPathsFromSelection } from "./mas-build";
 import {
@@ -3543,10 +3544,15 @@ export async function pickLocalRasterFiles(): Promise<{ file: File | string; pat
  */
 export async function pickImageFilesWithFallback(): Promise<File[]> {
   if (isTauri()) {
-    const selected = await open({
-      multiple: true,
-      filters: [{ name: "Images", extensions: [...PHOTO_IMAGE_EXTENSIONS] }],
-    });
+    // Desktop uses a native command that grants each containing directory once
+    // instead of persisting one fs and asset-scope entry per selected photo.
+    // Mobile keeps the plugin picker because its selections can be content URIs.
+    const selected = isMobile()
+      ? await open({
+          multiple: true,
+          filters: [{ name: "Images", extensions: [...PHOTO_IMAGE_EXTENSIONS] }],
+        })
+      : await invoke<string[]>("pick_image_paths");
     if (!selected) return [];
     const paths = (Array.isArray(selected) ? selected : [selected]).filter(isPhotoFileName);
     const files: File[] = [];

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -56,7 +56,7 @@ import { PHOTO_IMAGE_EXTENSIONS, isPhotoDropFileName, isPhotoFileName } from "./
 import { projectedGeoJsonCrs } from "./crs-utils";
 import { nativeFileDialogFilters, type FileDialogFilter } from "./file-dialog-filters";
 import { parseGpxLayer } from "./gpx";
-import { isMobile } from "./is-mobile";
+import { isDesktopRuntime } from "./is-mobile";
 import { isTauri } from "./is-tauri";
 import { SHAPEFILE_COMPANION_EXTENSIONS, shapefileCompanionPathsFromSelection } from "./mas-build";
 import {
@@ -3544,15 +3544,16 @@ export async function pickLocalRasterFiles(): Promise<{ file: File | string; pat
  */
 export async function pickImageFilesWithFallback(): Promise<File[]> {
   if (isTauri()) {
-    // Desktop uses a native command that grants each containing directory once
-    // instead of persisting one fs and asset-scope entry per selected photo.
-    // Mobile keeps the plugin picker because its selections can be content URIs.
-    const selected = isMobile()
-      ? await open({
+    // Desktop uses a native picker and one-shot reader, so selected photos do
+    // not enter either persisted scope. Mobile keeps the plugin picker because
+    // its selections can be content URIs.
+    const desktop = isDesktopRuntime();
+    const selected = desktop
+      ? await invoke<string[]>("pick_image_paths")
+      : await open({
           multiple: true,
           filters: [{ name: "Images", extensions: [...PHOTO_IMAGE_EXTENSIONS] }],
-        })
-      : await invoke<string[]>("pick_image_paths");
+        });
     if (!selected) return [];
     const paths = (Array.isArray(selected) ? selected : [selected]).filter(isPhotoFileName);
     const files: File[] = [];
@@ -3560,7 +3561,10 @@ export async function pickImageFilesWithFallback(): Promise<File[]> {
       // Read each pick independently so one unreadable file does not abandon the
       // rest of the selection.
       try {
-        files.push(new File([toArrayBuffer(await readFile(path))], browserSafeFileName(path)));
+        const bytes = desktop
+          ? await invoke<ArrayBuffer>("read_selected_image", { path })
+          : await readFile(path);
+        files.push(new File([bytes], browserSafeFileName(path)));
       } catch (error) {
         console.warn(`Could not read the selected image "${path}".`, error);
       }

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -207,6 +207,16 @@ assignability against the real imported type, so a renamed or dropped engine
 identifier fails `npm run typecheck`. Nothing extra to do on a bump beyond letting
 the build run.
 
+### `tauri-plugin-persisted-scope` — private on-disk format
+
+`PersistedScopeState` (`apps/geolibre-desktop/src-tauri/src/lib.rs`) mirrors the
+plugin's private bincode `Scope` structure so GeoLibre can remove legacy
+per-photo grants before the plugin synchronously replays them at startup. On a
+`tauri-plugin-persisted-scope` bump, compare the upstream struct's field order
+and types against this mirror and run the Rust scope-cleanup tests. Bincode
+encodes fields positionally, so an upstream layout change is not compiler
+checked.
+
 ### `@tauri-apps/plugin-http` — two upstream *behaviors*, not APIs
 
 `createNativeSidecarFetch`


### PR DESCRIPTION
## Summary

- remove legacy persisted image-file grants before Tauri restores its filesystem scopes
- use a desktop-native photo picker that grants each containing directory once instead of every selected file
- retain the existing content-URI-compatible picker on mobile

## Verification

- reproduced the per-file scope growth path in Tauri dialog and persisted-scope source
- verified the Geotagged Photos dialog in light and dark themes with Playwright
- `cargo test recognizes_only_persisted_image_file_grants`
- `npm run test:frontend` (7,401 passed, 1 skipped)
- `npm run build -w geolibre-desktop`
- pre-commit hooks on changed files

Fixes #2170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native desktop image selection with secure, temporary access to chosen files.
  * Preserved the existing image-picker experience on mobile devices.
  * Added automatic cleanup of outdated persisted image permissions while preserving supported directory and TIFF access.

* **Bug Fixes**
  * Improved image access reliability after restarting the desktop application.

* **Documentation**
  * Added maintenance guidance for validating persisted-permission updates and keeping image access dependable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->