### PR TITLE
fix(tests): make the local quality gate pass off Linux

### DIFF
--- a/scripts/render-linux-metainfo.sh
+++ b/scripts/render-linux-metainfo.sh
@@ -18,9 +18,14 @@ set -euo pipefail
 
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "VERSION does not look like a semver string" >&2; exit 1; }
 [[ "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "DATE must be YYYY-MM-DD" >&2; exit 1; }
-# Reject syntactically valid but impossible dates (e.g. 2026-13-40). `date -d`
-# is GNU coreutils; these scripts run on Linux/CI (on macOS, use coreutils).
-date -u -d "$DATE" +%F >/dev/null 2>&1 || { echo "DATE is not a valid calendar date" >&2; exit 1; }
+# Reject syntactically valid but impossible dates (e.g. 2026-13-40, 2026-02-31).
+# `date -d` is GNU coreutils and BSD/macOS date spells the same thing `-j -f`,
+# so try GNU first and fall back. BSD date also *normalises* an out-of-range day
+# instead of rejecting it (2026-02-31 comes back as 2026-03-03), so compare the
+# round-trip against the input rather than trusting the exit status — that check
+# is strict on either implementation.
+normalized="$(date -u -d "$DATE" +%F 2>/dev/null || date -u -j -f "%Y-%m-%d" "$DATE" +%F 2>/dev/null || true)"
+[[ "$normalized" == "$DATE" ]] || { echo "DATE is not a valid calendar date" >&2; exit 1; }
 
 cat <<XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/scripts/select-single-appimage.sh
+++ b/scripts/select-single-appimage.sh
@@ -21,7 +21,12 @@ set -euo pipefail
 # there would swallow the rest of the file.
 artifacts="${1:?Pass the artifactPaths JSON array from tauri-action}"
 
-mapfile -t images < <(jq -r '.[] | select(endswith(".AppImage"))' <<<"$artifacts")
+# Read with a loop rather than `mapfile`: that builtin arrived in bash 4, and
+# macOS still ships bash 3.2 as /bin/bash, where it is simply missing.
+images=()
+while IFS= read -r image; do
+  images+=("$image")
+done < <(jq -r '.[] | select(endswith(".AppImage"))' <<<"$artifacts")
 if [[ ${#images[@]} -ne 1 ]]; then
   echo "Expected exactly one .AppImage in artifactPaths, found ${#images[@]}" >&2
   exit 1

--- a/tests/desktop-settings-url.test.ts
+++ b/tests/desktop-settings-url.test.ts
@@ -90,10 +90,21 @@ describe("desktop settings URL", () => {
       });
     }) as typeof fetch;
 
-    await assert.rejects(
-      fetchDesktopSettings("https://example.com/stalled.json", { fetchImpl, timeoutMs: 5 }),
-      (error: Error) => error.name === "TimeoutError",
-    );
+    // AbortSignal.timeout()'s timer is unref'd, so it cannot hold the event loop
+    // open by itself, and the stalled fetch above settles only when that abort
+    // fires. With nothing else pending the loop drains first, the promise never
+    // settles, and the runner reports "Promise resolution is still pending but
+    // the event loop has already resolved" — taking the rest of the suite with
+    // it. A ref'd timer keeps the loop alive until the abort actually lands.
+    const keepAlive = setTimeout(() => {}, 1000);
+    try {
+      await assert.rejects(
+        fetchDesktopSettings("https://example.com/stalled.json", { fetchImpl, timeoutMs: 5 }),
+        (error: Error) => error.name === "TimeoutError",
+      );
+    } finally {
+      clearTimeout(keepAlive);
+    }
     assert.equal(signal?.aborted, true);
   });
 


### PR DESCRIPTION
Refs #2213.

CONTRIBUTING asks contributors to run `npm run ci` before opening a pull request. On macOS that gate fails with 5 errors and cancels 4 more tests, none of which belong to the contributor's change. CI doesn't catch it because it runs Linux with GNU coreutils, bash 5, and Node 22.23.2.

Three independent causes here, all in test-only or Linux-only helper code. Nothing in the app changes.

## `select-single-appimage.sh` — `mapfile` is bash 4+

```
scripts/select-single-appimage.sh: line 24: mapfile: command not found
```

macOS still ships bash 3.2.57 as `/bin/bash` (frozen at GPLv2), where that builtin doesn't exist, so all three of the suite's tests failed. Replaced with a `while IFS= read -r` loop.

Verified identical output on bash 3.2 for every branch — one AppImage, none, several, and an empty array.

Worth noting the suite already guards its other prerequisite (`skip: hasJq ? false : "jq is not installed"`), so skipping was an option. I fixed the script instead: the loop is portable, costs nothing on Linux, and a skipped test still isn't testing anything.

## `render-linux-metainfo.sh` — GNU-only `date -d`

BSD date rejects `-d` outright (`date: illegal option -- d`), so the validation failed for *every* date and the script always exited 1.

The fix needed more care than swapping the flag. **BSD date normalises an out-of-range day instead of rejecting it** — `2026-02-31` comes back as `2026-03-03` with exit status 0 — so a naive fallback would have been *weaker* than today's GNU check. It now compares the round-trip against the input rather than trusting the exit status, which is strict on either implementation:

| Input | Result |
|---|---|
| `2026-06-20` | accept |
| `2024-02-29` | accept |
| `2026-13-40` | reject |
| `2026-02-31` | reject |
| `2025-02-29` | reject |

The rendered XML is byte-identical, so `metainfo-generated`'s in-sync assertion still passes and `packaging/linux/org.geolibre.desktop.metainfo.xml` is untouched.

I dropped the "on macOS, use coreutils" note from the comment since the script no longer needs it.

## `desktop-settings-url` timeout test — an unref'd timer

**This one is not macOS-specific** and can bite Linux CI given the wrong timing:

```
not ok 4 - actually aborts a settings request after its timeout
  error: 'Promise resolution is still pending but the event loop has already resolved'
```

The test's fake `fetchImpl` returns a promise that settles *only* when the abort fires, and `fetchDesktopSettings` arms that abort with `AbortSignal.timeout()` — whose timer Node leaves unref'd, so it can't hold the event loop open. With no other pending work the loop drains before the 5 ms timer fires, the promise never settles, and the runner cancels the three tests after it.

The production code is fine — a browser event loop is always alive — so the fix is a ref'd timer held across the assertion.

## Result

macOS goes from `5 failed / 4 cancelled` to `1 failed / 0 cancelled`.

The remaining failure is item 4 in #2213: `python/src/geolibre/_frontend.js` is ESM but sits under a `package.json` with no `"type": "module"`, so Node classifies it CommonJS and only its syntax-detection fallback saves it — which is enough for a dynamic `import()` but not for the static named import the test uses. It passes on Node 22.23.2 and fails on 22.22.2, and `engines` declares `>=22`.

I left that out on purpose: the natural fix is a `package.json` inside `python/src/geolibre/`, and whether that belongs in the wheel is your call rather than something to decide in a drive-by PR. Happy to follow up either way.

## Verification

- `npm run test:frontend` — 7456 pass, 1 fail (the deferred item above), 0 cancelled; was 7448 pass / 5 fail / 4 cancelled
- `npm run lint` — no new findings
- `bash -n` clean on both scripts; each script exercised directly across all its branches on bash 3.2.57
- `oxfmt` run on the touched test
- Environment: macOS 26.6.2 arm64, bash 3.2.57, jq 1.7.1, Node v22.22.2, no coreutils


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date validation for Linux, macOS, and BSD environments, including rejection of invalid calendar dates.
  - Improved macOS compatibility when selecting AppImage files.

- **Tests**
  - Stabilized timeout-related test execution to prevent premature test runner completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->