### PR TITLE
fix(flight-simulator): bank camera in aircraft direction

### DIFF
--- a/packages/plugins/src/plugins/flight-simulator.ts
+++ b/packages/plugins/src/plugins/flight-simulator.ts
@@ -541,7 +541,7 @@ class FlightSimulatorEngine {
       MAX_CAMERA_PITCH,
       Math.max(MIN_CAMERA_PITCH, LEVEL_CAMERA_PITCH + pitch),
     );
-    const cameraRoll = this.settings.bankCamera ? -roll : 0;
+    const cameraRoll = this.settings.bankCamera ? roll : 0;
     try {
       const options = this.map.calculateCameraOptionsFromCameraLngLatAltRotation(
         [lng, lat],

--- a/tests/flight-simulator.test.ts
+++ b/tests/flight-simulator.test.ts
@@ -892,6 +892,30 @@ describe("flight simulator engine", () => {
     });
   });
 
+  it("banks the camera in the same direction as the aircraft", () => {
+    withStubWindow(({ pump, hold, release }) => {
+      resetStore();
+      const map = stubMap();
+      openFlightSimulatorPanel({ getMap: () => map } as unknown as GeoLibreAppAPI);
+      startFlying();
+      pump();
+
+      hold("ArrowRight");
+      for (let i = 0; i < 8; i += 1) pump();
+      release("ArrowRight");
+      const hud = getFlightHudSnapshot();
+      const flightJumps = map.state.jumps.filter((jump) => jump.eventData);
+      assert.ok(hud.rollDeg > 0, "Arrow Right should bank the aircraft right");
+      assert.ok(
+        (flightJumps.at(-1)?.options.roll as number) > 0,
+        "the camera should roll right with the aircraft",
+      );
+
+      stopFlying();
+      resetStore();
+    });
+  });
+
   it("starts every flight at the cruise throttle, not the previous flight's", () => {
     withStubWindow(({ pump, hold, release }) => {
       resetStore();


### PR DESCRIPTION
## Summary
- Correct the sign of the banked camera roll so it matches the aircraft roll direction.
- Add regression coverage for the camera and aircraft banking together.

## Tests
- node --import tsx --test tests/flight-simulator.test.ts