### PR TITLE
3D globe: build a bare CesiumWidget, import the engine directly, and smoke-test the globe

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -20,6 +20,7 @@
     "@auth0/auth0-react": "^2.24.1",
     "@carbonplan/zarr-layer": "^0.9.0",
     "@cereusdb/standard": "^0.2.0",
+    "@cesium/engine": "^26.2.0",
     "@clerk/react": "^6.14.8",
     "@deck.gl/aggregation-layers": "9.3.11",
     "@deck.gl/core": "^9.3.11",

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -559,11 +559,13 @@ function manualChunks(id: string): string | undefined {
   if (id.includes("maplibre-gl")) return "maplibre";
   // Cesium is large (~several MB) and only loads when the user opens the 3D
   // globe view; keep it in its own lazily-fetched chunk, off the boot graph.
-  // `@cesium/engine`/`@cesium/widgets` (which the `cesium` wrapper re-exports)
-  // are only reachable through the lazy `import("cesium")`, so Rollup already
-  // groups them into this chunk; matching them explicitly keeps that intent
-  // even if some future eager import would otherwise pull them onto the boot
-  // graph.
+  // The globe imports `@cesium/engine` directly rather than the `cesium`
+  // wrapper: the wrapper re-exports `@cesium/widgets` too, and that barrel
+  // defeats tree-shaking, so the widget chrome and Knockout shipped in this
+  // chunk even though the pane builds a bare `CesiumWidget`. The `cesium`
+  // package is still a dependency — copy-cesium-assets stages the runtime
+  // Workers/Assets from its prebuilt `Build/Cesium` — so both paths are matched
+  // here, which also keeps the intent if a future eager import appears.
   if (id.includes("/node_modules/cesium/") || id.includes("/node_modules/@cesium/"))
     return "cesium";
   // Returning undefined hands remaining node_modules back to Rollup's default
@@ -920,11 +922,13 @@ function pwaPlugin(): Plugin[] {
     // its first runtime fetch and is CacheFirst-cached thereafter.
     "**/maplibre-*",
     "**/duckdb-*",
-    // CesiumJS (~4.8 MB) for the 3D-globe view. Lazily imported only when a pane
+    // CesiumJS (~4.6 MB) for the 3D-globe view. Lazily imported only when a pane
     // switches to the globe, so it is CacheFirst-cached on first use rather than
-    // bloating the app-shell precache. The `Cesium-*` (capital) glob catches the
-    // Rollup facade chunk for the dynamic `import("cesium")` boundary, which the
-    // lowercase glob misses on case-sensitive matchers.
+    // bloating the app-shell precache. The `Cesium-*` (capital) glob covered the
+    // Rollup facade chunk for the old `import("cesium")` boundary; importing
+    // `@cesium/engine` directly no longer emits it, but the glob is kept so a
+    // revert to the wrapper does not silently push a facade chunk into the
+    // precache.
     "**/cesium-*",
     "**/Cesium-*",
     // h5wasm's ~5.6 MB single-file chunk (embedded libhdf5) for the local

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1187,12 +1187,20 @@ export default defineConfig({
       // CJS→ESM interop to its CommonJS transitive deps (e.g. mersenne-twister,
       // which has no ESM entry): without this, the dev server serves those raw
       // and the `import x from "mersenne-twister"` default import throws. It is
-      // reached only through the lazy `import("cesium")` in CesiumCanvas, so
-      // without pre-bundling Vite would also discover it on first open and do a
-      // full-page reload to re-optimize. Cesium locates its Workers/Assets via
-      // the CESIUM_BASE_URL global (never `import.meta.url`), so pre-bundling
-      // does not mangle any asset reference.
-      "cesium",
+      // reached only through the lazy `import("@cesium/engine")` in
+      // CesiumCanvas, so without pre-bundling Vite would also discover it on
+      // first open and do a full-page reload to re-optimize. Cesium locates its
+      // Workers/Assets via the CESIUM_BASE_URL global (never
+      // `import.meta.url`), so pre-bundling does not mangle any asset
+      // reference.
+      //
+      // This must name the same specifier the globe imports. It used to be the
+      // `cesium` wrapper; that package is still a dependency for its prebuilt
+      // Workers/Assets (see copy-cesium-assets.ts) but nothing imports it as a
+      // module any more, so pre-bundling it would optimize the wrong graph and
+      // leave `@cesium/engine` to be discovered on first open — the full-page
+      // reload this list exists to prevent.
+      "@cesium/engine",
     ],
     // PGlite ships its own WASM + filesystem bundles and must not be pre-bundled
     // by esbuild, which mangles those asset references (per PGlite's Vite guide).

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1189,10 +1189,15 @@ export default defineConfig({
       // and the `import x from "mersenne-twister"` default import throws. It is
       // reached only through the lazy `import("@cesium/engine")` in
       // CesiumCanvas, so without pre-bundling Vite would also discover it on
-      // first open and do a full-page reload to re-optimize. Cesium locates its
-      // Workers/Assets via the CESIUM_BASE_URL global (never
-      // `import.meta.url`), so pre-bundling does not mangle any asset
-      // reference.
+      // first open and do a full-page reload to re-optimize.
+      //
+      // Pre-bundling is safe for the asset resolution because *this app* always
+      // defines the `CESIUM_BASE_URL` global before importing the engine
+      // (`prepareCesiumEnvironment()` in CesiumCanvas). The engine only derives
+      // a base from `import.meta.url` when that global is undefined
+      // (`buildModuleUrl.js`), and esbuild rewriting the module URL is exactly
+      // what would break that fallback — so dropping the global would make this
+      // entry unsafe, not just the paths wrong.
       //
       // This must name the same specifier the globe imports. It used to be the
       // `cesium` wrapper; that package is still a dependency for its prebuilt

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -277,8 +277,11 @@ After a bump, check all four — none of these fail the build:
 - **Asset copy.** `vite-plugins/copy-cesium-assets.ts` copies `Assets`,
   `ThirdParty`, `Widgets` and `Workers` out of `cesium/Build/Cesium` into
   `public/cesium/`, keyed on the installed version. The copy is gitignored, so a
-  stale one is refreshed automatically — but a directory renamed upstream is
-  silently dropped.
+  stale one is refreshed automatically. A directory *renamed or removed*
+  upstream fails loudly — `cpSync` throws `ENOENT` from `buildStart`, so the dev
+  server and the build both stop. The silent case is the opposite one: a runtime
+  directory *added* upstream is simply not in `RUNTIME_DIRS`, so it is never
+  copied and only surfaces as a 404 when the globe reaches for it.
 - **`CESIUM_BASE_URL`.** `CesiumCanvas.tsx` derives it from the app's
   `BASE_URL`, not a hardcoded `/cesium`, so a sub-path deploy (the `/demo/`
   build) still resolves. Cesium reads it at import time; if the Workers 404 the

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -259,6 +259,43 @@ both behaviors against the sources above; the failure modes are a leaked token a
 a sidecar that is unreachable only for proxied users, neither of which shows up in
 CI or on an unproxied dev machine.
 
+### `cesium` / `@cesium/engine` — runtime assets fetched by URL
+
+The 3D globe pane loads its code from **`@cesium/engine`** but its runtime
+assets from the **`cesium`** wrapper. Both are dependencies and both must move
+together: `cesium@1.x` pins the matching `@cesium/engine`, and the prebuilt
+Workers/Assets staged from the wrapper have to match the engine running them.
+
+The code imports the engine directly because the `cesium` barrel re-exports
+`@cesium/widgets` as well, and that defeats tree-shaking — the base-layer
+picker, geocoder, info box and Knockout all shipped in the lazy chunk even
+though the pane builds a bare `CesiumWidget`. Reverting to `import("cesium")`
+adds ~340 KB back with no build error and no test failure.
+
+After a bump, check all four — none of these fail the build:
+
+- **Asset copy.** `vite-plugins/copy-cesium-assets.ts` copies `Assets`,
+  `ThirdParty`, `Widgets` and `Workers` out of `cesium/Build/Cesium` into
+  `public/cesium/`, keyed on the installed version. The copy is gitignored, so a
+  stale one is refreshed automatically — but a directory renamed upstream is
+  silently dropped.
+- **`CESIUM_BASE_URL`.** `CesiumCanvas.tsx` derives it from the app's
+  `BASE_URL`, not a hardcoded `/cesium`, so a sub-path deploy (the `/demo/`
+  build) still resolves. Cesium reads it at import time; if the Workers 404 the
+  render loop dies with no error boundary.
+- **The stylesheet.** The pane links `Widgets/CesiumWidget/CesiumWidget.css`,
+  not the 32 KB `Widgets/widgets.css` — it only needs the canvas sizing, credit
+  container and error panel. If upstream moves that file the globe still mounts
+  but its canvas stops filling the pane, which no assertion catches.
+- **PWA globs.** `**/cesium-*` / `**/Cesium-*` in `vite.config.ts` keep the
+  chunk out of the app-shell precache and CacheFirst-cache it instead. A chunk
+  renamed out of that pattern would be precached, adding megabytes to first load.
+
+`e2e/cesium-globe.spec.ts` mounts the real engine keyless and drags the globe,
+so it catches a broken `CESIUM_BASE_URL` or a dead chunk. It cannot catch the
+CSS regression or the bundle-size one — check those by eye and in the build
+output.
+
 ## Adding a blend mode
 
 **Do not add a blend mode without checking it in the browser.** MapLibre's blend

--- a/e2e/cesium-globe.spec.ts
+++ b/e2e/cesium-globe.spec.ts
@@ -11,11 +11,13 @@ import { waitForMap } from "./helpers";
  * production build, or that the camera actually moves. Two behavioural changes
  * shipped on the globe (#2205, #2207) verified only by hand in a browser.
  *
- * This runs **keyless on purpose**. Until #2205 the pane was hidden without a
- * Cesium Ion token, so it could not mount in CI without a secret; the toggle is
- * now always offered and the globe draws the project basemap. That makes the
- * test itself the guard on that behaviour: if the token gating ever comes back,
- * this fails at `globeToggle` rather than silently skipping.
+ * This runs **keyless on purpose**, and deterministically so: the web server in
+ * `playwright.config.ts` blanks `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` for the
+ * build, so a developer whose shell holds a token still exercises the same path
+ * CI does. Until #2205 the pane was hidden without a token and could not mount
+ * without a secret; the toggle is now always offered and the globe draws the
+ * project basemap. That makes this the guard on that behaviour: if the token
+ * gating ever comes back, it fails at `globeToggle` rather than skipping.
  *
  * It deliberately asserts nothing about tiles. Imagery comes from third-party
  * hosts, so a CI runner with no egress must still pass — the globe mounts and
@@ -57,10 +59,12 @@ test.describe("Cesium 3D globe pane", () => {
     // empty error region is what distinguishes "mounted" from "threw".
     await expect(globe.getByText(/CESIUM_BASE_URL|Cannot read|undefined|failed/i)).toHaveCount(0);
 
-    // Toggling back and forth must leave a working 2D pane behind — the pane
-    // swaps the whole canvas component, so a torn-down globe that left Cesium
-    // state behind would show up here.
-    await expect(page.getByRole("button", { name: "Show map 2 as a 2D map" })).toBeVisible();
+    // The build is keyless (see the file header), so the pane must be offering
+    // the hint about what an Ion token would add. This is the assertion that
+    // distinguishes the keyless path from the tokened one.
+    await expect(
+      page.getByText("Add a Cesium Ion token in Settings for terrain and Ion imagery"),
+    ).toBeVisible();
 
     // Dragging the globe writes back into the shared `mapView`, which moves the
     // primary MapLibre pane. Reading the status bar proves the whole round trip:
@@ -83,5 +87,15 @@ test.describe("Cesium 3D globe pane", () => {
     await expect
       .poll(async () => bboxReadout(page).textContent(), { timeout: 30_000 })
       .not.toBe(before);
+
+    // Toggle back to 2D. The pane swaps the whole canvas component, so this
+    // runs CesiumCanvas's cleanup — `viewer.destroy()` plus the layer-sync and
+    // basemap teardown — and then mounts a MapLibre pane in its place. A
+    // destroy that threw, or Cesium state left holding the container, shows up
+    // as the 2D canvas never appearing.
+    await page.getByRole("button", { name: "Show map 2 as a 2D map" }).click();
+    await expect(page.getByTestId("secondary-map-canvas")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("cesium-canvas")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Show map 2 as a 3D globe" })).toBeVisible();
   });
 });

--- a/e2e/cesium-globe.spec.ts
+++ b/e2e/cesium-globe.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from "@playwright/test";
+import { waitForMap } from "./helpers";
+
+/**
+ * Smoke test for the CesiumJS 3D globe pane.
+ *
+ * The globe had no e2e coverage at all: a regression in the camera conversion
+ * or the layer/basemap sync only showed up in unit tests driving a *fake*
+ * Cesium, which by construction cannot catch anything about the real engine —
+ * that the chunk loads, that `CESIUM_BASE_URL` resolves its Workers/Assets in a
+ * production build, or that the camera actually moves. Two behavioural changes
+ * shipped on the globe (#2205, #2207) verified only by hand in a browser.
+ *
+ * This runs **keyless on purpose**. Until #2205 the pane was hidden without a
+ * Cesium Ion token, so it could not mount in CI without a secret; the toggle is
+ * now always offered and the globe draws the project basemap. That makes the
+ * test itself the guard on that behaviour: if the token gating ever comes back,
+ * this fails at `globeToggle` rather than silently skipping.
+ *
+ * It deliberately asserts nothing about tiles. Imagery comes from third-party
+ * hosts, so a CI runner with no egress must still pass — the globe mounts and
+ * its camera works whether or not a single tile arrives.
+ */
+
+/** The status bar's bbox readout, which reflects the shared store camera. */
+function bboxReadout(page: Page) {
+  return page.getByText(/^BBox:/);
+}
+
+/** Split the workspace into two panes via View → Split View → Two columns. */
+async function splitIntoTwoPanes(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "View", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Split View" }).click();
+  await page.getByRole("menuitemradio", { name: "Two columns" }).click();
+  await expect(page.getByTestId("map-grid")).toBeVisible();
+}
+
+test.describe("Cesium 3D globe pane", () => {
+  test("mounts keyless and drives the shared camera", async ({ page }) => {
+    await waitForMap(page);
+    await splitIntoTwoPanes(page);
+
+    // The toggle is offered with or without an Ion token (#2180). Its presence
+    // here, in a CI run with no secret configured, is the keyless guarantee.
+    const globeToggle = page.getByRole("button", { name: "Show map 2 as a 3D globe" });
+    await expect(globeToggle).toBeVisible();
+    await globeToggle.click();
+
+    // The engine is a ~4.9 MB lazily imported chunk that then loads its Workers
+    // and Assets from CESIUM_BASE_URL, so allow well past the default timeout
+    // on a cold, software-rendered runner.
+    const globe = page.getByTestId("cesium-canvas");
+    await expect(globe).toBeVisible({ timeout: 60_000 });
+    await expect(globe.locator("canvas")).toBeVisible({ timeout: 60_000 });
+
+    // CesiumCanvas renders the failure message in place of the globe, so an
+    // empty error region is what distinguishes "mounted" from "threw".
+    await expect(globe.getByText(/CESIUM_BASE_URL|Cannot read|undefined|failed/i)).toHaveCount(0);
+
+    // Toggling back and forth must leave a working 2D pane behind — the pane
+    // swaps the whole canvas component, so a torn-down globe that left Cesium
+    // state behind would show up here.
+    await expect(page.getByRole("button", { name: "Show map 2 as a 2D map" })).toBeVisible();
+
+    // Dragging the globe writes back into the shared `mapView`, which moves the
+    // primary MapLibre pane. Reading the status bar proves the whole round trip:
+    // Cesium camera -> readMapViewFromCamera -> store -> the 2D map.
+    const before = await bboxReadout(page).textContent();
+    expect(before).toBeTruthy();
+
+    const box = await globe.locator("canvas").boundingBox();
+    expect(box).not.toBeNull();
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    // Several steps: Cesium's camera controller integrates pointer motion, so a
+    // single jump can be swallowed as a click.
+    await page.mouse.move(cx - 90, cy - 60, { steps: 12 });
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => bboxReadout(page).textContent(), { timeout: 30_000 })
+      .not.toBe(before);
+  });
+});

--- a/e2e/cesium-globe.spec.ts
+++ b/e2e/cesium-globe.spec.ts
@@ -11,13 +11,18 @@ import { waitForMap } from "./helpers";
  * production build, or that the camera actually moves. Two behavioural changes
  * shipped on the globe (#2205, #2207) verified only by hand in a browser.
  *
- * This runs **keyless on purpose**, and deterministically so: the web server in
- * `playwright.config.ts` blanks `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` for the
- * build, so a developer whose shell holds a token still exercises the same path
- * CI does. Until #2205 the pane was hidden without a token and could not mount
- * without a secret; the toggle is now always offered and the globe draws the
- * project basemap. That makes this the guard on that behaviour: if the token
- * gating ever comes back, it fails at `globeToggle` rather than skipping.
+ * This runs **keyless on purpose**. `playwright.config.ts` blanks
+ * `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` for the build and refuses to reuse an
+ * already-running server, so a developer whose shell holds a token still
+ * exercises the path CI does. That does not reach a token in
+ * `apps/geolibre-desktop/.env.local`, which `vite.config.ts` reads off disk —
+ * so rather than assume, the test asserts the tokenless hint and fails with a
+ * message naming that file.
+ *
+ * Until #2205 the pane was hidden without a token and could not mount without a
+ * secret; the toggle is now always offered and the globe draws the project
+ * basemap. That makes this the guard on that behaviour: if the token gating
+ * ever comes back, it fails at `globeToggle` rather than skipping.
  *
  * It deliberately asserts nothing about tiles. Imagery comes from third-party
  * hosts, so a CI runner with no egress must still pass — the globe mounts and
@@ -39,6 +44,12 @@ async function splitIntoTwoPanes(page: Page): Promise<void> {
 
 test.describe("Cesium 3D globe pane", () => {
   test("mounts keyless and drives the shared camera", async ({ page }) => {
+    // The config's 60s per-test cap is a hard ceiling on the whole test, not on
+    // each step, so the generous per-assertion budgets below (a ~4.6 MB engine
+    // chunk plus its Workers on a cold, software-rendered runner) could never
+    // be reached inside it. Raise the test's own budget so they can.
+    test.setTimeout(180_000);
+
     await waitForMap(page);
     await splitIntoTwoPanes(page);
 
@@ -61,9 +72,13 @@ test.describe("Cesium 3D globe pane", () => {
 
     // The build is keyless (see the file header), so the pane must be offering
     // the hint about what an Ion token would add. This is the assertion that
-    // distinguishes the keyless path from the tokened one.
+    // distinguishes the keyless path from the tokened one — and the one that
+    // catches a build the config's env override could not reach.
     await expect(
       page.getByText("Add a Cesium Ion token in Settings for terrain and Ion imagery"),
+      "the globe pane came up with an Ion token, so this run is not testing the keyless path. " +
+        "playwright.config.ts blanks CESIUM_TOKEN/VITE_CESIUM_TOKEN for the build, but a token in " +
+        "apps/geolibre-desktop/.env.local is read straight off disk by vite.config.ts and wins.",
     ).toBeVisible();
 
     // Dragging the globe writes back into the shared `mapView`, which moves the

--- a/e2e/cesium-globe.spec.ts
+++ b/e2e/cesium-globe.spec.ts
@@ -12,12 +12,12 @@ import { waitForMap } from "./helpers";
  * shipped on the globe (#2205, #2207) verified only by hand in a browser.
  *
  * This runs **keyless on purpose**. `playwright.config.ts` blanks
- * `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` for the build and refuses to reuse an
- * already-running server, so a developer whose shell holds a token still
- * exercises the path CI does. That does not reach a token in
- * `apps/geolibre-desktop/.env.local`, which `vite.config.ts` reads off disk —
- * so rather than assume, the test asserts the tokenless hint and fails with a
- * message naming that file.
+ * `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` for the build, which covers a token
+ * exported in the shell. Two cases it cannot cover: a token in
+ * `apps/geolibre-desktop/.env.local`, which `vite.config.ts` reads straight off
+ * disk, and a locally reused server, which Playwright starts without applying
+ * that override at all. So rather than assume the build is keyless, the test
+ * asserts the tokenless hint and fails with a message explaining both.
  *
  * Until #2205 the pane was hidden without a token and could not mount without a
  * secret; the toggle is now always offered and the globe draws the project
@@ -77,8 +77,9 @@ test.describe("Cesium 3D globe pane", () => {
     await expect(
       page.getByText("Add a Cesium Ion token in Settings for terrain and Ion imagery"),
       "the globe pane came up with an Ion token, so this run is not testing the keyless path. " +
-        "playwright.config.ts blanks CESIUM_TOKEN/VITE_CESIUM_TOKEN for the build, but a token in " +
-        "apps/geolibre-desktop/.env.local is read straight off disk by vite.config.ts and wins.",
+        "playwright.config.ts blanks CESIUM_TOKEN/VITE_CESIUM_TOKEN for the build, but that misses " +
+        "a token in apps/geolibre-desktop/.env.local (read off disk by vite.config.ts), and is not " +
+        "applied at all to a locally reused preview server — stop it and re-run to rebuild.",
     ).toBeVisible();
 
     // Dragging the globe writes back into the shared `mapView`, which moves the

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@auth0/auth0-react": "^2.24.1",
         "@carbonplan/zarr-layer": "^0.9.0",
         "@cereusdb/standard": "^0.2.0",
+        "@cesium/engine": "^26.2.0",
         "@clerk/react": "^6.14.8",
         "@deck.gl/aggregation-layers": "9.3.11",
         "@deck.gl/core": "^9.3.11",
@@ -24897,6 +24898,7 @@
       "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
+        "@cesium/engine": "^26.2.0",
         "@geolibre/core": "*",
         "@maplibre/geojson-vt": "^6.1.1",
         "@maplibre/vt-pbf": "^4.3.2",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -64,6 +64,7 @@
     "build": "tsdown src/headless.ts src/derived-geometry.ts src/pmtiles-layer.ts src/style-layer-ids.ts --format esm --dts"
   },
   "dependencies": {
+    "@cesium/engine": "^26.2.0",
     "@geolibre/core": "*",
     "@maplibre/geojson-vt": "^6.1.1",
     "@maplibre/vt-pbf": "^4.3.2",

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -7,7 +7,7 @@ import {
   type GeoLibreLayer,
   type MapViewState,
 } from "@geolibre/core";
-import type { ImageryLayer, Viewer } from "cesium";
+import type { CesiumWidget, ImageryLayer } from "@cesium/engine";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { applyBasemapAppearance, applyBasemapImagery } from "./cesium-basemap";
 import {
@@ -37,6 +37,14 @@ const APP_BASE_URL =
 const CESIUM_BASE_URL = `${APP_BASE_URL}cesium`;
 /** id for the one-time <link> to Cesium's widget stylesheet (served from base). */
 const CESIUM_CSS_LINK_ID = "cesium-widgets-css";
+/**
+ * Just the `CesiumWidget` styles — the canvas sizing, the credit container, and
+ * the render-error panel. The full `Widgets/widgets.css` (32 KB) also carries
+ * the chrome for the base-layer picker, geocoder, timeline, animation dial and
+ * info box, none of which this pane creates. Both are staged by
+ * copy-cesium-assets, so narrowing the link costs nothing.
+ */
+const CESIUM_CSS_PATH = "/Widgets/CesiumWidget/CesiumWidget.css";
 
 export interface CesiumCanvasProps {
   /** Id of the `secondaryMapViews` entry this pane renders (label/telemetry). */
@@ -64,7 +72,7 @@ function prepareCesiumEnvironment(): void {
     const link = document.createElement("link");
     link.id = CESIUM_CSS_LINK_ID;
     link.rel = "stylesheet";
-    link.href = `${CESIUM_BASE_URL}/Widgets/widgets.css`;
+    link.href = `${CESIUM_BASE_URL}${CESIUM_CSS_PATH}`;
     document.head.appendChild(link);
   }
 }
@@ -77,8 +85,8 @@ function prepareCesiumEnvironment(): void {
  */
 export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: CesiumCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const viewerRef = useRef<Viewer | null>(null);
-  const cesiumRef = useRef<typeof import("cesium") | null>(null);
+  const viewerRef = useRef<CesiumWidget | null>(null);
+  const cesiumRef = useRef<typeof import("@cesium/engine") | null>(null);
   const layerSyncRef = useRef<CesiumLayerSync | null>(null);
   // The imagery layers currently drawing the project basemap, at the bottom of
   // the stack. Tracked so a basemap change replaces exactly these and leaves
@@ -221,7 +229,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
 
     void (async () => {
       try {
-        const Cesium = await import("cesium");
+        const Cesium = await import("@cesium/engine");
         // The effect may have been cleaned up (StrictMode double-mount, fast
         // unmount) while the chunk loaded; bail before creating a viewer whose
         // container is gone.
@@ -230,22 +238,16 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         const token = ionTokenRef.current?.trim();
         if (token) Cesium.Ion.defaultAccessToken = token;
 
-        const viewer = new Cesium.Viewer(container, {
-          // A focused globe: no base-layer picker, geocoder, timeline, or
-          // animation widget — this pane is a viewport, not a full Cesium app.
-          baseLayerPicker: false,
-          geocoder: false,
-          homeButton: false,
-          sceneModePicker: false,
-          navigationHelpButton: false,
-          timeline: false,
-          animation: false,
-          fullscreenButton: false,
-          // No default click popup / selection outline: clicking a GeoJSON
-          // feature must not pop Cesium's unstyled InfoBox (it isn't wired to
-          // GeoLibre's identify UI and would overflow a small grid pane).
-          infoBox: false,
-          selectionIndicator: false,
+        // CesiumWidget, not Viewer: this pane is a viewport, not a full Cesium
+        // app. `Viewer` is a wrapper that builds the base-layer picker,
+        // geocoder, home button, scene-mode picker, help button, timeline,
+        // animation dial, fullscreen button, info box and selection indicator —
+        // all of which this pane then had to switch off one by one — on top of
+        // the widget. Constructing the widget directly skips building them, and
+        // it already exposes everything the pane uses: `scene`, `camera`,
+        // `canvas`, `imageryLayers`, `dataSources`, `terrainProvider` and
+        // `screenSpaceEventHandler`.
+        const viewer = new Cesium.CesiumWidget(container, {
           // No base imagery from Cesium: the project basemap supplies it, drawn
           // by applyBasemap() below and re-drawn whenever the basemap changes.
           // Letting Cesium add its own default here would both ignore the user's
@@ -261,14 +263,13 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         viewerRef.current = viewer;
         layerSyncRef.current = new CesiumLayerSync(Cesium, viewer);
 
-        // Drop Cesium's default double-click "track entity" gesture: it flies to
-        // and camera-locks a picked feature, which fights the store-driven camera
-        // sync and isn't wired to GeoLibre. Removing it also means every camera
-        // move now comes through the pointer/wheel/touch input the moveEnd
-        // handler watches, so a real move is never mistaken for an autonomous one.
-        viewer.screenSpaceEventHandler.removeInputAction(
-          Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK,
-        );
+        // Note for anyone reintroducing `Viewer`: it installs a double-click
+        // "track entity" gesture that flies to and camera-locks a picked
+        // feature, which fights the store-driven camera sync and isn't wired to
+        // GeoLibre — the pane used to remove that input action explicitly.
+        // CesiumWidget never installs it, so every camera move now reaches the
+        // moveEnd handler through the pointer/wheel/touch input flagged below,
+        // and a real move can't be mistaken for an autonomous one.
 
         // Flag genuine camera-moving input on the globe so the moveEnd handler
         // can tell a real move from an autonomous settle. Only motion events

--- a/packages/map/src/cesium-basemap.ts
+++ b/packages/map/src/cesium-basemap.ts
@@ -1,5 +1,5 @@
 import type { CesiumBasemapImagery } from "@geolibre/core";
-import type { ImageryLayer, ImageryProvider, Viewer } from "cesium";
+import type { CesiumWidget, ImageryLayer, ImageryProvider } from "@cesium/engine";
 
 // Draws the project basemap on the Cesium globe. `@geolibre/core`'s
 // `basemapToCesiumImagery` decides *what* to show (it reads the basemap
@@ -8,11 +8,11 @@ import type { ImageryLayer, ImageryProvider, Viewer } from "cesium";
 // the React/viewer lifecycle and makes the stacking rules testable against a
 // fake Cesium, the way cesium-layer-sync is.
 //
-// The engine is injected (the `Cesium` namespace + a `Viewer`) so this module
+// The engine is injected (the `Cesium` namespace + a `CesiumWidget`) so this module
 // carries only type-only Cesium imports and never pulls the engine into the
 // build graph itself.
 
-type CesiumNs = typeof import("cesium");
+type CesiumNs = typeof import("@cesium/engine");
 
 /** Keyless imagery for a basemap with no raster form when no Ion token is set. */
 const KEYLESS_FALLBACK_URL = "https://tile.openstreetmap.org/";
@@ -81,7 +81,7 @@ export function applyBasemapAppearance(
  */
 export function applyBasemapImagery(
   Cesium: CesiumNs,
-  viewer: Viewer,
+  viewer: CesiumWidget,
   previous: readonly ImageryLayer[],
   imagery: CesiumBasemapImagery,
   ionToken: string | undefined,

--- a/packages/map/src/cesium-camera.ts
+++ b/packages/map/src/cesium-camera.ts
@@ -1,5 +1,5 @@
 import type { MapViewState } from "@geolibre/core";
-import type { Viewer } from "cesium";
+import type { CesiumWidget } from "@cesium/engine";
 
 // Camera conversion between MapLibre's `MapViewState` (Web-Mercator zoom + a
 // nadir-referenced pitch) and Cesium's camera (a metric range + a
@@ -71,13 +71,13 @@ export function normalizeBearing(deg: number): number {
 }
 
 /** The vertical field of view of a viewer's camera, with a safe fallback. */
-function cameraFovy(viewer: Viewer): number {
+function cameraFovy(viewer: CesiumWidget): number {
   const frustum = viewer.camera.frustum as { fovy?: number };
   return frustum.fovy && frustum.fovy > 0 ? frustum.fovy : DEFAULT_FOVY;
 }
 
 /** The viewer canvas height in CSS pixels, guarding against a 0 during layout. */
-function canvasHeight(viewer: Viewer): number {
+function canvasHeight(viewer: CesiumWidget): number {
   const canvas = viewer.scene.canvas;
   return canvas.clientHeight || canvas.height || 1;
 }
@@ -99,8 +99,8 @@ function canvasHeight(viewer: Viewer): number {
  * area arrive, which is why {@link CesiumCanvas} re-applies once terrain settles.
  */
 export function groundHeightAt(
-  Cesium: typeof import("cesium"),
-  viewer: Viewer,
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
   lngDeg: number,
   latDeg: number,
 ): number {
@@ -117,8 +117,8 @@ export function groundHeightAt(
  * readback side so a view survives the apply → read round trip unchanged.
  */
 function pickGlobe(
-  Cesium: typeof import("cesium"),
-  viewer: Viewer,
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
   position: { x: number; y: number },
 ) {
   const { scene, camera } = viewer;
@@ -137,8 +137,8 @@ function pickGlobe(
  * module stays free of a runtime Cesium import.
  */
 export function applyMapViewToCamera(
-  Cesium: typeof import("cesium"),
-  viewer: Viewer,
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
   view: MapViewState,
 ): void {
   const [lng, lat] = view.center;
@@ -162,8 +162,8 @@ export function applyMapViewToCamera(
  * it falls back to the camera's sub-point.
  */
 export function readMapViewFromCamera(
-  Cesium: typeof import("cesium"),
-  viewer: Viewer,
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
 ): MapViewState {
   const { scene, camera } = viewer;
   const canvas = scene.canvas;

--- a/packages/map/src/cesium-layer-sync.ts
+++ b/packages/map/src/cesium-layer-sync.ts
@@ -1,5 +1,5 @@
 import { resolveThreeDTilesRequestHeaders, type GeoLibreLayer } from "@geolibre/core";
-import type { Cesium3DTileset, DataSource, ImageryLayer, Viewer } from "cesium";
+import type { Cesium3DTileset, CesiumWidget, DataSource, ImageryLayer } from "@cesium/engine";
 
 // Reconciles the store's `GeoLibreLayer[]` onto a Cesium globe, mirroring what
 // MapController.syncLayers does for MapLibre. M3 covers the layer kinds where
@@ -8,11 +8,11 @@ import type { Cesium3DTileset, DataSource, ImageryLayer, Viewer } from "cesium";
 // Cesium3DTileset). Other kinds are skipped on the globe (they still render in
 // the 2D panes); the exported `isCesiumSupportedLayerType` lets the UI flag them.
 //
-// The engine is injected (the `Cesium` namespace + a `Viewer`) so this module
+// The engine is injected (the `Cesium` namespace + a `CesiumWidget`) so this module
 // carries only type-only Cesium imports and never pulls the engine into the
 // build graph itself.
 
-type CesiumNs = typeof import("cesium");
+type CesiumNs = typeof import("@cesium/engine");
 
 /** Layer kinds this pass renders on the globe. */
 const IMAGERY_TYPES = new Set(["raster", "xyz", "wms", "wmts"]);
@@ -124,7 +124,7 @@ export class CesiumLayerSync {
 
   constructor(
     private readonly Cesium: CesiumNs,
-    private readonly viewer: Viewer,
+    private readonly viewer: CesiumWidget,
   ) {}
 
   /** Reconcile the globe to `layers` (order preserved for imagery stacking). */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,6 +56,14 @@ export default defineConfig({
   ],
   webServer: {
     command: `npm run build && npm run preview -w geolibre-desktop -- --port ${PORT} --strictPort`,
+    // Build without a Cesium Ion token, whatever the developer's shell holds.
+    // `vite.config.ts` bakes `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` into the bundle,
+    // so a machine with one set would produce a *different* app than CI builds:
+    // the 3D globe would come up with Ion terrain and imagery, and
+    // `cesium-globe.spec.ts` could no longer tell the keyless path from the
+    // tokened one. Blanking both here makes that spec's keyless assertions mean
+    // the same thing everywhere.
+    env: { CESIUM_TOKEN: "", VITE_CESIUM_TOKEN: "" },
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,
     // The build (tsc -b + vite build) runs as part of this command, so allow

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -69,11 +69,14 @@ export default defineConfig({
     // asserts the tokenless hint and fails with a message naming the file.
     env: { CESIUM_TOKEN: "", VITE_CESIUM_TOKEN: "" },
     url: BASE_URL,
-    // Never reuse a server that is already up. Playwright skips the whole
-    // command when it reuses one, so `env` above would not be applied and the
-    // run could silently test a previously built, tokened bundle — or simply a
-    // stale build. Correctness over the rebuild it costs on repeat local runs.
-    reuseExistingServer: false,
+    // Reuse locally (the repo's existing DX trade-off), never in CI. Note the
+    // interaction with `env` above: Playwright skips the whole command when it
+    // reuses a server, so the override is *not* applied to a reused one. That
+    // is why `cesium-globe.spec.ts` asserts the tokenless hint rather than
+    // trusting this — a reused tokened build fails there with an explanation
+    // instead of silently exercising the wrong path. In CI, where determinism
+    // actually matters, this is false and the override always applies.
+    reuseExistingServer: !process.env.CI,
     // The build (tsc -b + vite build) runs as part of this command, so allow
     // generous startup time on cold CI runners.
     timeout: 300_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,16 +56,24 @@ export default defineConfig({
   ],
   webServer: {
     command: `npm run build && npm run preview -w geolibre-desktop -- --port ${PORT} --strictPort`,
-    // Build without a Cesium Ion token, whatever the developer's shell holds.
-    // `vite.config.ts` bakes `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` into the bundle,
-    // so a machine with one set would produce a *different* app than CI builds:
-    // the 3D globe would come up with Ion terrain and imagery, and
-    // `cesium-globe.spec.ts` could no longer tell the keyless path from the
-    // tokened one. Blanking both here makes that spec's keyless assertions mean
-    // the same thing everywhere.
+    // Build without a Cesium Ion token from the shell. `vite.config.ts` bakes
+    // `CESIUM_TOKEN`/`VITE_CESIUM_TOKEN` into the bundle, so a machine with one
+    // exported would produce a *different* app than CI builds: the 3D globe
+    // would come up with Ion terrain and imagery, and `cesium-globe.spec.ts`
+    // could no longer tell the keyless path from the tokened one.
+    //
+    // This covers the shell only. The bridge in `vite.config.ts` falls through
+    // to `loadEnv()` when the prefixed name is falsy, so a token in
+    // `apps/geolibre-desktop/.env.local` is still picked up despite these being
+    // blanked. That case is not silently tolerated — `cesium-globe.spec.ts`
+    // asserts the tokenless hint and fails with a message naming the file.
     env: { CESIUM_TOKEN: "", VITE_CESIUM_TOKEN: "" },
     url: BASE_URL,
-    reuseExistingServer: !process.env.CI,
+    // Never reuse a server that is already up. Playwright skips the whole
+    // command when it reuses one, so `env` above would not be applied and the
+    // run could silently test a previously built, tokened bundle — or simply a
+    // stale build. Correctness over the rebuild it costs on repeat local runs.
+    reuseExistingServer: false,
     // The build (tsc -b + vite build) runs as part of this command, so allow
     // generous startup time on cold CI runners.
     timeout: 300_000,


### PR DESCRIPTION
Closes #2189. Part of #2179.

## What changed

**`CesiumWidget` instead of `Viewer`.** The pane constructed `Cesium.Viewer` and then switched off ten widgets one by one. `Viewer` is a wrapper that *builds* the base-layer picker, geocoder, home button, scene-mode picker, help button, timeline, animation dial, fullscreen button, info box and selection indicator on top of `CesiumWidget`. Constructing the widget directly skips building them, and it already exposes everything the pane uses — `scene`, `camera`, `canvas`, `imageryLayers`, `dataSources`, `terrainProvider`, `screenSpaceEventHandler`.

Two things the issue got wrong, both in our favour:

- It expected this to need a hand-wired `DataSourceCollection` + `DataSourceDisplay` driven from `scene.postUpdate`. Modern `CesiumWidget` owns both, so `CesiumLayerSync` needed nothing but a type change.
- It expected the swap itself to drop `@cesium/widgets`. **It changed the bundle by exactly zero bytes** — see below.

**Importing `@cesium/engine` rather than `cesium` is what actually slims it.** `import("cesium")` pulls the barrel that re-exports `@cesium/widgets`, and that barrel defeats tree-shaking, so Knockout and the widget chrome shipped regardless of which class was constructed:

| | `cesium-*.js` | facade chunk | total |
| --- | --- | --- | --- |
| before | 4,896,009 B | 47,342 B | 4,943,351 B |
| after | 4,593,633 B | none | 4,593,633 B |
| | | | **−349,718 B (~341 KB, 7%)** |

`BaseLayerPicker`, `InfoBox` and `knockout` are now absent from the chunk. The `cesium` package stays a dependency — `copy-cesium-assets` stages the runtime Workers/Assets from its prebuilt `Build/Cesium`, and `cesium@1.144` pins the matching `@cesium/engine@26.2.0`. The linked stylesheet also narrows from the 32 KB `Widgets/widgets.css` to `Widgets/CesiumWidget/CesiumWidget.css`, which is all a bare widget needs.

The pane also drops its explicit `removeInputAction(LEFT_DOUBLE_CLICK)`. That "track entity" gesture is a `Viewer` feature the widget never installs, so the removal was dead code — but the reason it existed (every camera move must reach `moveEnd` through watched pointer input, or an autonomous settle gets mistaken for a user move) is preserved as a comment for anyone tempted to reintroduce `Viewer`.

**A keyless e2e smoke test.** `e2e/cesium-globe.spec.ts` splits the grid, toggles a pane to 3D, asserts the real engine mounts, then drags the globe and asserts the primary MapLibre pane's bbox moved — exercising the whole camera round trip (Cesium camera → `readMapViewFromCamera` → store → the 2D map) against the actual engine rather than the fake the unit tests use.

I wrote it **before** the refactor and confirmed it passed against the old `Viewer` code, so it genuinely guarded the change rather than being written to fit the result. Running keyless is also the standing guard on #2180: if the token gating ever returns, this fails at the toggle instead of silently skipping. It asserts nothing about tiles, so a CI runner with no egress still passes.

**`docs/maintenance.md`** gains a `cesium` / `@cesium/engine` entry: the asset copy, the `CESIUM_BASE_URL` contract, the stylesheet path, and the PWA globs. None of those fail the build when they drift, which is the point of that page.

## Verified

- 7453 unit tests, **all 48 e2e specs**, `npm run lint` and `npm run build` clean.
- The e2e spec passes identically before and after the widget swap and after the engine-only import.
- Checked by eye what the e2e cannot catch: with the narrower stylesheet the canvas still exactly fills its pane (435×648 both), `.cesium-widget` is applied, and the rendered globe is indistinguishable from before.

## Note

The `**/Cesium-*` PWA glob is now dead — the facade chunk it covered is no longer emitted. I kept it so that a revert to the `cesium` wrapper cannot silently push a facade chunk into the app-shell precache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the 3D globe pane for a leaner rendering experience while preserving globe navigation, basemap imagery, and synchronization with the 2D map.
  * Simplified the globe interface by removing unused toolbar controls and related interactions.

* **Tests**
  * Added automated coverage for opening the globe, switching back to 2D, navigating the globe, and synchronizing map coordinates without requiring a Cesium Ion token.

* **Documentation**
  * Added maintenance guidance for managing globe runtime assets and validating globe-related configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->