### PR TITLE
docs(downloads): clarify iOS release IPA

### DIFF
--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -316,10 +316,11 @@ builds:
 
 [Get GeoLibre on the App Store](https://apps.apple.com/app/geolibre/id6796039674){ .md-button .md-button--primary }
 
-GeoLibre does not publish a sideloadable `.ipa` for end users, so unlike Android
-there are no iOS files attached to GitHub releases: the App Store listing, and
-TestFlight for beta builds, are how it is distributed. To run an unreleased
-build, build it yourself on a Mac (see [iOS](ios.md)).
+GeoLibre does not publish a sideloadable `.ipa` for end users. A release may
+include an `*_ios_app-store.ipa` archive for App Store submission, but that
+archive cannot be installed directly. Use the App Store or TestFlight for beta
+builds; to run an unreleased build, build it yourself on a Mac (see
+[iOS](ios.md)).
 
 The tools that are hidden on Android are hidden on iOS too, for the same reason:
 the Raster, Conversion, and AI Segmentation toolboxes and the PostgreSQL data

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -318,9 +318,9 @@ builds:
 
 GeoLibre does not publish a sideloadable `.ipa` for end users. A release may
 include an `*_ios_app-store.ipa` archive for App Store submission, but that
-archive cannot be installed directly. Use the App Store or TestFlight for beta
-builds; to run an unreleased build, build it yourself on a Mac (see
-[iOS](ios.md)).
+archive cannot be installed directly. Use the App Store for released builds or
+TestFlight for beta builds; to run an unreleased build, build it yourself on a
+Mac (see [iOS](ios.md)).
 
 The tools that are hidden on Android are hidden on iOS too, for the same reason:
 the Raster, Conversion, and AI Segmentation toolboxes and the PostgreSQL data


### PR DESCRIPTION
Closes #2176. The Downloads page currently says GitHub releases have no iOS files, while releases now include an App Store submission IPA. This change keeps the important no-sideloading warning and explains that the ios_app-store.ipa artifact is submission-only and cannot be installed directly. Validation: npx prettier --check docs/downloads.md; zensical build --strict; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified iOS installation options through the App Store, TestFlight, or building on a Mac.
  * Explained that App Store submission archives cannot be installed directly.
  * Updated guidance to reflect that iOS archives may be included in some releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->