### PR TITLE
fix: load rasters with large TIFF metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ WORKDIR /app
 # layer is cached. Adding a new package under apps/ or packages/ requires
 # adding its package.json here, or npm ci fails with a missing workspace.
 COPY package.json package-lock.json ./
+COPY patches patches
+COPY scripts/apply-dependency-patches.mjs scripts/apply-dependency-patches.mjs
 COPY apps/geolibre-desktop/package.json apps/geolibre-desktop/package.json
 COPY packages/core/package.json packages/core/package.json
 COPY packages/collab-core/package.json packages/collab-core/package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,15 @@
     "": {
       "name": "geolibre",
       "version": "2.8.0",
+      "hasInstallScript": true,
       "workspaces": [
         "apps/*",
         "packages/*",
         "workers/*"
       ],
+      "dependencies": {
+        "patch-package": "^8.0.1"
+      },
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",
         "@playwright/test": "^1.62.1",
@@ -20,7 +24,6 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "fflate": "^0.8.3",
         "linkedom": "^0.18.13",
-        "patch-package": "^8.0.1",
         "tsx": "^4.23.12",
         "typescript-eslint": "^8.68.0"
       },
@@ -13112,7 +13115,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@yuku-codegen/binding-android-arm64": {
@@ -14272,7 +14274,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -14462,7 +14463,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14960,7 +14960,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -16234,7 +16233,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
@@ -17270,7 +17268,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -17908,7 +17905,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -18299,7 +18295,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -18487,7 +18482,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
       "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -18514,7 +18508,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-pretty-compact": {
@@ -18555,7 +18548,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18650,7 +18642,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
@@ -20349,7 +20340,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -20503,7 +20493,6 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -20751,7 +20740,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
       "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
@@ -20781,7 +20769,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -20796,7 +20783,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -20809,7 +20795,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -20822,7 +20807,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20832,7 +20816,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -22132,7 +22115,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -22956,7 +22938,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
       "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "fflate": "^0.8.3",
         "linkedom": "^0.18.13",
+        "patch-package": "^8.0.1",
         "tsx": "^4.23.12",
         "typescript-eslint": "^8.68.0"
       },
@@ -13107,6 +13108,13 @@
         }
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@yuku-codegen/binding-android-arm64": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-android-arm64/-/binding-android-arm64-0.8.7.tgz",
@@ -14448,6 +14456,22 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/class-variance-authority": {
@@ -16206,6 +16230,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -17870,6 +17904,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -18245,6 +18295,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -18420,10 +18483,37 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -18459,6 +18549,16 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonpointer": {
@@ -18544,6 +18644,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -20389,6 +20499,23 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open-location-code-typescript": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/open-location-code-typescript/-/open-location-code-typescript-1.5.0.tgz",
@@ -20618,6 +20745,97 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -22733,6 +22951,16 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/msix/build-msix.ps1",
     "portable:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/portable/build-portable.ps1"
   },
+  "dependencies": {
+    "patch-package": "^8.0.1"
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",
     "@playwright/test": "^1.62.1",
@@ -78,8 +81,5 @@
     "protobufjs",
     "sharp",
     "workerd"
-  ],
-  "dependencies": {
-    "patch-package": "^8.0.1"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "workers/*"
   ],
   "scripts": {
-    "postinstall": "patch-package",
+    "postinstall": "node scripts/apply-dependency-patches.mjs",
     "dev": "npm run dev -w geolibre-desktop",
     "build": "npm run build -w geolibre-desktop",
     "lite:build": "node scripts/lite-build.mjs",
@@ -46,7 +46,6 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "fflate": "^0.8.3",
     "linkedom": "^0.18.13",
-    "patch-package": "^8.0.1",
     "tsx": "^4.23.12",
     "typescript-eslint": "^8.68.0"
   },
@@ -79,5 +78,8 @@
     "protobufjs",
     "sharp",
     "workerd"
-  ]
+  ],
+  "dependencies": {
+    "patch-package": "^8.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "workers/*"
   ],
   "scripts": {
+    "postinstall": "patch-package",
     "dev": "npm run dev -w geolibre-desktop",
     "build": "npm run build -w geolibre-desktop",
     "lite:build": "node scripts/lite-build.mjs",
@@ -45,6 +46,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "fflate": "^0.8.3",
     "linkedom": "^0.18.13",
+    "patch-package": "^8.0.1",
     "tsx": "^4.23.12",
     "typescript-eslint": "^8.68.0"
   },

--- a/patches/@cogeotiff+core+9.5.0.patch
+++ b/patches/@cogeotiff+core+9.5.0.patch
@@ -2,12 +2,14 @@ diff --git a/node_modules/@cogeotiff/core/build/read/tiff.tag.factory.js b/node_
 index e9bb438..768886b 100644
 --- a/node_modules/@cogeotiff/core/build/read/tiff.tag.factory.js
 +++ b/node_modules/@cogeotiff/core/build/read/tiff.tag.factory.js
-@@ -4,6 +4,15 @@ import { getUint, getUint64 } from '../util/bytes.js';
+@@ -4,6 +4,17 @@ import { getUint, getUint64 } from '../util/bytes.js';
  import { hasBytes } from './data.view.offset.js';
  import { isLittleEndian } from './endian.js';
  import { getTiffTagSize } from './tiff.value.reader.js';
 +const ASCII_DECODE_CHUNK_SIZE = 32768;
 +function readAscii(bytes, offset, length) {
++    // DataView offsets are relative to the view, while Uint8Array offsets are
++    // relative to the underlying buffer. Preserve sliced views correctly.
 +    const input = new Uint8Array(bytes.buffer, bytes.byteOffset + offset, length);
 +    let output = '';
 +    for (let index = 0; index < input.length; index += ASCII_DECODE_CHUNK_SIZE) {
@@ -18,7 +20,7 @@ index e9bb438..768886b 100644
  function readTagValue(fieldType, bytes, offset, isLittleEndian) {
      switch (fieldType) {
          case TiffTagValueType.Ascii:
-@@ -76,7 +85,7 @@ function readValue(tiff, tagId, bytes, offset, type, count) {
+@@ -76,7 +87,7 @@ function readValue(tiff, tagId, bytes, offset, type, count) {
      }
      switch (type) {
          case TiffTagValueType.Ascii:

--- a/patches/@cogeotiff+core+9.5.0.patch
+++ b/patches/@cogeotiff+core+9.5.0.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/@cogeotiff/core/build/read/tiff.tag.factory.js b/node_modules/@cogeotiff/core/build/read/tiff.tag.factory.js
+index e9bb438..768886b 100644
+--- a/node_modules/@cogeotiff/core/build/read/tiff.tag.factory.js
++++ b/node_modules/@cogeotiff/core/build/read/tiff.tag.factory.js
+@@ -4,6 +4,15 @@ import { getUint, getUint64 } from '../util/bytes.js';
+ import { hasBytes } from './data.view.offset.js';
+ import { isLittleEndian } from './endian.js';
+ import { getTiffTagSize } from './tiff.value.reader.js';
++const ASCII_DECODE_CHUNK_SIZE = 32768;
++function readAscii(bytes, offset, length) {
++    const input = new Uint8Array(bytes.buffer, bytes.byteOffset + offset, length);
++    let output = '';
++    for (let index = 0; index < input.length; index += ASCII_DECODE_CHUNK_SIZE) {
++        output += String.fromCharCode.apply(null, input.subarray(index, index + ASCII_DECODE_CHUNK_SIZE));
++    }
++    return output;
++}
+ function readTagValue(fieldType, bytes, offset, isLittleEndian) {
+     switch (fieldType) {
+         case TiffTagValueType.Ascii:
+@@ -76,7 +85,7 @@ function readValue(tiff, tagId, bytes, offset, type, count) {
+     }
+     switch (type) {
+         case TiffTagValueType.Ascii:
+-            return String.fromCharCode.apply(null, new Uint8Array(bytes.buffer, offset, dataLength - 1));
++            return readAscii(bytes, offset, dataLength - 1);
+     }
+     // TODO should we convert all tag values to typed arrays if possible?
+     if (tagId === TiffTag.TileOffsets ||

--- a/scripts/apply-dependency-patches.mjs
+++ b/scripts/apply-dependency-patches.mjs
@@ -1,0 +1,17 @@
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+// Workspace-scoped production installs, such as the collaboration worker
+// image, do not install GeoLibre's raster dependencies. There is nothing to
+// patch in those trees, and asking patch-package to find @cogeotiff/core would
+// make an otherwise valid `npm ci --omit=dev` fail.
+if (!existsSync("node_modules/@cogeotiff/core/package.json")) {
+  process.exit(0);
+}
+
+const result = spawnSync("patch-package", [], {
+  shell: process.platform === "win32",
+  stdio: "inherit",
+});
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/tests/cogeotiff-patch.test.ts
+++ b/tests/cogeotiff-patch.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { GeoTIFF } from "@developmentseed/geotiff";
+import { DOMParser } from "linkedom";
+
+Object.assign(globalThis, { DOMParser });
+
+const LARGE_METADATA_LENGTH = 200_000;
+
+/** Build a minimal one-pixel TIFF carrying a large GDAL_METADATA ASCII tag. */
+function tiffWithLargeMetadata(): ArrayBuffer {
+  const metadata = `<GDALMetadata>${"x".repeat(LARGE_METADATA_LENGTH)}</GDALMetadata>\0`;
+  const entries = 10;
+  const ifdOffset = 8;
+  const metadataOffset = ifdOffset + 2 + entries * 12 + 4;
+  const pixelOffset = metadataOffset + metadata.length;
+  const buffer = new ArrayBuffer(pixelOffset + 1);
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+
+  bytes.set([0x49, 0x49]);
+  view.setUint16(2, 42, true);
+  view.setUint32(4, ifdOffset, true);
+  view.setUint16(ifdOffset, entries, true);
+
+  const entry = (index: number, tag: number, type: number, count: number, value: number) => {
+    const offset = ifdOffset + 2 + index * 12;
+    view.setUint16(offset, tag, true);
+    view.setUint16(offset + 2, type, true);
+    view.setUint32(offset + 4, count, true);
+    view.setUint32(offset + 8, value, true);
+  };
+  entry(0, 256, 4, 1, 1); // ImageWidth
+  entry(1, 257, 4, 1, 1); // ImageLength
+  entry(2, 258, 3, 1, 8); // BitsPerSample
+  entry(3, 259, 3, 1, 1); // Compression
+  entry(4, 262, 3, 1, 1); // PhotometricInterpretation
+  entry(5, 273, 4, 1, pixelOffset); // StripOffsets
+  entry(6, 277, 3, 1, 1); // SamplesPerPixel
+  entry(7, 278, 4, 1, 1); // RowsPerStrip
+  entry(8, 279, 4, 1, 1); // StripByteCounts
+  entry(9, 42112, 2, metadata.length, metadataOffset); // GDAL_METADATA
+  bytes.set(new TextEncoder().encode(metadata), metadataOffset);
+  bytes[pixelOffset] = 1;
+  return buffer;
+}
+
+describe("@cogeotiff/core dependency patch", () => {
+  it("decodes TIFF ASCII metadata larger than the JavaScript argument limit", async () => {
+    const tiff = await GeoTIFF.fromArrayBuffer(tiffWithLargeMetadata());
+    assert.equal(tiff.cachedTags.gdalMetadata?.length, LARGE_METADATA_LENGTH + 29);
+  });
+});

--- a/tests/cogeotiff-patch.test.ts
+++ b/tests/cogeotiff-patch.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { createTag } from "@cogeotiff/core/build/read/tiff.tag.factory.js";
 import { GeoTIFF } from "@developmentseed/geotiff";
 import { DOMParser } from "linkedom";
 
@@ -7,9 +8,13 @@ Object.assign(globalThis, { DOMParser });
 
 const LARGE_METADATA_LENGTH = 200_000;
 
+function largeMetadata(): string {
+  return `<GDALMetadata>${"x".repeat(LARGE_METADATA_LENGTH)}</GDALMetadata>`;
+}
+
 /** Build a minimal one-pixel TIFF carrying a large GDAL_METADATA ASCII tag. */
 function tiffWithLargeMetadata(): ArrayBuffer {
-  const metadata = `<GDALMetadata>${"x".repeat(LARGE_METADATA_LENGTH)}</GDALMetadata>\0`;
+  const metadata = `${largeMetadata()}\0`;
   const entries = 10;
   const ifdOffset = 8;
   const metadataOffset = ifdOffset + 2 + entries * 12 + 4;
@@ -48,6 +53,24 @@ function tiffWithLargeMetadata(): ArrayBuffer {
 describe("@cogeotiff/core dependency patch", () => {
   it("decodes TIFF ASCII metadata larger than the JavaScript argument limit", async () => {
     const tiff = await GeoTIFF.fromArrayBuffer(tiffWithLargeMetadata());
-    assert.equal(tiff.cachedTags.gdalMetadata?.length, LARGE_METADATA_LENGTH + 29);
+    assert.equal(tiff.cachedTags.gdalMetadata, largeMetadata());
+  });
+
+  it("reads ASCII tags relative to a DataView with a non-zero byte offset", () => {
+    const buffer = new ArrayBuffer(32);
+    const view = new DataView(buffer, 16, 12);
+    view.setUint16(0, 270, true); // ImageDescription
+    view.setUint16(2, 2, true); // ASCII
+    view.setUint32(4, 4, true);
+    new Uint8Array(buffer, view.byteOffset + 8, 4).set([0x61, 0x62, 0x63, 0]);
+
+    const tiff = {
+      ifdConfig: { pointer: 4 },
+      isLittleEndian: true,
+    } as unknown as Parameters<typeof createTag>[0];
+    const tag = createTag(tiff, view, 0);
+
+    assert.equal(tag.type, "inline");
+    assert.equal(tag.value, "abc");
   });
 });

--- a/workers/collab-node/Dockerfile
+++ b/workers/collab-node/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:22-bookworm-slim AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
+COPY patches patches
+COPY scripts/apply-dependency-patches.mjs scripts/apply-dependency-patches.mjs
 COPY packages/collab-core/package.json packages/collab-core/package.json
 COPY workers/collab-node/package.json workers/collab-node/package.json
 RUN npm ci --workspace geolibre-collab-node --workspace @geolibre/collab-core


### PR DESCRIPTION
## Summary
- decode large ASCII TIFF metadata tags in bounded chunks
- preserve the dependency fix across clean installs with `patch-package`
- prevent valid large remote rasters from failing with `Maximum call stack size exceeded`

## Test plan
- [x] Run `npm ci` and confirm the dependency patch applies
- [x] Run `npm run build`
- [x] Load `https://data.source.coop/giswqs/opengeos/labdata/landsat_july.tif` in the real web app
- [x] Confirm the raster renders, fits to its extent, and produces no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large TIFF ASCII metadata values to prevent failures when reading lengthy content.
  * Corrected byte-offset handling for TIFF ASCII data, improving accuracy when reading values from buffered data.

* **Maintenance**
  * Added automatic application of the dependency compatibility patch during installation.
  * Updated application builds to apply the patch consistently across supported deployment environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->