### PR TITLE
docs: clarify iOS release IPA availability

### DIFF
--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -316,10 +316,11 @@ builds:
 
 [Get GeoLibre on the App Store](https://apps.apple.com/app/geolibre/id6796039674){ .md-button .md-button--primary }
 
-GeoLibre does not publish a sideloadable `.ipa` for end users, so unlike Android
-there are no iOS files attached to GitHub releases: the App Store listing, and
-TestFlight for beta builds, are how it is distributed. To run an unreleased
-build, build it yourself on a Mac (see [iOS](ios.md)).
+GeoLibre does not publish a sideloadable `.ipa` for end users. The App Store
+listing, and TestFlight for beta builds, are how it is distributed. Releases may
+include a `GeoLibre_<version>_ios_app-store.ipa` asset, but this is the App Store
+submission package and cannot be installed directly on a device. To run an
+unreleased build, build it yourself on a Mac (see [iOS](ios.md)).
 
 The tools that are hidden on Android are hidden on iOS too, for the same reason:
 the Raster, Conversion, and AI Segmentation toolboxes and the PostgreSQL data


### PR DESCRIPTION
## Summary

- clarify that GeoLibre does not publish a sideloadable IPA
- document the App Store submission IPA attached to releases
- direct users to the App Store, TestFlight, or a source build as appropriate

## Verification

- `zensical build --strict`
- `pre-commit run --files docs/downloads.md`
- verified the rendered Downloads page in dark and light themes

Fixes #2176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified iOS release download guidance.
  * Explained that the App Store submission package cannot be installed directly on a device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->