### PR TITLE
fix: default map sharing to public

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
@@ -147,7 +147,7 @@ export function ShareProjectDialog({
   const shareHost = shareHostLabel();
   const shareToken = useDesktopSettingsStore((s) => s.desktopSettings.shareToken);
   const [title, setTitle] = useState("");
-  const [visibility, setVisibility] = useState<ShareVisibility>("unlisted");
+  const [visibility, setVisibility] = useState<ShareVisibility>("public");
   const [status, setStatus] = useState<"idle" | "uploading">("idle");
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<ShareUploadErrorCode | null>(null);
@@ -169,7 +169,7 @@ export function ShareProjectDialog({
   useEffect(() => {
     if (open) {
       setTitle(isShareableTitle(currentTitle) ? currentTitle.trim() : "");
-      setVisibility("unlisted");
+      setVisibility("public");
       setStatus("idle");
       setError(null);
       setErrorCode(null);


### PR DESCRIPTION
## Summary
- default new map shares to Public visibility
- reset reopened sharing dialogs to Public while keeping the visibility selector available

## Test plan
- [x] Run scoped pre-commit hooks
- [x] Run ESLint and the production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New project shares now default to **Public** visibility.
  * Reopening the share dialog consistently preserves the **Public** default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->