### PR TITLE
fix(assistant): keep conversation history across turns

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -290,15 +290,21 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   useEffect(() => () => resizeCleanupRef.current?.(), []);
 
   // Track which provider keys are configured; rebuild the agent on change so a
-  // newly-added key takes effect without reopening the panel.
+  // newly-added key takes effect without reopening the panel. Credentials are
+  // read when the agent is built, so the reset has to be explicit here — the
+  // profile effect below deliberately does nothing when the profile itself is
+  // unchanged. Skipped mid-run: reset() cancels the in-flight agent, and that
+  // cancellation is not user-initiated, so send()'s catch would surface it as
+  // an error turn and drop the reply.
   useEffect(() => {
     const onEnvChange = () => {
       setHasKey(hasProviderKey());
       setProviders(availableProviders());
+      if (!runningRef.current) session.reset();
     };
     window.addEventListener(RUNTIME_ENV_EVENT, onEnvChange);
     return () => window.removeEventListener(RUNTIME_ENV_EVENT, onEnvChange);
-  }, []);
+  }, [session]);
 
   // When the default profile changes (user set a new default in Settings),
   // reset the "user explicitly chose" flag so the new default takes effect.
@@ -317,12 +323,15 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   // Push the active profile into the session. When no profile is available,
   // fall back to auto-resolution (which reads from the runtime env directly).
   //
-  // Deferred while a response is streaming: setSelection resets the session,
-  // which cancels the in-flight agent. That cancellation is not user-initiated,
-  // so send()'s catch would surface it as an error turn and drop the reply. The
-  // panel dropdown is disabled while running, but Settings can still change the
-  // default profile, so guard here. `running` is a dependency, so the latest
-  // activeProfile is applied as soon as the run finishes.
+  // Deferred while a response is streaming: applying a *changed* profile resets
+  // the session, which cancels the in-flight agent. That cancellation is not
+  // user-initiated, so send()'s catch would surface it as an error turn and drop
+  // the reply. The panel dropdown is disabled while running, but Settings can
+  // still change the default profile, so guard here. `running` is a dependency,
+  // so the latest activeProfile is applied as soon as the run finishes — and it
+  // flips back to false after every turn, which re-runs this effect on turns
+  // where nothing changed. setSelection compares the selection by value and
+  // no-ops on those, which is what keeps the conversation history alive.
   useEffect(() => {
     if (running) return;
     session.setSelection(activeProfile ?? null);

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -148,6 +148,9 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   const promptDraftRef = useRef("");
   // Guards a synchronous double-submit before `running` re-renders.
   const runningRef = useRef(false);
+  // A runtime credential change that arrived mid-run, deferred because reset()
+  // would cancel the in-flight agent. Flushed when the run finishes.
+  const envResetPendingRef = useRef(false);
   // Generation that was stopped (0 = none), so a stopped run's rejection isn't
   // shown as an error even after a newer send has started.
   const cancelledGenerationRef = useRef(0);
@@ -293,18 +296,35 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   // newly-added key takes effect without reopening the panel. Credentials are
   // read when the agent is built, so the reset has to be explicit here — the
   // profile effect below deliberately does nothing when the profile itself is
-  // unchanged. Skipped mid-run: reset() cancels the in-flight agent, and that
-  // cancellation is not user-initiated, so send()'s catch would surface it as
-  // an error turn and drop the reply.
+  // unchanged, and would leave the agent on the superseded key.
+  //
+  // Deferred rather than dropped while a response is streaming: reset() cancels
+  // the in-flight agent, and that cancellation is not user-initiated, so send()'s
+  // catch would surface it as an error turn and drop the reply. The effect below
+  // flushes the deferred reset once the run finishes.
   useEffect(() => {
     const onEnvChange = () => {
       setHasKey(hasProviderKey());
       setProviders(availableProviders());
-      if (!runningRef.current) session.reset();
+      if (runningRef.current) {
+        envResetPendingRef.current = true;
+        return;
+      }
+      session.reset();
     };
     window.addEventListener(RUNTIME_ENV_EVENT, onEnvChange);
     return () => window.removeEventListener(RUNTIME_ENV_EVENT, onEnvChange);
   }, [session]);
+
+  // Flush a credential change that arrived mid-run, now that the run is over.
+  // Nothing else would: the profile effect below no-ops when the profile itself
+  // is unchanged, so without this the agent would keep serving the superseded
+  // key until some later env change or profile switch happened to reset it.
+  useEffect(() => {
+    if (running || !envResetPendingRef.current) return;
+    envResetPendingRef.current = false;
+    session.reset();
+  }, [running, session]);
 
   // When the default profile changes (user set a new default in Settings),
   // reset the "user explicitly chose" flag so the new default takes effect.

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -1,12 +1,11 @@
 import { useAppStore } from "@geolibre/core";
 import { Agent } from "@strands-agents/sdk";
+import { configForProvider, createModel, resolveProviderConfig } from "./provider";
 import {
-  configForProvider,
-  createModel,
-  resolveProviderConfig,
-  type AssistantProviderId,
-} from "./provider";
-import { assistantSelectionKey, configForProfile } from "./profiles";
+  assistantSelectionKey,
+  configForProfile,
+  type AssistantProviderSelection,
+} from "./profiles";
 import type { AssistantProfile } from "./provider";
 import { createAssistantTools, describeLayers, type AssistantToolDeps } from "./tools";
 
@@ -43,7 +42,7 @@ export type AssistantStreamEvent =
 export class AssistantSession {
   private agent: Agent | null = null;
   /** Explicit provider/model chosen in the UI; null means auto-resolve. */
-  private selection: { provider: AssistantProviderId; model?: string } | null = null;
+  private selection: AssistantProviderSelection | null = null;
   /**
    * When set, the user chose a named profile from Settings → AI Providers.
    * The profile's own credential fieldValues are used directly rather than
@@ -79,9 +78,7 @@ export class AssistantSession {
    * calls. Equivalence is by value, not object identity, so a profile object
    * rebuilt with the same provider, model, and credentials still matches.
    */
-  setSelection(
-    selection: { provider: AssistantProviderId; model?: string } | AssistantProfile | null,
-  ): void {
+  setSelection(selection: AssistantProviderSelection | AssistantProfile | null): void {
     const key = assistantSelectionKey(selection);
     if (key === this.selectionKey) return;
     this.selectionKey = key;
@@ -92,7 +89,7 @@ export class AssistantSession {
       this.selection = null;
     } else {
       // Legacy provider+model pair, or null for auto-resolve.
-      this.selection = selection as { provider: AssistantProviderId; model?: string } | null;
+      this.selection = selection as AssistantProviderSelection | null;
       this.profile = null;
     }
     this.reset();

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -6,7 +6,7 @@ import {
   resolveProviderConfig,
   type AssistantProviderId,
 } from "./provider";
-import { configForProfile } from "./profiles";
+import { assistantSelectionKey, configForProfile } from "./profiles";
 import type { AssistantProfile } from "./provider";
 import { createAssistantTools, describeLayers, type AssistantToolDeps } from "./tools";
 
@@ -53,6 +53,12 @@ export class AssistantSession {
   private profile: AssistantProfile | null = null;
   /** Last layer context sent, so it is only re-sent when it actually changes. */
   private lastContext: string | null = null;
+  /**
+   * Value identity of the currently applied selection, so re-applying an
+   * equivalent one is a no-op. Starts as the key for `null` (auto-resolve),
+   * matching the initial `selection`/`profile` state above.
+   */
+  private selectionKey: string = assistantSelectionKey(null);
 
   constructor(private readonly deps: AssistantToolDeps) {}
 
@@ -65,11 +71,21 @@ export class AssistantSession {
    * Pin the provider/model (from the legacy UI picker) or pass a full
    * {@link AssistantProfile} for profile-based credential resolution.
    * Pass null to auto-resolve from the configured keys. Rebuilds the agent
-   * on the next prompt.
+   * on the next prompt, but only when the selection actually changed.
+   *
+   * Re-applying an equivalent selection must stay a no-op: callers re-run this
+   * whenever their inputs are recomputed, and resetting there would discard the
+   * conversation history this session exists to keep across {@link stream}
+   * calls. Equivalence is by value, not object identity, so a profile object
+   * rebuilt with the same provider, model, and credentials still matches.
    */
   setSelection(
     selection: { provider: AssistantProviderId; model?: string } | AssistantProfile | null,
   ): void {
+    const key = assistantSelectionKey(selection);
+    if (key === this.selectionKey) return;
+    this.selectionKey = key;
+
     if (selection && "fieldValues" in selection) {
       // Profile-based: store the full profile, clear the legacy selection.
       this.profile = selection;

--- a/apps/geolibre-desktop/src/lib/assistant/profiles.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/profiles.ts
@@ -6,6 +6,7 @@ import {
   PROVIDER_LABELS,
   readRuntimeEnv,
   type AssistantProviderConfig,
+  type AssistantProviderId,
   type RuntimeEnv,
 } from "./provider";
 import { PROVIDER_FIELDS } from "./provider-fields";
@@ -102,6 +103,44 @@ export function migrateLegacyAiEnv(
   }
 
   return result;
+}
+
+/** An explicit provider/model pin from the legacy UI picker. */
+export type AssistantProviderSelection = { provider: AssistantProviderId; model?: string };
+
+/** Field separator for selection keys; never appears in a provider id or a credential. */
+const KEY_SEPARATOR = "\u0000";
+
+/**
+ * Build a stable, value-based identity for an assistant selection. Two
+ * selections sharing a key resolve to the same provider, model, and
+ * credentials, so a session already built from one can keep serving the other
+ * — conversation history included.
+ *
+ * Only the fields that feed {@link configForProfile} and `configForProvider`
+ * are included. A profile's `name` is deliberately left out: renaming a profile
+ * in Settings does not change how its agent is built, so it must not count as a
+ * different selection.
+ *
+ * @param selection A saved profile, a legacy provider/model pin, or null for
+ *   auto-resolution from the runtime env.
+ * @returns An opaque string to compare with `===`.
+ */
+export function assistantSelectionKey(
+  selection: AssistantProviderSelection | AssistantProfile | null,
+): string {
+  if (!selection) return "auto";
+  if ("fieldValues" in selection) {
+    // Sort the credential keys so an equivalent profile that happens to have
+    // been built in a different insertion order still compares equal.
+    const fields = Object.keys(selection.fieldValues)
+      .sort()
+      .map((key) => `${key}=${selection.fieldValues[key]}`);
+    return ["profile", selection.id, selection.provider, selection.modelId, ...fields].join(
+      KEY_SEPARATOR,
+    );
+  }
+  return ["provider", selection.provider, selection.model ?? ""].join(KEY_SEPARATOR);
 }
 
 /** Return the config for a profile, merging its field values into the runtime env. */

--- a/tests/assistant-selection-identity.test.ts
+++ b/tests/assistant-selection-identity.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { assistantSelectionKey } from "../apps/geolibre-desktop/src/lib/assistant/profiles";
+import type { AssistantProfile } from "../apps/geolibre-desktop/src/lib/assistant/provider";
+
+function profile(overrides: Partial<AssistantProfile> = {}): AssistantProfile {
+  return {
+    id: "prof_1",
+    name: "Work Gemini",
+    provider: "google",
+    modelId: "gemini-3.5-flash",
+    fieldValues: { GEMINI_API_KEY: "AIza-abc" },
+    ...overrides,
+  };
+}
+
+// AssistantSession keeps one Strands agent (and its whole message history)
+// alive across stream calls, and rebuilds it whenever setSelection receives a
+// *different* selection. AssistantPanel re-runs that call after every turn —
+// `running` is one of its effect's dependencies and flips back to false when a
+// reply finishes — so "different" has to be decided by value. Comparing object
+// identity instead reset the agent on every turn and wiped the conversation.
+describe("assistantSelectionKey", () => {
+  it("treats auto-resolution as a single stable selection", () => {
+    assert.equal(assistantSelectionKey(null), assistantSelectionKey(null));
+  });
+
+  it("matches an equal profile rebuilt as a new object", () => {
+    // The regression: the panel re-derives activeProfile from the settings
+    // store, so a turn ending can hand the session a fresh object holding the
+    // same configuration. That must not count as a change.
+    assert.equal(assistantSelectionKey(profile()), assistantSelectionKey(profile()));
+  });
+
+  it("ignores the credential insertion order", () => {
+    const a = profile({ fieldValues: { OLLAMA_BASE_URL: "http://x", OLLAMA_MODEL: "llama3.2" } });
+    const b = profile({ fieldValues: { OLLAMA_MODEL: "llama3.2", OLLAMA_BASE_URL: "http://x" } });
+    assert.equal(assistantSelectionKey(a), assistantSelectionKey(b));
+  });
+
+  it("ignores a profile rename, which does not change how the agent is built", () => {
+    assert.equal(
+      assistantSelectionKey(profile()),
+      assistantSelectionKey(profile({ name: "Renamed" })),
+    );
+  });
+
+  it("changes when the model changes", () => {
+    assert.notEqual(
+      assistantSelectionKey(profile()),
+      assistantSelectionKey(profile({ modelId: "gemini-3.5-pro" })),
+    );
+  });
+
+  it("changes when a credential value changes", () => {
+    assert.notEqual(
+      assistantSelectionKey(profile()),
+      assistantSelectionKey(profile({ fieldValues: { GEMINI_API_KEY: "AIza-rotated" } })),
+    );
+  });
+
+  it("changes when a credential field is added or removed", () => {
+    const withExtra = profile({
+      fieldValues: { GEMINI_API_KEY: "AIza-abc", GOOGLE_API_KEY: "AIza-def" },
+    });
+    assert.notEqual(assistantSelectionKey(profile()), assistantSelectionKey(withExtra));
+    assert.notEqual(
+      assistantSelectionKey(profile({ fieldValues: {} })),
+      assistantSelectionKey(profile()),
+    );
+  });
+
+  it("separates two profiles that differ only by id", () => {
+    // Duplicating a profile in Settings yields identical settings under a new
+    // id; switching between them is still a real switch.
+    assert.notEqual(
+      assistantSelectionKey(profile()),
+      assistantSelectionKey(profile({ id: "prof_2" })),
+    );
+  });
+
+  it("separates a pinned profile from auto-resolution", () => {
+    assert.notEqual(assistantSelectionKey(profile()), assistantSelectionKey(null));
+  });
+
+  it("compares legacy provider/model pins by value", () => {
+    assert.equal(
+      assistantSelectionKey({ provider: "anthropic", model: "claude-opus-5" }),
+      assistantSelectionKey({ provider: "anthropic", model: "claude-opus-5" }),
+    );
+    assert.notEqual(
+      assistantSelectionKey({ provider: "anthropic", model: "claude-opus-5" }),
+      assistantSelectionKey({ provider: "anthropic", model: "claude-sonnet-5" }),
+    );
+    assert.notEqual(
+      assistantSelectionKey({ provider: "anthropic" }),
+      assistantSelectionKey({ provider: "openai" }),
+    );
+    assert.notEqual(assistantSelectionKey({ provider: "anthropic" }), assistantSelectionKey(null));
+  });
+
+  it("never confuses a legacy pin with a profile on the same provider", () => {
+    assert.notEqual(
+      assistantSelectionKey({ provider: "google", model: "gemini-3.5-flash" }),
+      assistantSelectionKey(profile()),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2210. Diagnosis and reproduction credit to @ttntbn, who traced this to the exact effect below.

## The bug

`AssistantSession` is designed to keep one Strands `Agent` — and its whole message history — alive across `stream()` calls, as its own doc comment says. In practice every assistant reply destroyed it, so the next user message started from a blank conversation:

1. Send "My name is Kamin" → the assistant acknowledges it.
2. Send "What is my name?" in the same session → it doesn't know.

`AssistantPanel` pushes the active profile into the session from an effect that lists `running` in its dependency array. `running` flips back to `false` at the end of every turn, so the effect re-ran after *every* reply, and `setSelection()` called `reset()` unconditionally — dropping `this.agent`, and the conversation with it, even though the profile hadn't changed.

Within a single turn the assistant kept context correctly, because a multi-tool sequence all happens inside one `stream()` call before the effect can fire. Only memory *between* messages was lost.

## The fix

Rather than tracking the last-applied profile in the component, the guard goes where the invariant lives: `setSelection()` now no-ops when the selection is equivalent to the one already applied.

A new pure helper, `assistantSelectionKey()` in `lib/assistant/profiles.ts`, builds a value-based identity for a selection. Comparing by value rather than object identity matters here — the panel re-derives `activeProfile` from the settings store, so an unchanged profile can still arrive as a freshly built object, which a `useRef` reference check would miss.

The key covers only what actually feeds the agent's provider config:

- **id, provider, model, credential values** — a rotated key or a model switch still rebuilds the agent, as it must.
- **not `name`** — renaming a profile in Settings doesn't change how its agent is built, so it no longer wipes the conversation.
- credential keys are sorted, so insertion order doesn't produce a spurious mismatch.

## One behavior that had to be made explicit

The reset-on-every-turn also *incidentally* picked up credentials edited in Settings → Environment Variables. The `RUNTIME_ENV_EVENT` listener's comment already claims to do this ("rebuild the agent on change so a newly-added key takes effect without reopening the panel") but it only called `setHasKey`/`setProviders` — it never reset anything. Any correct fix for this issue removes that accident, so the listener now performs the reset itself.

It's skipped mid-run for exactly the reason the profile effect defers: `reset()` cancels the in-flight agent, and that cancellation isn't user-initiated, so `send()`'s `catch` would surface it as an error turn and drop the reply.

`session.reset()` from the "clear conversation" button is untouched and still unconditional.

## Tests

`tests/assistant-selection-identity.test.ts` adds 11 cases over the new helper, including the regression itself (an equal profile rebuilt as a new object must compare equal), the rename case, and the changed-model / rotated-credential / added-field / duplicated-profile cases that must still rebuild.

`agent.ts` can't be imported under `node --test` — it reaches `lib/pyodide`, which pulls a `.py` file through a Vite `?raw` import — which is why the logic lives in a pure, testable helper rather than inline in the class.

## Verification

- `npm run test:frontend` — the 11 new tests pass. The suite has 5 pre-existing failures on `main` (AppImage/Linux metainfo shell tests, desktop-settings-url, python-widget-frontend); the count is identical with and without this change.
- `npm run build` — clean.
- `npm run lint` — no new findings (36 pre-existing warnings, 0 errors, none in the touched files).
- `oxfmt` run over the four touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Assistant sessions now reset when the configured provider key changes, while avoiding interruptions during active runs.
  - Reapplying an equivalent assistant profile or provider selection no longer unnecessarily resets the session.
  - Selection matching now correctly distinguishes changes to models, credentials, profiles, and automatic resolution settings.

- **Tests**
  - Added coverage for stable assistant selection identity, including profile renames, credential ordering, and value changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->