### PR TITLE
fix: persist terrain control in projects

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1137,6 +1137,19 @@ export function TopToolbar({
       {} as Record<ToolbarMapControl, boolean>,
     ),
   );
+  const terrainEnabled = useAppStore((state) => state.preferences.map.terrainEnabled);
+
+  // Terrain is project state, unlike the other optional map chrome. Restore it
+  // after both project loads and controller/style initialization so reopening a
+  // saved project brings back the control and its active terrain surface.
+  useEffect(() => {
+    const controller = mapControllerRef.current;
+    if (!controller) return;
+    controller.setBuiltInControlVisible("terrain", terrainEnabled);
+    setControlsVisible((current) =>
+      current.terrain === terrainEnabled ? current : { ...current, terrain: terrainEnabled },
+    );
+  }, [mapControllerRef, mapReadyGeneration, projectGeneration, terrainEnabled]);
   const [initialService, setInitialService] = useState(() =>
     viewer || typeof window === "undefined" ? null : serviceUrlParameter(window.location.search),
   );
@@ -1262,11 +1275,17 @@ export function TopToolbar({
   const handleOpenPlanetaryComputer = () => openPlanetaryComputerPanel(appApi);
 
   const toggleMapControl = (control: ToolbarMapControl) => {
-    setControlsVisible((current) => {
-      const visible = !current[control];
-      const updated = mapControllerRef.current?.setBuiltInControlVisible(control, visible) ?? false;
-      return updated ? { ...current, [control]: visible } : current;
-    });
+    const visible = !controlsVisible[control];
+    const updated = mapControllerRef.current?.setBuiltInControlVisible(control, visible) ?? false;
+    if (!updated) return;
+    setControlsVisible((current) => ({ ...current, [control]: visible }));
+    if (control === "terrain") {
+      const { preferences, setPreferences } = useAppStore.getState();
+      setPreferences({
+        ...preferences,
+        map: { ...preferences.map, terrainEnabled: visible },
+      });
+    }
   };
 
   // The Maptoolkit logo is Maptoolkit-basemap attribution, required by their

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1200,6 +1200,11 @@ function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
         (map as Partial<ProjectPreferences["map"]>).showPointerElevation,
         DEFAULT_PROJECT_PREFERENCES.map.showPointerElevation,
       ),
+      // Older projects omit this field and continue to open with terrain off.
+      terrainEnabled: normalizeBoolean(
+        (map as Partial<ProjectPreferences["map"]>).terrainEnabled,
+        DEFAULT_PROJECT_PREFERENCES.map.terrainEnabled,
+      ),
       // Kept as a free string here; the app coerces an unknown notation to
       // decimal degrees when it renders, so a hand-edited project cannot break
       // the readout.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1555,6 +1555,8 @@ export interface MapPreferences {
    * from Controls -> Elevation.
    */
   showPointerElevation: boolean;
+  /** Whether the built-in 3D terrain control and terrain surface are enabled. */
+  terrainEnabled: boolean;
   /**
    * Notation the status bar reports the pointer coordinate in: `"dd"` decimal
    * degrees (default), `"dms"` degrees/minutes/seconds, `"ddm"` degrees and
@@ -1631,6 +1633,7 @@ export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
     // Off by default: turning it on can send pointer coordinates to a public
     // elevation service, which should be an explicit choice.
     showPointerElevation: false,
+    terrainEnabled: false,
     coordinateFormat: "dd",
   },
   environmentVariables: [],

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -251,10 +251,7 @@ describe("project parsing", () => {
         map: { ...base.preferences.map, terrainEnabled: true },
       },
     };
-    assert.equal(
-      parseProject(serializeProject(enabled)).preferences.map.terrainEnabled,
-      true,
-    );
+    assert.equal(parseProject(serializeProject(enabled)).preferences.map.terrainEnabled, true);
 
     const legacy = structuredClone(base) as unknown as {
       preferences: { map: Record<string, unknown> };

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -241,6 +241,28 @@ describe("project parsing", () => {
     assert.equal(reloaded.preferences.map.projection, "mercator");
   });
 
+  it("round-trips terrain and defaults legacy projects to terrain off", () => {
+    const base = createEmptyProject("Terrain");
+    assert.equal(base.preferences.map.terrainEnabled, false);
+    const enabled = {
+      ...base,
+      preferences: {
+        ...base.preferences,
+        map: { ...base.preferences.map, terrainEnabled: true },
+      },
+    };
+    assert.equal(
+      parseProject(serializeProject(enabled)).preferences.map.terrainEnabled,
+      true,
+    );
+
+    const legacy = structuredClone(base) as unknown as {
+      preferences: { map: Record<string, unknown> };
+    };
+    delete legacy.preferences.map.terrainEnabled;
+    assert.equal(parseProject(JSON.stringify(legacy)).preferences.map.terrainEnabled, false);
+  });
+
   it("round-trips the scale unit preference and defaults unknown values to metric", () => {
     const base = createEmptyProject("Scale");
     assert.equal(base.preferences.map.scaleUnit, "metric");


### PR DESCRIPTION
## Summary
- save whether the terrain control is enabled in project map preferences
- restore the terrain control and active terrain surface after project and map initialization
- keep legacy projects compatible by defaulting missing terrain state to off

## Test plan
- [x] Run the desktop production build
- [x] Run `node --import tsx --test tests/core-project.test.ts`
- [x] Run ESLint on the changed files
- [x] Run `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a project-level setting for enabling or disabling 3D terrain on the map.
  * Terrain visibility is now restored automatically when reopening a project or initializing a map.
  * The selected terrain preference is saved with the project.

* **Bug Fixes**
  * Projects without a terrain preference now open with terrain disabled by default.
  * Invalid terrain settings are safely reset to the default disabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->