### PR TITLE
fix: stabilize Android GPS readings

### DIFF
--- a/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/GEOLIBRE_PATCH.md
+++ b/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/GEOLIBRE_PATCH.md
@@ -12,7 +12,7 @@ The GeoLibre-specific delta is intentionally limited to:
 - `android/src/main/java/GeolocationPlugin.kt`: include `satellites` in native
   coordinates, briefly race GNSS metadata against a timeout, and unregister
   one-shot GNSS monitoring after completion when no continuous watch is active;
-  suppress speed below Android's reported speed uncertainty and omit unavailable
+  suppress speed at or below Android's reported speed uncertainty and omit unavailable
   speed/bearing values instead of serializing Android's zero-value placeholders.
 - `src/models.rs`: preserve the optional value through Rust deserialization.
 

--- a/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/GEOLIBRE_PATCH.md
+++ b/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/GEOLIBRE_PATCH.md
@@ -6,11 +6,14 @@ number of GNSS satellites used in a location fix.
 
 The GeoLibre-specific delta is intentionally limited to:
 
-- `android/src/main/java/Geolocation.kt`: observe `GnssStatusCompat` and notify
+- `android/src/main/java/Geolocation.kt`: observe `GnssStatusCompat`, timestamp
+  the observation so stale metadata is not paired with a fused fix, and notify
   one-shot callers when a satellite count becomes available.
 - `android/src/main/java/GeolocationPlugin.kt`: include `satellites` in native
   coordinates, briefly race GNSS metadata against a timeout, and unregister
-  one-shot GNSS monitoring after completion when no continuous watch is active.
+  one-shot GNSS monitoring after completion when no continuous watch is active;
+  suppress speed below Android's reported speed uncertainty and omit unavailable
+  speed/bearing values instead of serializing Android's zero-value placeholders.
 - `src/models.rs`: preserve the optional value through Rust deserialization.
 
 When upgrading, compare the new upstream release against this directory,

--- a/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/Geolocation.kt
+++ b/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/Geolocation.kt
@@ -24,6 +24,10 @@ import com.google.android.gms.location.Priority
 
 
 public class Geolocation(private val context: Context) {
+    private companion object {
+        const val SATELLITE_STALENESS_NANOS = 3_000_000_000L
+    }
+
     private var fusedLocationClient: FusedLocationProviderClient? = null
     private var locationCallback: LocationCallback? = null
     private val locationManager =
@@ -80,7 +84,13 @@ public class Geolocation(private val context: Context) {
     fun satellitesUsedFor(location: Location): Int? {
         val updatedAt = satellitesUpdatedAtNanos ?: return null
         val ageNanos = kotlin.math.abs(location.elapsedRealtimeNanos - updatedAt)
-        return satellitesUsed?.takeIf { ageNanos <= 3_000_000_000L }
+        return satellitesUsed?.takeIf { ageNanos <= SATELLITE_STALENESS_NANOS }
+    }
+
+    /** True when a future GNSS callback could still match this location fix. */
+    fun canWaitForSatellites(location: Location): Boolean {
+        val locationAgeNanos = SystemClock.elapsedRealtimeNanos() - location.elapsedRealtimeNanos
+        return locationAgeNanos in 0..SATELLITE_STALENESS_NANOS
     }
 
     /**
@@ -89,7 +99,10 @@ public class Geolocation(private val context: Context) {
      */
     fun onSatellitesUsedAvailable(callback: (Int) -> Unit): () -> Unit {
         val updatedAt = satellitesUpdatedAtNanos
-        if (updatedAt != null && SystemClock.elapsedRealtimeNanos() - updatedAt <= 3_000_000_000L) {
+        if (
+            updatedAt != null &&
+            SystemClock.elapsedRealtimeNanos() - updatedAt <= SATELLITE_STALENESS_NANOS
+        ) {
             satellitesUsed?.let {
                 callback(it)
                 return {}

--- a/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/Geolocation.kt
+++ b/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/Geolocation.kt
@@ -32,6 +32,7 @@ public class Geolocation(private val context: Context) {
     private val satelliteListeners = mutableSetOf<(Int) -> Unit>()
     @Volatile var satellitesUsed: Int? = null
         private set
+    @Volatile private var satellitesUpdatedAtNanos: Long? = null
 
     @SuppressLint("MissingPermission")
     fun startGnssStatusUpdates() {
@@ -44,6 +45,7 @@ public class Geolocation(private val context: Context) {
                         if (status.usedInFix(index)) used += 1
                     }
                     satellitesUsed = used
+                    satellitesUpdatedAtNanos = SystemClock.elapsedRealtimeNanos()
                     val listeners = satelliteListeners.toList()
                     satelliteListeners.clear()
                     listeners.forEach { it(used) }
@@ -51,6 +53,7 @@ public class Geolocation(private val context: Context) {
 
                 override fun onStopped() {
                     satellitesUsed = null
+                    satellitesUpdatedAtNanos = null
                 }
             }
         try {
@@ -65,7 +68,19 @@ public class Geolocation(private val context: Context) {
             }
         } catch (_: SecurityException) {
             satellitesUsed = null
+            satellitesUpdatedAtNanos = null
         }
+    }
+
+    /**
+     * Return GNSS metadata only when it was observed close to this location.
+     * Fused fixes may come from Wi-Fi/cell positioning, while the GNSS status
+     * callback is global and otherwise leaves a stale count attached indoors.
+     */
+    fun satellitesUsedFor(location: Location): Int? {
+        val updatedAt = satellitesUpdatedAtNanos ?: return null
+        val ageNanos = kotlin.math.abs(location.elapsedRealtimeNanos - updatedAt)
+        return satellitesUsed?.takeIf { ageNanos <= 3_000_000_000L }
     }
 
     /**
@@ -73,9 +88,12 @@ public class Geolocation(private val context: Context) {
      * returned callback unregisters the listener when a caller times out.
      */
     fun onSatellitesUsedAvailable(callback: (Int) -> Unit): () -> Unit {
-        satellitesUsed?.let {
-            callback(it)
-            return {}
+        val updatedAt = satellitesUpdatedAtNanos
+        if (updatedAt != null && SystemClock.elapsedRealtimeNanos() - updatedAt <= 3_000_000_000L) {
+            satellitesUsed?.let {
+                callback(it)
+                return {}
+            }
         }
         satelliteListeners.add(callback)
         return { satelliteListeners.remove(callback) }
@@ -190,6 +208,7 @@ public class Geolocation(private val context: Context) {
         }
         gnssStatusCallback = null
         satellitesUsed = null
+        satellitesUpdatedAtNanos = null
     }
 
     @SuppressLint("MissingPermission")

--- a/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/GeolocationPlugin.kt
+++ b/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/GeolocationPlugin.kt
@@ -142,7 +142,7 @@ class GeolocationPlugin(private val activity: Activity): Plugin(activity) {
      * preserves the normal result on coarse-only or non-GNSS devices.
      */
     private fun resolveCurrentPosition(invoke: Invoke, location: Location) {
-        if (implementation.satellitesUsed != null) {
+        if (implementation.satellitesUsedFor(location) != null) {
             resolveOneShot(invoke, location)
             return
         }
@@ -209,13 +209,21 @@ class GeolocationPlugin(private val activity: Activity): Plugin(activity) {
         coords.put("latitude", location.latitude)
         coords.put("longitude", location.longitude)
         coords.put("accuracy", location.accuracy)
-        implementation.satellitesUsed?.let { coords.put("satellites", it) }
+        implementation.satellitesUsedFor(location)?.let { coords.put("satellites", it) }
         coords.put("altitude", location.altitude)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             coords.put("altitudeAccuracy", location.verticalAccuracyMeters)
         }
-        coords.put("speed", location.speed)
-        coords.put("heading", location.bearing)
+        if (location.hasSpeed()) {
+            val speed =
+                if (
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                    location.hasSpeedAccuracy() &&
+                    location.speed <= location.speedAccuracyMetersPerSecond
+                ) 0f else location.speed
+            coords.put("speed", speed)
+        }
+        if (location.hasBearing()) coords.put("heading", location.bearing)
         ret.put("timestamp", location.time)
         ret.put("coords", coords)
 

--- a/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/GeolocationPlugin.kt
+++ b/apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/src/main/java/GeolocationPlugin.kt
@@ -142,7 +142,10 @@ class GeolocationPlugin(private val activity: Activity): Plugin(activity) {
      * preserves the normal result on coarse-only or non-GNSS devices.
      */
     private fun resolveCurrentPosition(invoke: Invoke, location: Location) {
-        if (implementation.satellitesUsedFor(location) != null) {
+        if (
+            implementation.satellitesUsedFor(location) != null ||
+            !implementation.canWaitForSatellites(location)
+        ) {
             resolveOneShot(invoke, location)
             return
         }


### PR DESCRIPTION
## Summary
- associate satellite counts only with contemporaneous GNSS observations instead of stale fused-location metadata
- suppress stationary speed noise using Android's reported speed uncertainty
- omit unavailable speed and bearing values instead of emitting zero-value placeholders

## Test plan
- [x] Run scoped pre-commit hooks, including the production web build
- [x] Run `npm run check:rust`
- [ ] Verify satellite and stationary speed readings on a physical Android device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GNSS satellite reporting by matching satellite data to the relevant location timestamp.
  * Fixed cleanup of satellite monitoring when continuous tracking stops or fails.
  * Improved one-time location results when satellite data is already available.
  * More accurately reports uncertain or unavailable speed and heading values on Android.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->