### PR TITLE
chore(deps): keep bincode on 1.x and stop Dependabot major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # `bincode` must stay on the 1.x line: `PersistedScopeState` in
+      # `src/lib.rs` reads and rewrites the file `tauri-plugin-persisted-scope`
+      # serializes with bincode 1, so a major bump silently breaks the on-disk
+      # format. bincode 3.0.0 is also a deliberately unbuildable release whose
+      # whole source is `compile_error!("https://xkcd.com/2347/")` (see #2194).
+      - dependency-name: bincode
+        update-types:
+          - version-update:semver-major
     groups:
       cargo-security:
         applies-to: security-updates

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -67,6 +67,10 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Pinned to 1.x on purpose: this must match the bincode version
+# `tauri-plugin-persisted-scope` uses to write its scope file, which
+# `PersistedScopeState` in src/lib.rs reads and rewrites. Dependabot is told to
+# skip major bumps in .github/dependabot.yml; see docs/maintenance.md.
 bincode = "1"
 # OS CSPRNG for the per-launch Jupyter token (already an indirect dep).
 getrandom = "0.4"

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -217,6 +217,13 @@ and types against this mirror and run the Rust scope-cleanup tests. Bincode
 encodes fields positionally, so an upstream layout change is not compiler
 checked.
 
+The `bincode` dependency itself is pinned to the **1.x** line and Dependabot is
+configured (`.github/dependabot.yml`) to skip its major bumps: the plugin writes
+the file with bincode 1, so GeoLibre must decode and re-encode it with the same
+wire format. Only move when `tauri-plugin-persisted-scope` moves. (bincode 3.0.0
+is additionally a deliberately unbuildable release — its whole source is
+`compile_error!("https://xkcd.com/2347/")`.)
+
 ### `@tauri-apps/plugin-http` — two upstream *behaviors*, not APIs
 
 `createNativeSidecarFetch`


### PR DESCRIPTION
## Summary

Supersedes #2194 (Dependabot's bincode 1.3.3 → 3.0.0 bump), which cannot pass CI. Two independent reasons:

- **bincode 3.0.0 is a deliberately unbuildable release.** Its entire `src/lib.rs` is `compile_error!("https://xkcd.com/2347/")`, which is exactly the error the failing `Build and test` job reports. No change on our side can make it compile.
- **We must stay on the 1.x line anyway.** `PersistedScopeState` in `apps/geolibre-desktop/src-tauri/src/lib.rs` reads and rewrites the scope file that `tauri-plugin-persisted-scope` serializes with bincode 1 (the lockfile in #2194 shows the plugin still on 1.3.3). Decoding that file with a different bincode major would silently break the on-disk format.

## Changes

- `.github/dependabot.yml`: `ignore` rule for `bincode` `version-update:semver-major` in the cargo ecosystem, with a comment explaining why.
- `apps/geolibre-desktop/src-tauri/Cargo.toml`: comment next to `bincode = "1"` pointing at the constraint.
- `docs/maintenance.md`: note under the `tauri-plugin-persisted-scope` section that bincode only moves when the plugin moves.

## Verification

- `cargo check` in `apps/geolibre-desktop/src-tauri` passes on bincode 1.
- `pre-commit run --files` on the three changed files passes.

https://claude.ai/code/session_01X12zcgwSGPQYJbprdsYHqn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved compatibility with existing saved desktop application data, preventing potential data-format issues after updates.

* **Documentation**
  * Added maintenance guidance describing the compatibility constraint and when it may be safely changed.

* **Chores**
  * Updated automated update rules to avoid changes that could break persisted application data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->