### PR TITLE
fix: prevent map flash during window resize

### DIFF
--- a/apps/geolibre-desktop/src/lib/panel-resize.ts
+++ b/apps/geolibre-desktop/src/lib/panel-resize.ts
@@ -1,6 +1,7 @@
 // Window events dispatched by the docked panels (Python Console, SQL Workspace,
 // Dashboard, Assistant, Attribute Table) while a drag-to-resize is in progress,
-// so MapCanvas can pause expensive work until the drag ends. Shared here so the
-// event names cannot drift between the dispatchers and the listener.
-export const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
-export const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+// so the map can pause expensive work until the drag ends. The names live in
+// `@geolibre/map` beside the listener that consumes them and are re-exported
+// here, so the event names cannot drift between the dispatchers and the
+// listener.
+export { PANEL_RESIZE_END_EVENT, PANEL_RESIZE_START_EVENT } from "@geolibre/map";

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -69,6 +69,7 @@ const FEATURE_SELECTION_BEGIN_EVENT = "geolibre:feature-selection-begin";
 const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
 const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
+const RESIZE_DEBOUNCE_MS = 100;
 const WEB_MERCATOR_MAX_LATITUDE = 85.0511287798066;
 const WEB_MERCATOR_EARTH_RADIUS = 6378137;
 const WEB_MERCATOR_WORLD_SIZE = 2 * Math.PI * WEB_MERCATOR_EARTH_RADIUS;
@@ -1636,14 +1637,14 @@ export const MapCanvas = memo(function MapCanvas({
       }
       // Resizing a WebGL canvas reallocates and clears its framebuffer before
       // MapLibre's next render. During a continuous window drag that used to
-      // reveal the transparent canvas for several frames. Keep the previous
-      // frame CSS-scaled while dimensions are changing, then resize once after
-      // they settle.
+      // reveal the transparent canvas for several frames. While dimensions are
+      // changing, the browser naturally stretches the previous canvas bitmap
+      // to its CSS box; resize the backing store once the dimensions settle.
       if (resizeTimer !== null) window.clearTimeout(resizeTimer);
       resizeTimer = window.setTimeout(() => {
         resizeTimer = null;
         commitResize();
-      }, 100);
+      }, RESIZE_DEBOUNCE_MS);
     };
     const onPanelResizeStart = () => {
       panelResizeActive = true;
@@ -1668,7 +1669,7 @@ export const MapCanvas = memo(function MapCanvas({
     resizeObserver.observe(containerRef.current);
     window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
     window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
-    resizeMap();
+    commitResize();
 
     return () => {
       resizeObserver.disconnect();

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1621,6 +1621,9 @@ export const MapCanvas = memo(function MapCanvas({
 
     let resizeFrame: number | null = null;
     let resizeTimer: number | null = null;
+    let windowResizeTimer: number | null = null;
+    let windowResizeActive = false;
+    let observedDevicePixelRatio = window.devicePixelRatio;
     let panelResizeActive = false;
     let resizeAfterPanelResize = false;
     const mapNeedsResize = () => {
@@ -1629,18 +1632,32 @@ export const MapCanvas = memo(function MapCanvas({
       if (!map || !container) return false;
       const { width, height } = container.getBoundingClientRect();
       const canvas = map.getCanvas();
-      return parseFloat(canvas.style.width) !== width || parseFloat(canvas.style.height) !== height;
+      return (
+        parseFloat(canvas.style.width) !== width ||
+        parseFloat(canvas.style.height) !== height ||
+        observedDevicePixelRatio !== window.devicePixelRatio
+      );
     };
     const commitResize = () => {
       if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
       resizeFrame = window.requestAnimationFrame(() => {
         resizeFrame = null;
-        if (mapNeedsResize()) mc.getMap()?.resize();
+        if (mapNeedsResize()) {
+          mc.getMap()?.resize();
+          observedDevicePixelRatio = window.devicePixelRatio;
+        }
       });
     };
     const resizeMap = () => {
       if (panelResizeActive) {
         resizeAfterPanelResize = true;
+        return;
+      }
+      // App layout changes such as toggling a sidebar are discrete and should
+      // resize on the next frame. Only coalesce the rapid observer callbacks
+      // produced while the browser window itself is being dragged.
+      if (!windowResizeActive) {
+        commitResize();
         return;
       }
       // Resizing a WebGL canvas reallocates and clears its framebuffer before
@@ -1653,6 +1670,15 @@ export const MapCanvas = memo(function MapCanvas({
         resizeTimer = null;
         commitResize();
       }, RESIZE_DEBOUNCE_MS);
+    };
+    const onWindowResize = () => {
+      windowResizeActive = true;
+      if (windowResizeTimer !== null) window.clearTimeout(windowResizeTimer);
+      windowResizeTimer = window.setTimeout(() => {
+        windowResizeTimer = null;
+        windowResizeActive = false;
+      }, RESIZE_DEBOUNCE_MS);
+      resizeMap();
     };
     const onPanelResizeStart = () => {
       panelResizeActive = true;
@@ -1675,12 +1701,14 @@ export const MapCanvas = memo(function MapCanvas({
     };
     const resizeObserver = new ResizeObserver(resizeMap);
     resizeObserver.observe(containerRef.current);
+    window.addEventListener("resize", onWindowResize);
     window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
     window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
     commitResize();
 
     return () => {
       resizeObserver.disconnect();
+      window.removeEventListener("resize", onWindowResize);
       window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
       window.removeEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
       if (resizeFrame !== null) {
@@ -1688,6 +1716,9 @@ export const MapCanvas = memo(function MapCanvas({
       }
       if (resizeTimer !== null) {
         window.clearTimeout(resizeTimer);
+      }
+      if (windowResizeTimer !== null) {
+        window.clearTimeout(windowResizeTimer);
       }
       pointerElevation.dispose();
       map.getContainer().removeEventListener("click", handleProjectionControlClick);

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1623,11 +1623,19 @@ export const MapCanvas = memo(function MapCanvas({
     let resizeTimer: number | null = null;
     let panelResizeActive = false;
     let resizeAfterPanelResize = false;
+    const mapNeedsResize = () => {
+      const map = mc.getMap();
+      const container = containerRef.current;
+      if (!map || !container) return false;
+      const { width, height } = container.getBoundingClientRect();
+      const canvas = map.getCanvas();
+      return parseFloat(canvas.style.width) !== width || parseFloat(canvas.style.height) !== height;
+    };
     const commitResize = () => {
       if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
       resizeFrame = window.requestAnimationFrame(() => {
         resizeFrame = null;
-        mc.getMap()?.resize();
+        if (mapNeedsResize()) mc.getMap()?.resize();
       });
     };
     const resizeMap = () => {
@@ -1637,9 +1645,9 @@ export const MapCanvas = memo(function MapCanvas({
       }
       // Resizing a WebGL canvas reallocates and clears its framebuffer before
       // MapLibre's next render. During a continuous window drag that used to
-      // reveal the transparent canvas for several frames. While dimensions are
-      // changing, the browser naturally stretches the previous canvas bitmap
-      // to its CSS box; resize the backing store once the dimensions settle.
+      // reveal the transparent canvas for several frames. Keep the previous
+      // bitmap in place while dimensions are changing, then resize the backing
+      // store once the dimensions settle.
       if (resizeTimer !== null) window.clearTimeout(resizeTimer);
       resizeTimer = window.setTimeout(() => {
         resizeTimer = null;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -54,6 +54,7 @@ import {
 import { isGlobeControlToggleClick } from "./globe-control-toggle";
 import { createGlobalIdentifyHitDeduper } from "./identify-all";
 import { createMapController, type MapController } from "./map-controller";
+import { createMapResizeScheduler } from "./map-resize";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "maplibre-gl-layer-control/style.css";
 import "./layer-control-overrides.css";
@@ -66,10 +67,7 @@ import "./layer-control-overrides.css";
  * motionless cursor would sit there until the first drag.
  */
 const FEATURE_SELECTION_BEGIN_EVENT = "geolibre:feature-selection-begin";
-const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
-const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
-const RESIZE_DEBOUNCE_MS = 100;
 const WEB_MERCATOR_MAX_LATITUDE = 85.0511287798066;
 const WEB_MERCATOR_EARTH_RADIUS = 6378137;
 const WEB_MERCATOR_WORLD_SIZE = 2 * Math.PI * WEB_MERCATOR_EARTH_RADIUS;
@@ -1619,107 +1617,13 @@ export const MapCanvas = memo(function MapCanvas({
       onControllerReadyRef.current?.();
     });
 
-    let resizeFrame: number | null = null;
-    let resizeTimer: number | null = null;
-    let windowResizeTimer: number | null = null;
-    let windowResizeActive = false;
-    let observedDevicePixelRatio = window.devicePixelRatio;
-    let panelResizeActive = false;
-    let resizeAfterPanelResize = false;
-    const mapNeedsResize = () => {
-      const map = mc.getMap();
-      const container = containerRef.current;
-      if (!map || !container) return false;
-      const { width, height } = container.getBoundingClientRect();
-      const canvas = map.getCanvas();
-      return (
-        parseFloat(canvas.style.width) !== width ||
-        parseFloat(canvas.style.height) !== height ||
-        observedDevicePixelRatio !== window.devicePixelRatio
-      );
-    };
-    const commitResize = () => {
-      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
-      resizeFrame = window.requestAnimationFrame(() => {
-        resizeFrame = null;
-        if (mapNeedsResize()) {
-          mc.getMap()?.resize();
-          observedDevicePixelRatio = window.devicePixelRatio;
-        }
-      });
-    };
-    const resizeMap = () => {
-      if (panelResizeActive) {
-        resizeAfterPanelResize = true;
-        return;
-      }
-      // App layout changes such as toggling a sidebar are discrete and should
-      // resize on the next frame. Only coalesce the rapid observer callbacks
-      // produced while the browser window itself is being dragged.
-      if (!windowResizeActive) {
-        commitResize();
-        return;
-      }
-      // Resizing a WebGL canvas reallocates and clears its framebuffer before
-      // MapLibre's next render. During a continuous window drag that used to
-      // reveal the transparent canvas for several frames. Keep the previous
-      // bitmap in place while dimensions are changing, then resize the backing
-      // store once the dimensions settle.
-      if (resizeTimer !== null) window.clearTimeout(resizeTimer);
-      resizeTimer = window.setTimeout(() => {
-        resizeTimer = null;
-        commitResize();
-      }, RESIZE_DEBOUNCE_MS);
-    };
-    const onWindowResize = () => {
-      windowResizeActive = true;
-      if (windowResizeTimer !== null) window.clearTimeout(windowResizeTimer);
-      windowResizeTimer = window.setTimeout(() => {
-        windowResizeTimer = null;
-        windowResizeActive = false;
-      }, RESIZE_DEBOUNCE_MS);
-      resizeMap();
-    };
-    const onPanelResizeStart = () => {
-      panelResizeActive = true;
-      resizeAfterPanelResize = false;
-      if (resizeFrame !== null) {
-        window.cancelAnimationFrame(resizeFrame);
-        resizeFrame = null;
-      }
-      if (resizeTimer !== null) {
-        window.clearTimeout(resizeTimer);
-        resizeTimer = null;
-      }
-    };
-    const onPanelResizeEnd = () => {
-      panelResizeActive = false;
-      if (resizeAfterPanelResize) {
-        resizeAfterPanelResize = false;
-      }
-      commitResize();
-    };
-    const resizeObserver = new ResizeObserver(resizeMap);
-    resizeObserver.observe(containerRef.current);
-    window.addEventListener("resize", onWindowResize);
-    window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
-    window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
-    commitResize();
+    const disposeResizeScheduler = createMapResizeScheduler({
+      getMap: () => mc.getMap(),
+      container: containerRef.current,
+    });
 
     return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener("resize", onWindowResize);
-      window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
-      window.removeEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
-      if (resizeFrame !== null) {
-        window.cancelAnimationFrame(resizeFrame);
-      }
-      if (resizeTimer !== null) {
-        window.clearTimeout(resizeTimer);
-      }
-      if (windowResizeTimer !== null) {
-        window.clearTimeout(windowResizeTimer);
-      }
+      disposeResizeScheduler();
       pointerElevation.dispose();
       map.getContainer().removeEventListener("click", handleProjectionControlClick);
       mc.destroy();

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1619,21 +1619,31 @@ export const MapCanvas = memo(function MapCanvas({
     });
 
     let resizeFrame: number | null = null;
+    let resizeTimer: number | null = null;
     let panelResizeActive = false;
     let resizeAfterPanelResize = false;
+    const commitResize = () => {
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null;
+        mc.getMap()?.resize();
+      });
+    };
     const resizeMap = () => {
       if (panelResizeActive) {
         resizeAfterPanelResize = true;
         return;
       }
-
-      if (resizeFrame !== null) {
-        window.cancelAnimationFrame(resizeFrame);
-      }
-      resizeFrame = window.requestAnimationFrame(() => {
-        resizeFrame = null;
-        mc.getMap()?.resize();
-      });
+      // Resizing a WebGL canvas reallocates and clears its framebuffer before
+      // MapLibre's next render. During a continuous window drag that used to
+      // reveal the transparent canvas for several frames. Keep the previous
+      // frame CSS-scaled while dimensions are changing, then resize once after
+      // they settle.
+      if (resizeTimer !== null) window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(() => {
+        resizeTimer = null;
+        commitResize();
+      }, 100);
     };
     const onPanelResizeStart = () => {
       panelResizeActive = true;
@@ -1642,13 +1652,17 @@ export const MapCanvas = memo(function MapCanvas({
         window.cancelAnimationFrame(resizeFrame);
         resizeFrame = null;
       }
+      if (resizeTimer !== null) {
+        window.clearTimeout(resizeTimer);
+        resizeTimer = null;
+      }
     };
     const onPanelResizeEnd = () => {
       panelResizeActive = false;
       if (resizeAfterPanelResize) {
         resizeAfterPanelResize = false;
       }
-      resizeMap();
+      commitResize();
     };
     const resizeObserver = new ResizeObserver(resizeMap);
     resizeObserver.observe(containerRef.current);
@@ -1662,6 +1676,9 @@ export const MapCanvas = memo(function MapCanvas({
       window.removeEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
       if (resizeFrame !== null) {
         window.cancelAnimationFrame(resizeFrame);
+      }
+      if (resizeTimer !== null) {
+        window.clearTimeout(resizeTimer);
       }
       pointerElevation.dispose();
       map.getContainer().removeEventListener("click", handleProjectionControlClick);

--- a/packages/map/src/SecondaryMapCanvas.tsx
+++ b/packages/map/src/SecondaryMapCanvas.tsx
@@ -6,6 +6,7 @@ import {
 } from "@geolibre/core";
 import { memo, useEffect, useMemo, useRef } from "react";
 import { createMapController, type MapController } from "./map-controller";
+import { createMapResizeScheduler } from "./map-resize";
 import "maplibre-gl/dist/maplibre-gl.css";
 
 export interface SecondaryMapCanvasProps {
@@ -126,20 +127,15 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
       mc.setBasemapOpacity(live.basemapOpacity);
     });
 
-    let resizeFrame: number | null = null;
-    const resizeMap = () => {
-      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
-      resizeFrame = window.requestAnimationFrame(() => {
-        resizeFrame = null;
-        mc.getMap()?.resize();
-      });
-    };
-    const resizeObserver = new ResizeObserver(resizeMap);
-    resizeObserver.observe(containerRef.current);
+    // Shared with the primary map so a compare/swipe pane gets the same
+    // flash-free behaviour during a continuous window drag.
+    const disposeResizeScheduler = createMapResizeScheduler({
+      getMap: () => mc.getMap(),
+      container: containerRef.current,
+    });
 
     return () => {
-      resizeObserver.disconnect();
-      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      disposeResizeScheduler();
       mc.destroy();
       controller.current = null;
     };

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -14,6 +14,7 @@ export {
   type FeatureSelectionRequest,
   type FeatureSelectionShape,
 } from "./feature-selection";
+export { PANEL_RESIZE_END_EVENT, PANEL_RESIZE_START_EVENT } from "./map-resize";
 export { SecondaryMapCanvas, type SecondaryMapCanvasProps } from "./SecondaryMapCanvas";
 export { CesiumCanvas, type CesiumCanvasProps } from "./CesiumCanvas";
 export { isCesiumSupportedLayerType } from "./cesium-layer-sync";

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -580,6 +580,11 @@ export class MapController {
       renderWorldCopies: mapPreferences.renderWorldCopies,
       attributionControl: false,
       maplibreLogo: false,
+      // MapCanvas owns resizing through a ResizeObserver because its container
+      // also changes when app panels open and close. Letting MapLibre listen to
+      // window.resize as well causes competing framebuffer reallocations while
+      // a browser window is dragged, briefly exposing a transparent canvas.
+      trackResize: false,
       // preserveDrawingBuffer must stay true: the Print Layout composer and any
       // future export feature reads the canvas via drawImage / toDataURL outside
       // of a render callback. Removing this causes blank captures on browsers

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -580,8 +580,9 @@ export class MapController {
       renderWorldCopies: mapPreferences.renderWorldCopies,
       attributionControl: false,
       maplibreLogo: false,
-      // MapCanvas owns resizing through a ResizeObserver because its container
-      // also changes when app panels open and close. Letting MapLibre listen to
+      // The canvases own resizing through the shared scheduler in map-resize.ts
+      // (both MapCanvas and SecondaryMapCanvas) because the container also
+      // changes when app panels open and close. Letting MapLibre listen to
       // window.resize as well causes competing framebuffer reallocations while
       // a browser window is dragged, briefly exposing a transparent canvas.
       trackResize: false,

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -42,6 +42,8 @@ export function createMapResizeScheduler({
   let resizeTimer: number | null = null;
   let windowResizeTimer: number | null = null;
   let windowResizeActive = false;
+  let observedWindowWidth = window.innerWidth;
+  let observedWindowHeight = window.innerHeight;
   let observedDevicePixelRatio = window.devicePixelRatio;
   let panelResizeActive = false;
 
@@ -103,12 +105,33 @@ export function createMapResizeScheduler({
     devicePixelRatioQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
     devicePixelRatioQuery.addEventListener("change", onDevicePixelRatioChange);
   };
+  // Whether a callback belongs to a browser-window drag is decided by comparing
+  // the window's own dimensions, not by whether the `resize` event happened to
+  // be handled before the ResizeObserver callback for the same layout change:
+  // that ordering is not guaranteed across engines, and losing the race on the
+  // first frame of a drag would resize the backing store mid-drag. Both signals
+  // run after the window has already taken its new size, so either one detects
+  // the drag; the settle timer then keeps the following frames coalesced.
+  const windowResizeInProgress = () => {
+    if (observedWindowWidth === window.innerWidth && observedWindowHeight === window.innerHeight) {
+      return windowResizeActive;
+    }
+    observedWindowWidth = window.innerWidth;
+    observedWindowHeight = window.innerHeight;
+    windowResizeActive = true;
+    if (windowResizeTimer !== null) window.clearTimeout(windowResizeTimer);
+    windowResizeTimer = window.setTimeout(() => {
+      windowResizeTimer = null;
+      windowResizeActive = false;
+    }, RESIZE_DEBOUNCE_MS);
+    return true;
+  };
   const resizeMap = () => {
     if (panelResizeActive) return;
     // App layout changes such as toggling a sidebar are discrete and should
     // resize on the next frame. Only coalesce the rapid observer callbacks
     // produced while the browser window itself is being dragged.
-    if (!windowResizeActive) {
+    if (!windowResizeInProgress()) {
       commitResize();
       return;
     }
@@ -124,15 +147,6 @@ export function createMapResizeScheduler({
       resizeTimer = null;
       commitResize();
     }, RESIZE_DEBOUNCE_MS);
-  };
-  const onWindowResize = () => {
-    windowResizeActive = true;
-    if (windowResizeTimer !== null) window.clearTimeout(windowResizeTimer);
-    windowResizeTimer = window.setTimeout(() => {
-      windowResizeTimer = null;
-      windowResizeActive = false;
-    }, RESIZE_DEBOUNCE_MS);
-    resizeMap();
   };
   const clearWindowResizeState = () => {
     if (windowResizeTimer !== null) {
@@ -156,7 +170,7 @@ export function createMapResizeScheduler({
 
   const resizeObserver = new ResizeObserver(resizeMap);
   resizeObserver.observe(container);
-  window.addEventListener("resize", onWindowResize);
+  window.addEventListener("resize", resizeMap);
   window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
   window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
   watchDevicePixelRatio();
@@ -164,7 +178,7 @@ export function createMapResizeScheduler({
 
   return () => {
     resizeObserver.disconnect();
-    window.removeEventListener("resize", onWindowResize);
+    window.removeEventListener("resize", resizeMap);
     window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
     window.removeEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
     unwatchDevicePixelRatio();

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -1,0 +1,151 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+/** Dispatched by the drag-resizable docked panels when a splitter drag begins. */
+export const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
+/** Dispatched by the drag-resizable docked panels when a splitter drag ends. */
+export const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+/**
+ * How long the container dimensions must stay still before the WebGL backing
+ * store is resized. Long enough to swallow a continuous window drag, short
+ * enough that the stretched previous frame is not perceived as lag.
+ */
+export const RESIZE_DEBOUNCE_MS = 100;
+
+export interface MapResizeSchedulerOptions {
+  /** The MapLibre map, read lazily so the scheduler survives style reloads. */
+  getMap: () => MapLibreMap | null | undefined;
+  /** The element the map is mounted in; observed for size changes. */
+  container: HTMLElement;
+}
+
+/**
+ * Own MapLibre canvas sizing for a map pane.
+ *
+ * MapLibre's own `trackResize` is disabled (see `createMapController`) because
+ * the container also changes when app panels open, close, and are dragged;
+ * letting both resize paths run causes competing framebuffer reallocations that
+ * briefly expose a transparent canvas. This scheduler is the single owner:
+ *
+ * - discrete layout changes (toggling a sidebar) resize on the next frame,
+ * - the rapid observer callbacks of a continuous window drag are debounced so
+ *   the previously rendered bitmap stays on screen while dimensions move,
+ * - a docked-panel splitter drag suppresses resizes until the drag ends.
+ *
+ * @param options Map accessor and the container element to observe.
+ * @returns A dispose function that detaches every listener and pending timer.
+ */
+export function createMapResizeScheduler({
+  getMap,
+  container,
+}: MapResizeSchedulerOptions): () => void {
+  let resizeFrame: number | null = null;
+  let resizeTimer: number | null = null;
+  let windowResizeTimer: number | null = null;
+  let windowResizeActive = false;
+  let observedDevicePixelRatio = window.devicePixelRatio;
+  let panelResizeActive = false;
+
+  const cancelFrame = () => {
+    if (resizeFrame === null) return;
+    window.cancelAnimationFrame(resizeFrame);
+    resizeFrame = null;
+  };
+  const cancelTimer = () => {
+    if (resizeTimer === null) return;
+    window.clearTimeout(resizeTimer);
+    resizeTimer = null;
+  };
+  // MapLibre sizes the canvas from `clientWidth`/`clientHeight` and writes those
+  // integers back as the canvas CSS size, so the comparison has to read the same
+  // properties — `getBoundingClientRect()` returns sub-pixel floats that never
+  // match on a fractionally sized container, which would make this guard a
+  // no-op. `devicePixelRatio` is checked too because moving the window to a
+  // display with a different scale factor changes the backing store without
+  // changing the CSS box, so no ResizeObserver callback fires.
+  const mapNeedsResize = () => {
+    const map = getMap();
+    if (!map) return false;
+    const canvas = map.getCanvas();
+    return (
+      parseFloat(canvas.style.width) !== container.clientWidth ||
+      parseFloat(canvas.style.height) !== container.clientHeight ||
+      observedDevicePixelRatio !== window.devicePixelRatio
+    );
+  };
+  const commitResize = () => {
+    cancelFrame();
+    resizeFrame = window.requestAnimationFrame(() => {
+      resizeFrame = null;
+      if (!mapNeedsResize()) return;
+      getMap()?.resize();
+      observedDevicePixelRatio = window.devicePixelRatio;
+    });
+  };
+  const resizeMap = () => {
+    if (panelResizeActive) return;
+    // App layout changes such as toggling a sidebar are discrete and should
+    // resize on the next frame. Only coalesce the rapid observer callbacks
+    // produced while the browser window itself is being dragged.
+    if (!windowResizeActive) {
+      commitResize();
+      return;
+    }
+    // Resizing a WebGL canvas reallocates and clears its framebuffer before
+    // MapLibre's next render. During a continuous window drag that used to
+    // reveal the transparent canvas for several frames. Keep the previous
+    // bitmap in place while dimensions are changing, then resize the backing
+    // store once the dimensions settle. A frame already queued by an earlier
+    // discrete change has to be dropped, or it would resize mid-drag anyway.
+    cancelFrame();
+    cancelTimer();
+    resizeTimer = window.setTimeout(() => {
+      resizeTimer = null;
+      commitResize();
+    }, RESIZE_DEBOUNCE_MS);
+  };
+  const onWindowResize = () => {
+    windowResizeActive = true;
+    if (windowResizeTimer !== null) window.clearTimeout(windowResizeTimer);
+    windowResizeTimer = window.setTimeout(() => {
+      windowResizeTimer = null;
+      windowResizeActive = false;
+    }, RESIZE_DEBOUNCE_MS);
+    resizeMap();
+  };
+  const clearWindowResizeState = () => {
+    if (windowResizeTimer !== null) {
+      window.clearTimeout(windowResizeTimer);
+      windowResizeTimer = null;
+    }
+    windowResizeActive = false;
+  };
+  const onPanelResizeStart = () => {
+    panelResizeActive = true;
+    // A splitter drag cannot overlap a window drag, so any window-drag burst
+    // still settling is over; clearing it keeps the two states independent.
+    clearWindowResizeState();
+    cancelFrame();
+    cancelTimer();
+  };
+  const onPanelResizeEnd = () => {
+    panelResizeActive = false;
+    commitResize();
+  };
+
+  const resizeObserver = new ResizeObserver(resizeMap);
+  resizeObserver.observe(container);
+  window.addEventListener("resize", onWindowResize);
+  window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
+  window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
+  commitResize();
+
+  return () => {
+    resizeObserver.disconnect();
+    window.removeEventListener("resize", onWindowResize);
+    window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
+    window.removeEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
+    cancelFrame();
+    cancelTimer();
+    clearWindowResizeState();
+  };
+}

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -59,9 +59,9 @@ export function createMapResizeScheduler({
   // integers back as the canvas CSS size, so the comparison has to read the same
   // properties — `getBoundingClientRect()` returns sub-pixel floats that never
   // match on a fractionally sized container, which would make this guard a
-  // no-op. `devicePixelRatio` is checked too because moving the window to a
-  // display with a different scale factor changes the backing store without
-  // changing the CSS box, so no ResizeObserver callback fires.
+  // no-op. `devicePixelRatio` is checked too because it changes the backing
+  // store resolution without changing the CSS box, so the size comparison alone
+  // would report nothing to do.
   const mapNeedsResize = () => {
     const map = getMap();
     if (!map) return false;
@@ -80,6 +80,28 @@ export function createMapResizeScheduler({
       getMap()?.resize();
       observedDevicePixelRatio = window.devicePixelRatio;
     });
+  };
+  // A `devicePixelRatio` change on its own — the window moved to a display with
+  // a different scale factor while keeping its CSS size — fires neither a
+  // window `resize` event nor a ResizeObserver callback, so without this the
+  // canvas would stay under- or over-sampled until an unrelated resize happened
+  // to run. (MapLibre's `trackResize` never covered it either: it is a plain
+  // container ResizeObserver.) A resolution media query is the signal that does
+  // fire; it has to be re-armed at the new ratio after every change.
+  let devicePixelRatioQuery: MediaQueryList | null = null;
+  const onDevicePixelRatioChange = () => {
+    watchDevicePixelRatio();
+    commitResize();
+  };
+  const unwatchDevicePixelRatio = () => {
+    devicePixelRatioQuery?.removeEventListener("change", onDevicePixelRatioChange);
+    devicePixelRatioQuery = null;
+  };
+  const watchDevicePixelRatio = () => {
+    if (typeof window.matchMedia !== "function") return;
+    unwatchDevicePixelRatio();
+    devicePixelRatioQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+    devicePixelRatioQuery.addEventListener("change", onDevicePixelRatioChange);
   };
   const resizeMap = () => {
     if (panelResizeActive) return;
@@ -137,6 +159,7 @@ export function createMapResizeScheduler({
   window.addEventListener("resize", onWindowResize);
   window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
   window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
+  watchDevicePixelRatio();
   commitResize();
 
   return () => {
@@ -144,6 +167,7 @@ export function createMapResizeScheduler({
     window.removeEventListener("resize", onWindowResize);
     window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
     window.removeEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
+    unwatchDevicePixelRatio();
     cancelFrame();
     cancelTimer();
     clearWindowResizeState();

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -22,6 +22,11 @@ interface Harness {
   setContainerSize: (width: number, height: number) => void;
   /** Fire a window `resize` event, as a continuous window drag does. */
   windowResize: (width?: number, height?: number) => void;
+  /**
+   * Shrink the window and deliver *only* the ResizeObserver callback, as an
+   * engine that dispatches observer entries before the `resize` event would.
+   */
+  windowResizeObserverFirst: (width: number, height: number) => void;
   dispatch: (type: string) => void;
   /** Run every queued animation frame callback. */
   flushFrames: () => void;
@@ -59,6 +64,8 @@ function install(): Harness {
   let observerCallback: (() => void) | null = null;
   const fakeWindow = {
     devicePixelRatio: 1,
+    innerWidth: 1000,
+    innerHeight: 800,
     requestAnimationFrame(callback: () => void) {
       const id = nextId++;
       frames.set(id, callback);
@@ -111,6 +118,14 @@ function install(): Harness {
   Object.assign(globalThis, { window: fakeWindow, ResizeObserver: fakeResizeObserver });
   restoreGlobals = () => Object.assign(globalThis, previous);
 
+  // The browser lays the window out before either signal is delivered, so both
+  // the window and the map container carry their new size by then.
+  const shrinkWindow = (width: number, height: number) => {
+    fakeWindow.innerWidth = width + 200;
+    fakeWindow.innerHeight = height + 200;
+    container.clientWidth = width;
+    container.clientHeight = height;
+  };
   const dispatch = (type: string) => {
     for (const handler of [...(listeners.get(type) ?? [])]) handler();
   };
@@ -143,10 +158,13 @@ function install(): Harness {
     },
     windowResize(width, height) {
       if (width !== undefined && height !== undefined) {
-        container.clientWidth = width;
-        container.clientHeight = height;
+        shrinkWindow(width, height);
       }
       dispatch("resize");
+      observerCallback?.();
+    },
+    windowResizeObserverFirst(width, height) {
+      shrinkWindow(width, height);
       observerCallback?.();
     },
     dispatch,
@@ -206,6 +224,21 @@ describe("createMapResizeScheduler", () => {
     harness.setContainerSize(700, 600);
     harness.windowResize(690, 600);
     harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 0);
+
+    harness.advance(RESIZE_DEBOUNCE_MS);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 1);
+  });
+
+  it("debounces a window drag whose ResizeObserver callback beats the resize event", () => {
+    // The delivery order of ResizeObserver entries and the `resize` event is
+    // not guaranteed across engines, so the drag is detected from the window's
+    // own dimensions rather than from whichever callback ran first.
+    for (let width = 799; width > 789; width -= 1) {
+      harness.windowResizeObserverFirst(width, 600);
+      harness.flushFrames();
+    }
     assert.equal(harness.resizeCalls(), 0);
 
     harness.advance(RESIZE_DEBOUNCE_MS);

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  createMapResizeScheduler,
+  PANEL_RESIZE_END_EVENT,
+  PANEL_RESIZE_START_EVENT,
+  RESIZE_DEBOUNCE_MS,
+} from "../packages/map/src/map-resize";
+
+/**
+ * The scheduler is a small state machine over three signals that cannot be
+ * exercised through a real browser here: ResizeObserver callbacks, the window
+ * `resize` burst of a drag, and the panel splitter events. GeoLibre#2172 was
+ * caused by resizing the WebGL canvas on every one of those callbacks, so what
+ * these tests pin down is *how many* `map.resize()` calls each path produces and
+ * *when* — the branch order in `resizeMap` is exactly what a future edit could
+ * silently undo.
+ */
+
+interface Harness {
+  /** Resize the container and fire the observer, as the browser would. */
+  setContainerSize: (width: number, height: number) => void;
+  /** Fire a window `resize` event, as a continuous window drag does. */
+  windowResize: (width?: number, height?: number) => void;
+  dispatch: (type: string) => void;
+  /** Run every queued animation frame callback. */
+  flushFrames: () => void;
+  /** Advance the fake clock, running timers as they come due. */
+  advance: (ms: number) => void;
+  setDevicePixelRatio: (ratio: number) => void;
+  resizeCalls: () => number;
+  listenerCount: () => number;
+}
+
+let harness: Harness;
+let dispose: () => void;
+
+function install(): Harness {
+  let now = 0;
+  let nextId = 1;
+  const frames = new Map<number, () => void>();
+  const timers = new Map<number, { due: number; run: () => void }>();
+  const listeners = new Map<string, Set<() => void>>();
+  const mediaListeners = new Map<string, Set<() => void>>();
+  const container = { clientWidth: 800, clientHeight: 600 };
+  // Mirrors MapLibre: `resize()` writes the container's client dimensions back
+  // as the canvas CSS size, which is what `mapNeedsResize` compares against.
+  const canvas = { style: { width: "800px", height: "600px" } };
+  let resizeCalls = 0;
+  const map = {
+    getCanvas: () => canvas,
+    resize: () => {
+      resizeCalls += 1;
+      canvas.style.width = `${container.clientWidth}px`;
+      canvas.style.height = `${container.clientHeight}px`;
+    },
+  };
+
+  let observerCallback: (() => void) | null = null;
+  const fakeWindow = {
+    devicePixelRatio: 1,
+    requestAnimationFrame(callback: () => void) {
+      const id = nextId++;
+      frames.set(id, callback);
+      return id;
+    },
+    cancelAnimationFrame(id: number) {
+      frames.delete(id);
+    },
+    setTimeout(callback: () => void, delay: number) {
+      const id = nextId++;
+      timers.set(id, { due: now + delay, run: callback });
+      return id;
+    },
+    clearTimeout(id: number) {
+      timers.delete(id);
+    },
+    addEventListener(type: string, handler: () => void) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(handler);
+    },
+    removeEventListener(type: string, handler: () => void) {
+      listeners.get(type)?.delete(handler);
+    },
+    matchMedia(query: string) {
+      return {
+        addEventListener(_type: string, handler: () => void) {
+          if (!mediaListeners.has(query)) mediaListeners.set(query, new Set());
+          mediaListeners.get(query)!.add(handler);
+        },
+        removeEventListener(_type: string, handler: () => void) {
+          mediaListeners.get(query)?.delete(handler);
+        },
+      };
+    },
+  };
+  const fakeResizeObserver = class {
+    constructor(callback: () => void) {
+      observerCallback = callback;
+    }
+    observe() {}
+    disconnect() {
+      observerCallback = null;
+    }
+  };
+
+  const previous = {
+    window: globalThis.window,
+    ResizeObserver: globalThis.ResizeObserver,
+  };
+  Object.assign(globalThis, { window: fakeWindow, ResizeObserver: fakeResizeObserver });
+  restoreGlobals = () => Object.assign(globalThis, previous);
+
+  const dispatch = (type: string) => {
+    for (const handler of [...(listeners.get(type) ?? [])]) handler();
+  };
+  const flushFrames = () => {
+    const queued = [...frames.values()];
+    frames.clear();
+    for (const frame of queued) frame();
+  };
+  const advance = (ms: number) => {
+    const target = now + ms;
+    for (;;) {
+      const due = [...timers.entries()]
+        .filter(([, timer]) => timer.due <= target)
+        .sort((a, b) => a[1].due - b[1].due)[0];
+      if (!due) break;
+      timers.delete(due[0]);
+      now = due[1].due;
+      due[1].run();
+    }
+    now = target;
+  };
+
+  dispose = createMapResizeScheduler({ getMap: () => map as never, container: container as never });
+
+  return {
+    setContainerSize(width, height) {
+      container.clientWidth = width;
+      container.clientHeight = height;
+      observerCallback?.();
+    },
+    windowResize(width, height) {
+      if (width !== undefined && height !== undefined) {
+        container.clientWidth = width;
+        container.clientHeight = height;
+      }
+      dispatch("resize");
+      observerCallback?.();
+    },
+    dispatch,
+    flushFrames,
+    advance,
+    setDevicePixelRatio(ratio) {
+      fakeWindow.devicePixelRatio = ratio;
+      for (const handlers of mediaListeners.values()) {
+        for (const handler of [...handlers]) handler();
+      }
+    },
+    resizeCalls: () => resizeCalls,
+    listenerCount: () =>
+      [...listeners.values()].reduce((total, set) => total + set.size, 0) +
+      [...mediaListeners.values()].reduce((total, set) => total + set.size, 0),
+  };
+}
+
+let restoreGlobals: () => void = () => {};
+
+beforeEach(() => {
+  harness = install();
+});
+
+afterEach(() => {
+  dispose();
+  restoreGlobals();
+});
+
+describe("createMapResizeScheduler", () => {
+  it("does not resize on mount when the canvas already matches the container", () => {
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 0);
+  });
+
+  it("resizes a discrete layout change on the next frame, without waiting out the debounce", () => {
+    harness.setContainerSize(600, 600);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 1);
+  });
+
+  it("coalesces a continuous window drag into a single resize once dimensions settle", () => {
+    for (let width = 799; width > 779; width -= 1) {
+      harness.windowResize(width, 600);
+      harness.flushFrames();
+    }
+    assert.equal(harness.resizeCalls(), 0, "the previous frame stays on screen during the drag");
+
+    harness.advance(RESIZE_DEBOUNCE_MS);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 1);
+  });
+
+  it("drops a frame queued by a discrete change when a window drag starts", () => {
+    // GeoLibre#2173 review: the rAF from the discrete change would otherwise
+    // fire mid-drag and reallocate the framebuffer the debounce exists to keep.
+    harness.setContainerSize(700, 600);
+    harness.windowResize(690, 600);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 0);
+
+    harness.advance(RESIZE_DEBOUNCE_MS);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 1);
+  });
+
+  it("suppresses resizes while a panel splitter is dragged and commits once on release", () => {
+    harness.dispatch(PANEL_RESIZE_START_EVENT);
+    for (let width = 780; width > 760; width -= 2) {
+      harness.setContainerSize(width, 600);
+      harness.flushFrames();
+    }
+    assert.equal(harness.resizeCalls(), 0);
+
+    harness.dispatch(PANEL_RESIZE_END_EVENT);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 1);
+  });
+
+  it("keeps a settling window drag from leaking into a following panel drag", () => {
+    harness.windowResize(700, 600);
+    harness.dispatch(PANEL_RESIZE_START_EVENT);
+    harness.dispatch(PANEL_RESIZE_END_EVENT);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 1);
+
+    // The window-drag burst was cleared with the panel drag, so the next
+    // discrete change takes the immediate path rather than the debounce.
+    harness.setContainerSize(650, 600);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 2);
+  });
+
+  it("resizes on a devicePixelRatio change that leaves the CSS box untouched", () => {
+    harness.setDevicePixelRatio(2);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 1);
+  });
+
+  it("detaches every listener on dispose", () => {
+    assert.ok(harness.listenerCount() > 0);
+    dispose();
+    dispose = () => {};
+    assert.equal(harness.listenerCount(), 0);
+  });
+});


### PR DESCRIPTION
## Summary

- make GeoLibre's ResizeObserver the sole owner of MapLibre canvas sizing
- debounce continuous container changes so the previous rendered frame remains visible while resizing
- keep panel resize completion immediate

## Verification

- exercised 20 rapid Chromium viewport changes with the default globe in light and dark themes
- confirmed each sequence produced one final WebGL backing-store resize and no console errors
- `npm run build`
- `pre-commit run --files packages/map/src/MapCanvas.tsx packages/map/src/map-controller.ts`

Fixes #2172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map resizing when browser windows or application panels change size.
  * Reduced flickering and temporary transparency during window resizing.
  * Smoothed panel resizing by consolidating and delaying map redraws.
  * Improved handling of display scaling changes during resizing.
  * Improved map rendering consistency across primary and secondary map panes during layout changes.
  * Prevented unnecessary redraws when map dimensions have not changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->