### PR TITLE
fix: preserve map frame through resize

### DIFF
--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -47,38 +47,76 @@ export function createMapResizeScheduler({
   let observedDevicePixelRatio = window.devicePixelRatio;
   let panelResizeActive = false;
   let frameOverlay: HTMLCanvasElement | null = null;
+  let frameSnapshot: HTMLCanvasElement | null = null;
+  let cachedFrame: ImageBitmap | null = null;
   let overlayMap: MapLibreMap | null = null;
+  const snapshotMap = getMap() ?? null;
+
+  const cacheRenderedFrame = () => {
+    const canvas = getMap()?.getCanvas();
+    if (!canvas || typeof createImageBitmap !== "function") return;
+    void createImageBitmap(canvas)
+      .then((bitmap) => {
+        cachedFrame?.close();
+        cachedFrame = bitmap;
+      })
+      .catch(() => undefined);
+  };
+  snapshotMap?.on("idle", cacheRenderedFrame);
+  cacheRenderedFrame();
 
   const removeFrameOverlay = () => {
     frameOverlay?.remove();
     frameOverlay = null;
+    frameSnapshot = null;
     if (overlayMap) {
       overlayMap.off("render", removeFrameOverlay);
       overlayMap = null;
     }
   };
   const preserveRenderedFrame = () => {
-    if (frameOverlay) return;
     const map = getMap();
     if (!map) return;
     const canvas = map.getCanvas();
     const canvasParent = canvas.parentElement;
     if (!canvasParent || canvas.width === 0 || canvas.height === 0) return;
 
-    const overlay = document.createElement("canvas");
+    const snapshot = frameSnapshot ?? document.createElement("canvas");
+    if (!frameSnapshot) {
+      snapshot.width = canvas.width;
+      snapshot.height = canvas.height;
+      const snapshotContext = snapshot.getContext("2d");
+      if (!snapshotContext) return;
+      snapshotContext.drawImage(cachedFrame ?? canvas, 0, 0);
+      frameSnapshot = snapshot;
+    }
+    const overlay = frameOverlay ?? document.createElement("canvas");
+    overlay.width = Math.round(container.clientWidth * window.devicePixelRatio);
+    overlay.height = Math.round(container.clientHeight * window.devicePixelRatio);
+    const context = overlay.getContext("2d");
+    if (!context) return;
+    let backgroundElement: HTMLElement | null = container;
+    let backgroundColor = "";
+    while (backgroundElement && (!backgroundColor || backgroundColor === "rgba(0, 0, 0, 0)")) {
+      backgroundColor = window.getComputedStyle(backgroundElement).backgroundColor;
+      backgroundElement = backgroundElement.parentElement;
+    }
+    context.fillStyle = backgroundColor || "#fff";
+    context.fillRect(0, 0, overlay.width, overlay.height);
+    const x = (overlay.width - snapshot.width) / 2;
+    const y = (overlay.height - snapshot.height) / 2;
+    context.drawImage(snapshot, x, y);
+    if (frameOverlay) return;
+
     overlay.className = "geolibre-map-resize-frame";
-    overlay.width = canvas.width;
-    overlay.height = canvas.height;
     Object.assign(overlay.style, {
       position: "absolute",
       inset: "0",
       width: "100%",
       height: "100%",
+      zIndex: "5",
       pointerEvents: "none",
     });
-    const context = overlay.getContext("2d");
-    if (!context) return;
-    context.drawImage(canvas, 0, 0);
     canvas.insertAdjacentElement("afterend", overlay);
     frameOverlay = overlay;
     overlayMap = map;
@@ -235,5 +273,8 @@ export function createMapResizeScheduler({
     cancelTimer();
     clearWindowResizeState();
     removeFrameOverlay();
+    snapshotMap?.off("idle", cacheRenderedFrame);
+    cachedFrame?.close();
+    cachedFrame = null;
   };
 }

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -48,34 +48,14 @@ export function createMapResizeScheduler({
   let panelResizeActive = false;
   let frameOverlay: HTMLCanvasElement | null = null;
   let frameSnapshot: HTMLCanvasElement | null = null;
-  let cachedFrame: ImageBitmap | null = null;
-  let frameCaptureVersion = 0;
-  let disposed = false;
+  let overlayBackgroundColor = "";
   let overlayMap: MapLibreMap | null = null;
-  const snapshotMap = getMap() ?? null;
-
-  const cacheRenderedFrame = () => {
-    const canvas = getMap()?.getCanvas();
-    if (!canvas || typeof createImageBitmap !== "function") return;
-    const captureVersion = ++frameCaptureVersion;
-    void createImageBitmap(canvas)
-      .then((bitmap) => {
-        if (disposed || captureVersion !== frameCaptureVersion) {
-          bitmap.close();
-          return;
-        }
-        cachedFrame?.close();
-        cachedFrame = bitmap;
-      })
-      .catch(() => undefined);
-  };
-  snapshotMap?.on("idle", cacheRenderedFrame);
-  cacheRenderedFrame();
 
   const removeFrameOverlay = () => {
     frameOverlay?.remove();
     frameOverlay = null;
     frameSnapshot = null;
+    overlayBackgroundColor = "";
     if (overlayMap) {
       overlayMap.off("render", removeFrameOverlay);
       overlayMap = null;
@@ -94,7 +74,7 @@ export function createMapResizeScheduler({
       snapshot.height = canvas.height;
       const snapshotContext = snapshot.getContext("2d");
       if (!snapshotContext) return;
-      snapshotContext.drawImage(cachedFrame ?? canvas, 0, 0);
+      snapshotContext.drawImage(canvas, 0, 0);
       frameSnapshot = snapshot;
     }
     const overlay = frameOverlay ?? document.createElement("canvas");
@@ -102,13 +82,17 @@ export function createMapResizeScheduler({
     overlay.height = Math.round(container.clientHeight * window.devicePixelRatio);
     const context = overlay.getContext("2d");
     if (!context) return;
-    let backgroundElement: HTMLElement | null = container;
-    let backgroundColor = "";
-    while (backgroundElement && (!backgroundColor || backgroundColor === "rgba(0, 0, 0, 0)")) {
-      backgroundColor = window.getComputedStyle(backgroundElement).backgroundColor;
-      backgroundElement = backgroundElement.parentElement;
+    if (!overlayBackgroundColor) {
+      let backgroundElement: HTMLElement | null = container;
+      while (
+        backgroundElement &&
+        (!overlayBackgroundColor || overlayBackgroundColor === "rgba(0, 0, 0, 0)")
+      ) {
+        overlayBackgroundColor = window.getComputedStyle(backgroundElement).backgroundColor;
+        backgroundElement = backgroundElement.parentElement;
+      }
     }
-    context.fillStyle = backgroundColor || "#fff";
+    context.fillStyle = overlayBackgroundColor || "#fff";
     context.fillRect(0, 0, overlay.width, overlay.height);
     const x = (overlay.width - snapshot.width) / 2;
     const y = (overlay.height - snapshot.height) / 2;
@@ -116,6 +100,7 @@ export function createMapResizeScheduler({
     if (frameOverlay) return;
 
     overlay.className = "geolibre-map-resize-frame";
+    overlay.setAttribute("aria-hidden", "true");
     Object.assign(overlay.style, {
       position: "absolute",
       inset: "0",
@@ -170,7 +155,7 @@ export function createMapResizeScheduler({
         return;
       }
       preserveRenderedFrame();
-      map.once("render", removeFrameOverlay);
+      if (frameOverlay) map.once("render", removeFrameOverlay);
       map.resize();
       observedDevicePixelRatio = window.devicePixelRatio;
     });
@@ -255,6 +240,7 @@ export function createMapResizeScheduler({
     clearWindowResizeState();
     cancelFrame();
     cancelTimer();
+    removeFrameOverlay();
     preserveRenderedFrame();
   };
   const onPanelResizeEnd = () => {
@@ -271,8 +257,6 @@ export function createMapResizeScheduler({
   commitResize();
 
   return () => {
-    disposed = true;
-    frameCaptureVersion += 1;
     resizeObserver.disconnect();
     window.removeEventListener("resize", resizeMap);
     window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
@@ -282,8 +266,5 @@ export function createMapResizeScheduler({
     cancelTimer();
     clearWindowResizeState();
     removeFrameOverlay();
-    snapshotMap?.off("idle", cacheRenderedFrame);
-    cachedFrame?.close();
-    cachedFrame = null;
   };
 }

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -49,14 +49,21 @@ export function createMapResizeScheduler({
   let frameOverlay: HTMLCanvasElement | null = null;
   let frameSnapshot: HTMLCanvasElement | null = null;
   let cachedFrame: ImageBitmap | null = null;
+  let frameCaptureVersion = 0;
+  let disposed = false;
   let overlayMap: MapLibreMap | null = null;
   const snapshotMap = getMap() ?? null;
 
   const cacheRenderedFrame = () => {
     const canvas = getMap()?.getCanvas();
     if (!canvas || typeof createImageBitmap !== "function") return;
+    const captureVersion = ++frameCaptureVersion;
     void createImageBitmap(canvas)
       .then((bitmap) => {
+        if (disposed || captureVersion !== frameCaptureVersion) {
+          bitmap.close();
+          return;
+        }
         cachedFrame?.close();
         cachedFrame = bitmap;
       })
@@ -264,6 +271,8 @@ export function createMapResizeScheduler({
   commitResize();
 
   return () => {
+    disposed = true;
+    frameCaptureVersion += 1;
     resizeObserver.disconnect();
     window.removeEventListener("resize", resizeMap);
     window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -46,6 +46,43 @@ export function createMapResizeScheduler({
   let observedWindowHeight = window.innerHeight;
   let observedDevicePixelRatio = window.devicePixelRatio;
   let panelResizeActive = false;
+  let frameOverlay: HTMLCanvasElement | null = null;
+  let overlayMap: MapLibreMap | null = null;
+
+  const removeFrameOverlay = () => {
+    frameOverlay?.remove();
+    frameOverlay = null;
+    if (overlayMap) {
+      overlayMap.off("render", removeFrameOverlay);
+      overlayMap = null;
+    }
+  };
+  const preserveRenderedFrame = () => {
+    if (frameOverlay) return;
+    const map = getMap();
+    if (!map) return;
+    const canvas = map.getCanvas();
+    const canvasParent = canvas.parentElement;
+    if (!canvasParent || canvas.width === 0 || canvas.height === 0) return;
+
+    const overlay = document.createElement("canvas");
+    overlay.className = "geolibre-map-resize-frame";
+    overlay.width = canvas.width;
+    overlay.height = canvas.height;
+    Object.assign(overlay.style, {
+      position: "absolute",
+      inset: "0",
+      width: "100%",
+      height: "100%",
+      pointerEvents: "none",
+    });
+    const context = overlay.getContext("2d");
+    if (!context) return;
+    context.drawImage(canvas, 0, 0);
+    canvas.insertAdjacentElement("afterend", overlay);
+    frameOverlay = overlay;
+    overlayMap = map;
+  };
 
   const cancelFrame = () => {
     if (resizeFrame === null) return;
@@ -79,7 +116,11 @@ export function createMapResizeScheduler({
     resizeFrame = window.requestAnimationFrame(() => {
       resizeFrame = null;
       if (!mapNeedsResize()) return;
-      getMap()?.resize();
+      const map = getMap();
+      if (!map) return;
+      preserveRenderedFrame();
+      map.once("render", removeFrameOverlay);
+      map.resize();
       observedDevicePixelRatio = window.devicePixelRatio;
     });
   };
@@ -143,6 +184,7 @@ export function createMapResizeScheduler({
     // discrete change has to be dropped, or it would resize mid-drag anyway.
     cancelFrame();
     cancelTimer();
+    preserveRenderedFrame();
     resizeTimer = window.setTimeout(() => {
       resizeTimer = null;
       commitResize();
@@ -162,6 +204,7 @@ export function createMapResizeScheduler({
     clearWindowResizeState();
     cancelFrame();
     cancelTimer();
+    preserveRenderedFrame();
   };
   const onPanelResizeEnd = () => {
     panelResizeActive = false;
@@ -185,5 +228,6 @@ export function createMapResizeScheduler({
     cancelFrame();
     cancelTimer();
     clearWindowResizeState();
+    removeFrameOverlay();
   };
 }

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -50,6 +50,7 @@ export function createMapResizeScheduler({
   let frameSnapshot: HTMLCanvasElement | null = null;
   let overlayBackgroundColor = "";
   let overlayMap: MapLibreMap | null = null;
+  let renderCleanupArmed = false;
 
   const removeFrameOverlay = () => {
     frameOverlay?.remove();
@@ -60,6 +61,7 @@ export function createMapResizeScheduler({
       overlayMap.off("render", removeFrameOverlay);
       overlayMap = null;
     }
+    renderCleanupArmed = false;
   };
   const preserveRenderedFrame = () => {
     const map = getMap();
@@ -91,8 +93,11 @@ export function createMapResizeScheduler({
         overlayBackgroundColor = window.getComputedStyle(backgroundElement).backgroundColor;
         backgroundElement = backgroundElement.parentElement;
       }
+      if (!overlayBackgroundColor || overlayBackgroundColor === "rgba(0, 0, 0, 0)") {
+        overlayBackgroundColor = "#fff";
+      }
     }
-    context.fillStyle = overlayBackgroundColor || "#fff";
+    context.fillStyle = overlayBackgroundColor;
     context.fillRect(0, 0, overlay.width, overlay.height);
     const x = (overlay.width - snapshot.width) / 2;
     const y = (overlay.height - snapshot.height) / 2;
@@ -155,7 +160,10 @@ export function createMapResizeScheduler({
         return;
       }
       preserveRenderedFrame();
-      if (frameOverlay) map.once("render", removeFrameOverlay);
+      if (frameOverlay && !renderCleanupArmed) {
+        map.once("render", removeFrameOverlay);
+        renderCleanupArmed = true;
+      }
       map.resize();
       observedDevicePixelRatio = window.devicePixelRatio;
     });
@@ -204,7 +212,10 @@ export function createMapResizeScheduler({
     return true;
   };
   const resizeMap = () => {
-    if (panelResizeActive) return;
+    if (panelResizeActive) {
+      preserveRenderedFrame();
+      return;
+    }
     // App layout changes such as toggling a sidebar are discrete and should
     // resize on the next frame. Only coalesce the rapid observer callbacks
     // produced while the browser window itself is being dragged.

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -78,7 +78,11 @@ export function createMapResizeScheduler({
       snapshot.height = canvas.height;
       const snapshotContext = snapshot.getContext("2d");
       if (!snapshotContext) return;
-      snapshotContext.drawImage(canvas, 0, 0);
+      try {
+        snapshotContext.drawImage(canvas, 0, 0);
+      } catch {
+        return;
+      }
       frameSnapshot = snapshot;
       frameSnapshotDevicePixelRatio = window.devicePixelRatio;
     }
@@ -107,7 +111,12 @@ export function createMapResizeScheduler({
     const snapshotHeight = snapshot.height * dprScale;
     const x = (overlay.width - snapshotWidth) / 2;
     const y = (overlay.height - snapshotHeight) / 2;
-    context.drawImage(snapshot, x, y, snapshotWidth, snapshotHeight);
+    try {
+      context.drawImage(snapshot, x, y, snapshotWidth, snapshotHeight);
+    } catch {
+      removeFrameOverlay();
+      return;
+    }
     if (frameOverlay) return;
 
     overlay.className = "geolibre-map-resize-frame";
@@ -152,7 +161,7 @@ export function createMapResizeScheduler({
       observedDevicePixelRatio !== window.devicePixelRatio
     );
   };
-  const commitResize = () => {
+  const commitResize = (preserveFrame = true) => {
     cancelFrame();
     resizeFrame = window.requestAnimationFrame(() => {
       resizeFrame = null;
@@ -165,8 +174,8 @@ export function createMapResizeScheduler({
         removeFrameOverlay();
         return;
       }
-      preserveRenderedFrame();
-      if (frameOverlay && !renderCleanupArmed) {
+      if (preserveFrame) preserveRenderedFrame();
+      if (preserveFrame && frameOverlay && !renderCleanupArmed) {
         map.once("render", removeFrameOverlay);
         renderCleanupArmed = true;
       }
@@ -271,7 +280,7 @@ export function createMapResizeScheduler({
   window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
   window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
   watchDevicePixelRatio();
-  commitResize();
+  commitResize(false);
 
   return () => {
     resizeObserver.disconnect();

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -115,9 +115,15 @@ export function createMapResizeScheduler({
     cancelFrame();
     resizeFrame = window.requestAnimationFrame(() => {
       resizeFrame = null;
-      if (!mapNeedsResize()) return;
+      if (!mapNeedsResize()) {
+        removeFrameOverlay();
+        return;
+      }
       const map = getMap();
-      if (!map) return;
+      if (!map) {
+        removeFrameOverlay();
+        return;
+      }
       preserveRenderedFrame();
       map.once("render", removeFrameOverlay);
       map.resize();

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -52,6 +52,8 @@ export function createMapResizeScheduler({
   let overlayBackgroundColor = "";
   let overlayMap: MapLibreMap | null = null;
   let renderCleanupArmed = false;
+  const backgroundIsTransparent = (color: string) =>
+    !color || color === "transparent" || color === "rgba(0, 0, 0, 0)";
 
   const removeFrameOverlay = () => {
     frameOverlay?.remove();
@@ -68,6 +70,7 @@ export function createMapResizeScheduler({
   const preserveRenderedFrame = () => {
     const map = getMap();
     if (!map) return;
+    if (frameOverlay && overlayMap !== map) removeFrameOverlay();
     const canvas = map.getCanvas();
     const canvasParent = canvas.parentElement;
     if (!canvasParent || canvas.width === 0 || canvas.height === 0) return;
@@ -84,7 +87,9 @@ export function createMapResizeScheduler({
         return;
       }
       frameSnapshot = snapshot;
-      frameSnapshotDevicePixelRatio = window.devicePixelRatio;
+      const canvasCssWidth = parseFloat(canvas.style.width) || canvas.clientWidth;
+      frameSnapshotDevicePixelRatio =
+        canvasCssWidth > 0 ? canvas.width / canvasCssWidth : window.devicePixelRatio;
     }
     const overlay = frameOverlay ?? document.createElement("canvas");
     overlay.width = Math.round(container.clientWidth * window.devicePixelRatio);
@@ -93,14 +98,11 @@ export function createMapResizeScheduler({
     if (!context) return;
     if (!overlayBackgroundColor) {
       let backgroundElement: HTMLElement | null = container;
-      while (
-        backgroundElement &&
-        (!overlayBackgroundColor || overlayBackgroundColor === "rgba(0, 0, 0, 0)")
-      ) {
+      while (backgroundElement && backgroundIsTransparent(overlayBackgroundColor)) {
         overlayBackgroundColor = window.getComputedStyle(backgroundElement).backgroundColor;
         backgroundElement = backgroundElement.parentElement;
       }
-      if (!overlayBackgroundColor || overlayBackgroundColor === "rgba(0, 0, 0, 0)") {
+      if (backgroundIsTransparent(overlayBackgroundColor)) {
         overlayBackgroundColor = "#fff";
       }
     }

--- a/packages/map/src/map-resize.ts
+++ b/packages/map/src/map-resize.ts
@@ -48,6 +48,7 @@ export function createMapResizeScheduler({
   let panelResizeActive = false;
   let frameOverlay: HTMLCanvasElement | null = null;
   let frameSnapshot: HTMLCanvasElement | null = null;
+  let frameSnapshotDevicePixelRatio = 1;
   let overlayBackgroundColor = "";
   let overlayMap: MapLibreMap | null = null;
   let renderCleanupArmed = false;
@@ -56,6 +57,7 @@ export function createMapResizeScheduler({
     frameOverlay?.remove();
     frameOverlay = null;
     frameSnapshot = null;
+    frameSnapshotDevicePixelRatio = 1;
     overlayBackgroundColor = "";
     if (overlayMap) {
       overlayMap.off("render", removeFrameOverlay);
@@ -78,6 +80,7 @@ export function createMapResizeScheduler({
       if (!snapshotContext) return;
       snapshotContext.drawImage(canvas, 0, 0);
       frameSnapshot = snapshot;
+      frameSnapshotDevicePixelRatio = window.devicePixelRatio;
     }
     const overlay = frameOverlay ?? document.createElement("canvas");
     overlay.width = Math.round(container.clientWidth * window.devicePixelRatio);
@@ -99,9 +102,12 @@ export function createMapResizeScheduler({
     }
     context.fillStyle = overlayBackgroundColor;
     context.fillRect(0, 0, overlay.width, overlay.height);
-    const x = (overlay.width - snapshot.width) / 2;
-    const y = (overlay.height - snapshot.height) / 2;
-    context.drawImage(snapshot, x, y);
+    const dprScale = window.devicePixelRatio / frameSnapshotDevicePixelRatio;
+    const snapshotWidth = snapshot.width * dprScale;
+    const snapshotHeight = snapshot.height * dprScale;
+    const x = (overlay.width - snapshotWidth) / 2;
+    const y = (overlay.height - snapshotHeight) / 2;
+    context.drawImage(snapshot, x, y, snapshotWidth, snapshotHeight);
     if (frameOverlay) return;
 
     overlay.className = "geolibre-map-resize-frame";

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -70,8 +70,9 @@ function install(): Harness {
     once: (_type: string, listener: () => void) => {
       renderListener = listener;
     },
-    off: (_type: string, listener: () => void) => {
-      if (renderListener === listener) renderListener = null;
+    on: () => {},
+    off: (type: string, listener: () => void) => {
+      if (type === "render" && renderListener === listener) renderListener = null;
     },
     resize: () => {
       resizeCalls += 1;
@@ -119,6 +120,7 @@ function install(): Harness {
         },
       };
     },
+    getComputedStyle: () => ({ backgroundColor: "#fff" }),
   };
   const fakeResizeObserver = class {
     constructor(callback: () => void) {
@@ -142,7 +144,7 @@ function install(): Harness {
         width: 0,
         height: 0,
         style: {},
-        getContext: () => ({ drawImage() {} }),
+        getContext: () => ({ drawImage() {}, fillRect() {} }),
         remove() {
           overlays.delete(overlay);
         },

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -70,7 +70,6 @@ function install(): Harness {
     once: (_type: string, listener: () => void) => {
       renderListener = listener;
     },
-    on: () => {},
     off: (type: string, listener: () => void) => {
       if (type === "render" && renderListener === listener) renderListener = null;
     },
@@ -144,6 +143,7 @@ function install(): Harness {
         width: 0,
         height: 0,
         style: {},
+        setAttribute() {},
         getContext: () => ({ drawImage() {}, fillRect() {} }),
         remove() {
           overlays.delete(overlay);
@@ -259,7 +259,7 @@ describe("createMapResizeScheduler", () => {
       harness.flushFrames();
     }
     assert.equal(harness.resizeCalls(), 0, "the previous frame stays on screen during the drag");
-    assert.equal(harness.overlayCount(), 1, "a stretched frame covers the growing container");
+    assert.equal(harness.overlayCount(), 1, "a preserved frame covers the changing container");
 
     harness.advance(RESIZE_DEBOUNCE_MS);
     harness.flushFrames();
@@ -317,6 +317,21 @@ describe("createMapResizeScheduler", () => {
     harness.dispatch(PANEL_RESIZE_END_EVENT);
     harness.flushFrames();
     assert.equal(harness.resizeCalls(), 0);
+    assert.equal(harness.overlayCount(), 0);
+  });
+
+  it("keeps the panel overlay when a prior resize render arrives", () => {
+    harness.windowResize(700, 600);
+    harness.advance(RESIZE_DEBOUNCE_MS);
+    harness.flushFrames();
+    assert.equal(harness.overlayCount(), 1);
+
+    harness.dispatch(PANEL_RESIZE_START_EVENT);
+    harness.render();
+    assert.equal(harness.overlayCount(), 1);
+
+    harness.dispatch(PANEL_RESIZE_END_EVENT);
+    harness.flushFrames();
     assert.equal(harness.overlayCount(), 0);
   });
 

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -36,6 +36,7 @@ interface Harness {
   resizeCalls: () => number;
   overlayCount: () => number;
   overlaySize: () => { width: number; height: number } | null;
+  drawnFrameWidth: () => number | null;
   render: () => void;
   listenerCount: () => number;
 }
@@ -65,6 +66,7 @@ function install(): Harness {
     },
   };
   let resizeCalls = 0;
+  let drawnFrameWidth: number | null = null;
   let renderListener: (() => void) | null = null;
   const map = {
     getCanvas: () => canvas,
@@ -145,7 +147,12 @@ function install(): Harness {
         height: 0,
         style: {},
         setAttribute() {},
-        getContext: () => ({ drawImage() {}, fillRect() {} }),
+        getContext: () => ({
+          drawImage(...args: unknown[]) {
+            if (args.length === 5) drawnFrameWidth = args[3] as number;
+          },
+          fillRect() {},
+        }),
         remove() {
           overlays.delete(overlay);
         },
@@ -224,6 +231,7 @@ function install(): Harness {
       const overlay = [...overlays][0] as { width: number; height: number } | undefined;
       return overlay ? { width: overlay.width, height: overlay.height } : null;
     },
+    drawnFrameWidth: () => drawnFrameWidth,
     render() {
       const listener = renderListener;
       renderListener = null;
@@ -359,6 +367,7 @@ describe("createMapResizeScheduler", () => {
     harness.setDevicePixelRatio(2);
     harness.flushFrames();
     assert.equal(harness.resizeCalls(), 1);
+    assert.equal(harness.drawnFrameWidth(), 1600);
   });
 
   it("detaches every listener on dispose", () => {

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -308,6 +308,16 @@ describe("createMapResizeScheduler", () => {
     assert.equal(harness.resizeCalls(), 1);
   });
 
+  it("removes the preserved frame when a panel resize ends without movement", () => {
+    harness.dispatch(PANEL_RESIZE_START_EVENT);
+    assert.equal(harness.overlayCount(), 1);
+
+    harness.dispatch(PANEL_RESIZE_END_EVENT);
+    harness.flushFrames();
+    assert.equal(harness.resizeCalls(), 0);
+    assert.equal(harness.overlayCount(), 0);
+  });
+
   it("keeps a settling window drag from leaking into a following panel drag", () => {
     harness.windowResize(700, 600);
     harness.dispatch(PANEL_RESIZE_START_EVENT);

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -35,6 +35,7 @@ interface Harness {
   setDevicePixelRatio: (ratio: number) => void;
   resizeCalls: () => number;
   overlayCount: () => number;
+  overlaySize: () => { width: number; height: number } | null;
   render: () => void;
   listenerCount: () => number;
 }
@@ -219,6 +220,10 @@ function install(): Harness {
     },
     resizeCalls: () => resizeCalls,
     overlayCount: () => overlays.size,
+    overlaySize: () => {
+      const overlay = [...overlays][0] as { width: number; height: number } | undefined;
+      return overlay ? { width: overlay.width, height: overlay.height } : null;
+    },
     render() {
       const listener = renderListener;
       renderListener = null;
@@ -304,6 +309,7 @@ describe("createMapResizeScheduler", () => {
       harness.flushFrames();
     }
     assert.equal(harness.resizeCalls(), 0);
+    assert.deepEqual(harness.overlaySize(), { width: 762, height: 600 });
 
     harness.dispatch(PANEL_RESIZE_END_EVENT);
     harness.flushFrames();

--- a/tests/map-resize.test.ts
+++ b/tests/map-resize.test.ts
@@ -34,6 +34,8 @@ interface Harness {
   advance: (ms: number) => void;
   setDevicePixelRatio: (ratio: number) => void;
   resizeCalls: () => number;
+  overlayCount: () => number;
+  render: () => void;
   listenerCount: () => number;
 }
 
@@ -50,10 +52,27 @@ function install(): Harness {
   const container = { clientWidth: 800, clientHeight: 600 };
   // Mirrors MapLibre: `resize()` writes the container's client dimensions back
   // as the canvas CSS size, which is what `mapNeedsResize` compares against.
-  const canvas = { style: { width: "800px", height: "600px" } };
+  const overlays = new Set<object>();
+  const canvasParent = {};
+  const canvas = {
+    style: { width: "800px", height: "600px" },
+    width: 800,
+    height: 600,
+    parentElement: canvasParent,
+    insertAdjacentElement(_position: string, overlay: object) {
+      overlays.add(overlay);
+    },
+  };
   let resizeCalls = 0;
+  let renderListener: (() => void) | null = null;
   const map = {
     getCanvas: () => canvas,
+    once: (_type: string, listener: () => void) => {
+      renderListener = listener;
+    },
+    off: (_type: string, listener: () => void) => {
+      if (renderListener === listener) renderListener = null;
+    },
     resize: () => {
       resizeCalls += 1;
       canvas.style.width = `${container.clientWidth}px`;
@@ -114,8 +133,28 @@ function install(): Harness {
   const previous = {
     window: globalThis.window,
     ResizeObserver: globalThis.ResizeObserver,
+    document: globalThis.document,
   };
-  Object.assign(globalThis, { window: fakeWindow, ResizeObserver: fakeResizeObserver });
+  const fakeDocument = {
+    createElement() {
+      const overlay = {
+        className: "",
+        width: 0,
+        height: 0,
+        style: {},
+        getContext: () => ({ drawImage() {} }),
+        remove() {
+          overlays.delete(overlay);
+        },
+      };
+      return overlay;
+    },
+  };
+  Object.assign(globalThis, {
+    window: fakeWindow,
+    ResizeObserver: fakeResizeObserver,
+    document: fakeDocument,
+  });
   restoreGlobals = () => Object.assign(globalThis, previous);
 
   // The browser lays the window out before either signal is delivered, so both
@@ -177,6 +216,12 @@ function install(): Harness {
       }
     },
     resizeCalls: () => resizeCalls,
+    overlayCount: () => overlays.size,
+    render() {
+      const listener = renderListener;
+      renderListener = null;
+      listener?.();
+    },
     listenerCount: () =>
       [...listeners.values()].reduce((total, set) => total + set.size, 0) +
       [...mediaListeners.values()].reduce((total, set) => total + set.size, 0),
@@ -212,10 +257,14 @@ describe("createMapResizeScheduler", () => {
       harness.flushFrames();
     }
     assert.equal(harness.resizeCalls(), 0, "the previous frame stays on screen during the drag");
+    assert.equal(harness.overlayCount(), 1, "a stretched frame covers the growing container");
 
     harness.advance(RESIZE_DEBOUNCE_MS);
     harness.flushFrames();
     assert.equal(harness.resizeCalls(), 1);
+    assert.equal(harness.overlayCount(), 1, "the frame remains while MapLibre renders");
+    harness.render();
+    assert.equal(harness.overlayCount(), 0, "the rendered map replaces the preserved frame");
   });
 
   it("drops a frame queued by a discrete change when a window drag starts", () => {


### PR DESCRIPTION
## Summary

- capture the current rendered map frame when a resize begins
- center the snapshot without changing its aspect ratio over a theme-matched background while the container changes
- keep it visible through the WebGL framebuffer clear, then remove it after MapLibre renders at the new size
- cover overlay cleanup and overlapping resize lifecycle edge cases in scheduler tests

## Verification

- reproduced the old canvas remaining 612 px wide while its container expanded to 1012 px
- confirmed the overlay covers the transparent framebuffer resize frame without deforming the globe
- verified the default globe through rapid Chromium viewport changes in light and dark themes
- `node --import tsx --test tests/map-resize.test.ts`
- `npm run build`
- `pre-commit run --files packages/map/src/map-resize.ts tests/map-resize.test.ts`

Fixes #2172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map content now remains visually stable during window and panel resizing.
  * Added a temporary frame overlay to prevent flickering or blank areas while the map redraws.
  * The preserved view is automatically removed once rendering completes or resizing ends.
  * Improved handling for resize events where no movement occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->