### PR TITLE
3D globe: place the camera against terrain, not the ellipsoid, so the panes stay in scale

### DIFF
--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -10,7 +10,12 @@ import {
 import type { ImageryLayer, Viewer } from "cesium";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { applyBasemapAppearance, applyBasemapImagery } from "./cesium-basemap";
-import { applyMapViewToCamera, isSameView, readMapViewFromCamera } from "./cesium-camera";
+import {
+  applyMapViewToCamera,
+  groundHeightAt,
+  isSameView,
+  readMapViewFromCamera,
+} from "./cesium-camera";
 import { CesiumLayerSync } from "./cesium-layer-sync";
 
 // The Cesium 3D-globe view (see private/cesium-view-plan.md). M1 wired the
@@ -83,6 +88,11 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   // moveEnd with a (rounding-drifted) echo of that same view; comparing against
   // this lets the moveEnd handler tell a real user move from that echo.
   const lastAppliedRef = useRef<MapViewState | null>(null);
+  // Ground height (metres) the last applyView placed the camera against. Terrain
+  // streams in after the camera is positioned, so the first apply over a new
+  // area sees height 0; comparing against this tells a settled terrain load
+  // whether the camera now needs correcting.
+  const lastGroundHeightRef = useRef(0);
   // Set by real pointer/wheel/touch input on the globe canvas and consumed by
   // the moveEnd handler. Cesium's camera.moveEnd carries no user-driven flag
   // (unlike MapLibre's moveend.originalEvent), so this stands in for it: an
@@ -195,6 +205,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
     const viewer = viewerRef.current;
     if (!Cesium || !viewer || viewer.isDestroyed()) return;
     lastAppliedRef.current = view;
+    lastGroundHeightRef.current = groundHeightAt(Cesium, viewer, view.center[0], view.center[1]);
     applyMapViewToCamera(Cesium, viewer, view);
   }
 
@@ -308,6 +319,23 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         // imagery stack rather than having to be lowered past the data layers.
         applyBasemap();
         layerSyncRef.current?.sync(paneLayersRef.current);
+
+        // Terrain arrives after the camera is placed, and the ground height is
+        // what turns MapLibre's zoom into a camera distance. Until the tiles for
+        // the view land, `groundHeightAt` reports 0 and the camera is positioned
+        // against the ellipsoid — over Las Vegas that renders ~2× too close at
+        // zoom 15. Re-apply once the queue drains and the height has actually
+        // changed, so the globe settles onto the real surface. The guard makes
+        // this a no-op without terrain (height stays 0) and stops it recursing:
+        // the re-apply's own load settles at the same height.
+        viewer.scene.globe.tileLoadProgressEvent.addEventListener((queued: number) => {
+          const ns = cesiumRef.current;
+          const view = lastAppliedRef.current;
+          if (queued > 0 || !ns || !view || viewer.isDestroyed()) return;
+          const height = groundHeightAt(ns, viewer, view.center[0], view.center[1]);
+          if (Math.abs(height - lastGroundHeightRef.current) < 1) return;
+          applyView(view);
+        });
 
         // Mirror a user's globe navigation back into the shared camera. Echoes
         // of our own applyView are filtered by the isSameView guard.

--- a/packages/map/src/cesium-camera.ts
+++ b/packages/map/src/cesium-camera.ts
@@ -83,6 +83,55 @@ function canvasHeight(viewer: Viewer): number {
 }
 
 /**
+ * Height (metres) of the rendered ground at a position — the terrain surface
+ * when terrain is on and its tiles have loaded, otherwise 0 (the ellipsoid).
+ *
+ * This is what makes the scale match on a terrain globe. Zoom is encoded as the
+ * camera's distance from the ground, so measuring that distance to the
+ * *ellipsoid* while the ground is 600 m higher puts the camera 600 m closer to
+ * what the user actually sees than intended. The error is the ratio
+ * `range / (range - groundHeight)`: invisible when the camera is far out, and
+ * runaway as `range` approaches the terrain height — over Las Vegas (~640 m) it
+ * passes 2× at around zoom 15.
+ *
+ * `Globe.getHeight` reads already-loaded tiles and is synchronous, so this stays
+ * cheap enough for the camera path; it returns undefined until the tiles for the
+ * area arrive, which is why {@link CesiumCanvas} re-applies once terrain settles.
+ */
+export function groundHeightAt(
+  Cesium: typeof import("cesium"),
+  viewer: Viewer,
+  lngDeg: number,
+  latDeg: number,
+): number {
+  const globe = viewer.scene.globe;
+  if (!globe) return 0;
+  const height = globe.getHeight(Cesium.Cartographic.fromDegrees(lngDeg, latDeg));
+  return typeof height === "number" && Number.isFinite(height) ? height : 0;
+}
+
+/**
+ * The point on the globe under a screen position: the terrain surface when
+ * terrain is loaded, else the ellipsoid, else undefined when the ray misses the
+ * globe entirely (the horizon is in view). Mirrors {@link groundHeightAt} on the
+ * readback side so a view survives the apply → read round trip unchanged.
+ */
+function pickGlobe(
+  Cesium: typeof import("cesium"),
+  viewer: Viewer,
+  position: { x: number; y: number },
+) {
+  const { scene, camera } = viewer;
+  const ray = camera.getPickRay(position as Parameters<typeof camera.getPickRay>[0]);
+  const onTerrain = ray && scene.globe ? scene.globe.pick(ray, scene) : undefined;
+  if (onTerrain) return onTerrain;
+  return camera.pickEllipsoid(
+    position as Parameters<typeof camera.pickEllipsoid>[0],
+    scene.globe?.ellipsoid ?? Cesium.Ellipsoid.WGS84,
+  );
+}
+
+/**
  * Point a viewer's camera at the map center described by `view`, matching
  * MapLibre's scale, bearing, and pitch. Requires the Cesium namespace so this
  * module stays free of a runtime Cesium import.
@@ -96,7 +145,10 @@ export function applyMapViewToCamera(
   const range = Math.max(zoomToRange(view.zoom, lat, canvasHeight(viewer), cameraFovy(viewer)), 1);
   const heading = Cesium.Math.toRadians(normalizeBearing(view.bearing));
   const pitch = Cesium.Math.toRadians(mapLibrePitchToCesiumDeg(view.pitch));
-  const target = Cesium.Cartesian3.fromDegrees(lng, lat);
+  // Aim at the ground, not the ellipsoid beneath it: `range` is the distance
+  // that encodes MapLibre's zoom, so on a terrain globe the target has to sit on
+  // the terrain or the pane renders far more zoomed in than its 2D twin.
+  const target = Cesium.Cartesian3.fromDegrees(lng, lat, groundHeightAt(Cesium, viewer, lng, lat));
   // lookAt orients the camera in the target's local frame; resetting the
   // transform to identity hands control back for free user navigation.
   viewer.camera.lookAt(target, new Cesium.HeadingPitchRange(heading, pitch, range));
@@ -120,7 +172,10 @@ export function readMapViewFromCamera(
   const ellipsoid = scene.globe?.ellipsoid ?? Cesium.Ellipsoid.WGS84;
 
   const centerPx = new Cesium.Cartesian2(width / 2, height / 2);
-  const groundPoint = camera.pickEllipsoid(centerPx, ellipsoid);
+  // Pick the terrain, not the ellipsoid, so the range read back is the same
+  // ground distance applyMapViewToCamera set — otherwise a terrain globe reads
+  // back a zoom that disagrees with the one just applied and the panes drift.
+  const groundPoint = pickGlobe(Cesium, viewer, centerPx);
 
   let lng: number;
   let lat: number;
@@ -131,6 +186,8 @@ export function readMapViewFromCamera(
     lat = Cesium.Math.toDegrees(carto.latitude);
     range = Cesium.Cartesian3.distance(camera.positionWC, groundPoint);
   } else {
+    // Horizon in view. The camera is thousands of kilometres out here, so the
+    // ellipsoid height is close enough and terrain is not worth sampling.
     const carto = camera.positionCartographic;
     lng = Cesium.Math.toDegrees(carto.longitude);
     lat = Cesium.Math.toDegrees(carto.latitude);

--- a/tests/cesium-camera.test.ts
+++ b/tests/cesium-camera.test.ts
@@ -224,10 +224,7 @@ describe("groundHeightAt", () => {
   it("falls back to the ellipsoid when the scene has no globe", () => {
     const { Cesium, viewer } = makeCameraFakes(0);
     const noGlobe = { ...viewer, scene: { ...viewer.scene, globe: undefined } };
-    assert.equal(
-      groundHeightAt(Cesium, noGlobe as unknown as typeof viewer, -115.2, 36.12),
-      0,
-    );
+    assert.equal(groundHeightAt(Cesium, noGlobe as unknown as typeof viewer, -115.2, 36.12), 0);
   });
 });
 

--- a/tests/cesium-camera.test.ts
+++ b/tests/cesium-camera.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { MapViewState } from "../packages/core/src/types";
 import {
+  applyMapViewToCamera,
   cesiumPitchToMapLibreDeg,
+  groundHeightAt,
   groundResolution,
   isSameView,
   mapLibrePitchToCesiumDeg,
@@ -142,5 +144,115 @@ describe("isSameView", () => {
       isSameView({ ...base, center: [179.9, 40] }, { ...base, center: [-179.9, 40] }),
       false,
     );
+  });
+});
+
+// --- terrain-aware camera placement -----------------------------------------
+// Zoom is encoded as the camera's distance from the ground, so on a terrain
+// globe the look-at target has to sit on the terrain. Aiming at the ellipsoid
+// under 640 m of Las Vegas put the camera 640 m closer to the surface than the
+// zoom asked for — a >2x scale mismatch against the 2D pane at zoom 15.
+
+/** A fake Cesium namespace + viewer recording what the camera was told to do. */
+function makeCameraFakes(terrainHeight: number | undefined) {
+  const calls = {
+    target: null as { lng: number; lat: number; height?: number } | null,
+    range: 0,
+  };
+
+  const viewer = {
+    scene: {
+      canvas: { clientWidth: 600, clientHeight: HEIGHT, width: 600, height: HEIGHT },
+      globe: {
+        // Cesium returns undefined until the tiles for the position have loaded.
+        getHeight: () => terrainHeight,
+      },
+    },
+    camera: {
+      frustum: { fovy: FOVY },
+      lookAt: (_target: unknown, hpr: { range: number }) => {
+        calls.range = hpr.range;
+      },
+      lookAtTransform: () => {},
+    },
+  };
+
+  const Cesium = {
+    Math: { toRadians: (d: number) => (d * Math.PI) / 180, toDegrees: (r: number) => r },
+    Cartesian3: {
+      fromDegrees: (lng: number, lat: number, height?: number) => {
+        calls.target = { lng, lat, height };
+        return { lng, lat, height };
+      },
+    },
+    Cartographic: { fromDegrees: (lng: number, lat: number) => ({ lng, lat }) },
+    HeadingPitchRange: class {
+      range: number;
+      constructor(_heading: number, _pitch: number, range: number) {
+        this.range = range;
+      }
+    },
+    Matrix4: { IDENTITY: {} },
+  };
+
+  return {
+    calls,
+    viewer: viewer as unknown as Parameters<typeof applyMapViewToCamera>[1],
+    Cesium: Cesium as unknown as Parameters<typeof applyMapViewToCamera>[0],
+  };
+}
+
+const LAS_VEGAS: MapViewState = {
+  center: [-115.2037, 36.1207],
+  zoom: 14.86,
+  bearing: 0,
+  pitch: 0,
+};
+
+describe("groundHeightAt", () => {
+  it("reports the loaded terrain height", () => {
+    const { Cesium, viewer } = makeCameraFakes(640);
+    assert.equal(groundHeightAt(Cesium, viewer, -115.2, 36.12), 640);
+  });
+
+  it("falls back to the ellipsoid before the terrain tiles load", () => {
+    // Globe.getHeight returns undefined for a position with no loaded tile.
+    const { Cesium, viewer } = makeCameraFakes(undefined);
+    assert.equal(groundHeightAt(Cesium, viewer, -115.2, 36.12), 0);
+  });
+
+  it("falls back to the ellipsoid when the scene has no globe", () => {
+    const { Cesium, viewer } = makeCameraFakes(0);
+    const noGlobe = { ...viewer, scene: { ...viewer.scene, globe: undefined } };
+    assert.equal(
+      groundHeightAt(Cesium, noGlobe as unknown as typeof viewer, -115.2, 36.12),
+      0,
+    );
+  });
+});
+
+describe("applyMapViewToCamera on terrain", () => {
+  it("aims at the terrain surface, not the ellipsoid beneath it", () => {
+    const { Cesium, viewer, calls } = makeCameraFakes(640);
+    applyMapViewToCamera(Cesium, viewer, LAS_VEGAS);
+    assert.equal(calls.target?.height, 640);
+  });
+
+  it("keeps the range the zoom asks for regardless of terrain height", () => {
+    // The range is the distance from the target; raising the target is what
+    // keeps the camera that far above the *ground* rather than the ellipsoid.
+    const flat = makeCameraFakes(0);
+    applyMapViewToCamera(flat.Cesium, flat.viewer, LAS_VEGAS);
+    const high = makeCameraFakes(640);
+    applyMapViewToCamera(high.Cesium, high.viewer, LAS_VEGAS);
+
+    assert.equal(high.calls.range, flat.calls.range);
+    assert.equal(high.calls.range, zoomToRange(LAS_VEGAS.zoom, LAS_VEGAS.center[1], HEIGHT, FOVY));
+  });
+
+  it("targets height 0 when terrain has not loaded yet", () => {
+    const { Cesium, viewer, calls } = makeCameraFakes(undefined);
+    applyMapViewToCamera(Cesium, viewer, LAS_VEGAS);
+    assert.equal(calls.target?.height, 0);
   });
 });


### PR DESCRIPTION
Rebased onto `main` now that #2205 has merged, so this diff is just the camera fix. Reported while testing #2205 with the Las Vegas buildings sample; the bug itself predates it and is in the M2 camera sync from #1139.

## The bug

With terrain on, the globe pane renders far more zoomed in than its 2D twin at high zoom. Low zooms look fine, which is why it went unnoticed.

MapLibre's zoom is carried to Cesium as a camera *distance* (`zoomToRange`), but `applyMapViewToCamera` aimed at `Cartesian3.fromDegrees(lng, lat)` — a point on the **ellipsoid**, height 0. With Cesium World Terrain on, the ground at Las Vegas is ~640 m above that, so the camera sat 640 m closer to the visible surface than the zoom asked for.

The error is `range / (range - groundHeight)` — negligible when the camera is far out, runaway as `range` approaches the terrain height:

```
zoom 14.86, 648 px pane -> ground resolution 2.126 m/px
                        -> vertical extent 1378 m (what MapLibre shows)
                        -> camera range 1193 m above the ELLIPSOID
   terrain 640 m        -> 553 m above the GROUND -> 2.16x too close
```

Measured ~2.2× against a prediction of 2.16×.

## The fix

- `applyMapViewToCamera` aims at the terrain surface, via a new exported `groundHeightAt()` (`Globe.getHeight`, which reads loaded tiles synchronously and returns 0 when terrain is off or not yet loaded).
- `readMapViewFromCamera` picks the **terrain** (`Globe.pick`) instead of the ellipsoid, with the ellipsoid and then the camera sub-point as fallbacks. Without this the readback would report a different zoom than the one just applied and the panes would drift.
- Terrain streams in *after* the camera is placed, so the first apply over a new area still sees height 0. `CesiumCanvas` now re-applies once the tile queue drains **and** the ground height has actually changed. The equality guard makes it a no-op without terrain and stops it recursing, since the re-apply's own load settles at the same height.

## Verified in the browser

Same project, same layer, identical `Zoom: 14.86` and `BBox: -115.2088, 36.1145, -115.1986, 36.1269` in every run. Measuring West Twain Avenue to Via Renaldo in the globe pane:

| Run | Globe span | Matches 2D? |
| --- | --- | --- |
| No token (terrain off) — reference | 213 px | Yes |
| Token, terrain on, before fix | 469 px | No, ~2.2x too close |
| Token, terrain on, after fix | 213 px | Yes |

The terrain-off run is the control: it confirms the pure camera math was already correct and isolates terrain elevation as the whole cause.

## Tests

Six new tests in `tests/cesium-camera.test.ts` covering `groundHeightAt` (loaded height, the not-yet-loaded `undefined` case, no globe) and the terrain-aware apply (aims at the terrain, keeps the range the zoom asks for regardless of terrain height, targets 0 before terrain loads). Full frontend suite green at 7445 passing; lint and build clean.

## Note

This also mattered more than scale: at high enough zoom over high terrain the old code could put the camera *below* the ground surface, since `range` could be smaller than the terrain height.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera positioning on terrain maps so views settle onto the actual ground surface as terrain loads.
  * Prevented cameras from appearing too close to or below streamed terrain.
  * Added fallback behavior for areas where terrain data is unavailable.
* **Tests**
  * Added coverage for terrain-aware camera placement and unloaded-terrain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->