### PR TITLE
fix(python): declare the widget front-end as ESM for Node

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,6 +51,10 @@ packages = ["src/geolibre"]
 # The bundled app under static/ is produced by the build hook and git-ignored,
 # so it must be re-included explicitly here (VCS file discovery skips it).
 artifacts = ["src/geolibre/static/**"]
+# src/geolibre/package.json marks _frontend.js as ESM for Node, which only
+# matters when this repo's test suite imports it. Nothing in the installed
+# package runs Node, so keep it out of the distribution.
+exclude = ["src/geolibre/package.json"]
 
 # Install the Jupyter Server config drop-in to {sys.prefix}/etc/jupyter so the
 # bundled app-serving extension (geolibre._load_jupyter_server_extension)
@@ -60,6 +64,7 @@ artifacts = ["src/geolibre/static/**"]
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["src/geolibre/static/**"]
+exclude = ["src/geolibre/package.json"]
 # hatch_build.py scans the bundled app for credentials before packaging, using
 # the pattern definitions shared with scripts/scan-credentials.mjs. Those live
 # outside this directory, so vendor a copy into the sdist: an sdist -> wheel

--- a/python/src/geolibre/package.json
+++ b/python/src/geolibre/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Refs #2213 (item 4). This is the piece I left out of #2214 because the fix reaches into Python packaging — I've since verified the packaging side, described below.

## The problem

`python/src/geolibre/_frontend.js` is an ES module, but the nearest `package.json` is the repo root, which sets no `"type"`. Node therefore classifies it as CommonJS and only recovers via automatic module-syntax detection — printing:

```
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to .../package.json.
```

That fallback is enough for a dynamic `import()`, but **not** for a static named import, where the bindings are resolved before it can apply. I confirmed the split directly: `await import(...)` returns `canProxyLocalFiles, default, rewriteProxiedLocalFileUrls`, while the static form in `tests/python-widget-frontend.test.ts` fails with

```
SyntaxError: The requested module '../python/src/geolibre/_frontend.js'
does not provide an export named 'canProxyLocalFiles'
```

The outcome depends on the Node patch version: it passes on **v22.23.2** (what CI runs) and fails on **v22.22.2**, while `package.json` declares `engines.node: ">=22"` — so 22.22.2 sits inside the repo's own stated contract and still can't run the suite.

## The fix

A `package.json` containing `{"type": "module"}` beside the file — the mechanism Node's own warning asks for, scoped to the directory that needs it rather than the repo root, which would reclassify every other `.js` in the tree.

I checked it doesn't create tooling noise: Dependabot's npm ecosystem watches only `/`, and the workspace globs are `apps/*`, `packages/*`, `workers/*` — `python/` matches neither, so nothing else picks the file up as a manifest.

## Keeping it out of the wheel

This is the part I didn't want to assume on your behalf in #2213. The marker only matters when *this repo's* test suite imports the file; nothing in the installed package runs Node. So it's excluded from both build targets and the published artifacts stay exactly as they are.

I verified that empirically rather than trusting the config, and specifically re-ran it with the file **git-tracked**, since hatchling's VCS discovery would otherwise have skipped an untracked file and given a false pass:

| Build | `geolibre/package.json` in wheel | Entries |
|---|---|---|
| Before this change | — | 844 |
| Tracked, **without** `exclude` | yes | 845 |
| Tracked, **with** `exclude` | no | 844 |

So the `exclude` is load-bearing, and the wheel matches the pre-change baseline exactly.

## Verification

- `tests/python-widget-frontend.test.ts` — 10 pass, 0 fail (was a hard import failure). The "Reparsing as ES module" warning is gone too.
- `npm run test:frontend` on this branch — **7467 tests, matching CI's count exactly**; previously 7458 locally, because the failing import meant those 9 tests never ran. Remaining failures on this branch are only the three fixed by #2214, which is a separate branch off the same base.
- Wheel built with `python -m build` in a clean venv; credential scan clean, `geolibre-2.8.0-py3-none-any.whl` produced in all three configurations above.
- `python/src/geolibre/_frontend.js` and `geolibre.py`'s `_esm = _HERE / "_frontend.js"` are untouched, so anywidget's loading path is unchanged.
- Environment: macOS 26.6.2 arm64, Node v22.22.2.

Stacking note: this is independent of #2214 — different files, no overlap — so the two can merge in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution settings so an internal module marker is excluded from published wheel and source distributions.
  * Configured the development package for ES module compatibility during test and tooling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->