### PR TITLE
ci: add a release dry run that builds everything and publishes nothing

### DIFF
--- a/.github/workflows/publish-embed.yml
+++ b/.github/workflows/publish-embed.yml
@@ -3,6 +3,10 @@ name: Publish embed SDK
 on:
   release:
     types: [published]
+  # Build-only trial run before a tag is cut. The publish steps below also
+  # require the `release` event, so a dispatch installs, builds, prepares the
+  # manifests, and checks the registry without publishing anything.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -45,5 +49,5 @@ jobs:
       # can be made: version 2.4.0 is published from a maintainer's machine
       # once, then every later release goes through here.
       - name: Publish to npm (Trusted Publishing)
-        if: steps.version.outputs.publish == 'true'
+        if: github.event_name == 'release' && steps.version.outputs.publish == 'true'
         run: npm publish -w @geolibre/embed --provenance --access public

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,6 +3,10 @@ name: Publish core and map packages
 on:
   release:
     types: [published]
+  # Build-only trial run before a tag is cut. The publish steps below also
+  # require the `release` event, so a dispatch installs, builds, prepares the
+  # manifests, and checks the registry without publishing anything.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -64,11 +68,11 @@ jobs:
       # be made: the first version is published from a maintainer's machine
       # once, then every later release goes through here.
       - name: Publish @geolibre/core
-        if: steps.version.outputs.core == 'true'
+        if: github.event_name == 'release' && steps.version.outputs.core == 'true'
         run: npm publish -w @geolibre/core --provenance --access public
 
       # Published after core so a consumer installing @geolibre/map never
       # resolves a pinned @geolibre/core that is not on the registry yet.
       - name: Publish @geolibre/map
-        if: steps.version.outputs.map == 'true'
+        if: github.event_name == 'release' && steps.version.outputs.map == 'true'
         run: npm publish -w @geolibre/map --provenance --access public

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,158 @@
+# A trial run of everything a release fires, without publishing any of it.
+#
+# The release workflows only run on `release: published`, so until v2.9.0 a
+# build break could sit on `main` unnoticed and surface for the first time on
+# the release itself, with the tag already cut. That is exactly what happened:
+# a desktop-only `window.unminimize()` call landed on 2026-08-29 and took both
+# the Android and iOS builds down on release day, so v2.9.0 published with no
+# mobile artifacts and needed them backfilled by hand.
+#
+# Run this before tagging. It dispatches every release workflow that can build
+# without publishing, waits for them all, and fails if any of them fails.
+#
+#   gh workflow run release-dry-run.yml -R opengeos/GeoLibre --ref main
+#
+# Each workflow it triggers withholds its own publishing on a non-release
+# event, so nothing here can write a release asset, push to npm or PyPI, or
+# touch Homebrew, AUR, COPR or winget:
+#
+#   Release Desktop App  - builds all four desktop targets, MSIX, portable zip,
+#                          and the Chrome extension; attaches none of them, and
+#                          its homebrew/aur/copr/winget jobs are skipped
+#   Android              - builds and signs the APKs and AAB, attaches nothing
+#   iOS                  - builds and signs the .ipa, attaches nothing
+#   Mac App Store        - builds the .pkg, attaches nothing
+#   Store MSIX           - dispatch-only already
+#   Publish Python       - builds the wheel; the publish job is release-only
+#   Publish core and map - builds and prepares the manifests, publishes nothing
+#   Publish embed SDK    - same
+#
+# Deliberately not included: Publish Container Image already runs on every push
+# to `main`, so it is continuously covered and dispatching it here would push a
+# real image to the registry.
+name: Release dry run
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref to build (defaults to the branch this is run from)
+        required: false
+        default: ""
+
+concurrency:
+  group: release-dry-run-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dry-run:
+    name: Build everything, publish nothing
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      # Dispatch the release workflows and read back their conclusions.
+      actions: write
+    steps:
+      - name: Trigger every release workflow in build-only mode
+        id: trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF: ${{ inputs.ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          workflows="release.yml android.yml ios.yml mas-store.yml msix-store.yml publish-python.yml publish-packages.yml publish-embed.yml"
+
+          # Record the newest existing run id per workflow first. `gh workflow
+          # run` returns nothing identifying, and a run takes a moment to
+          # appear, so each new run is found by watching for an id above this
+          # watermark rather than by taking "the most recent run", which would
+          # happily pick up an unrelated one.
+          : > watermarks.txt
+          for wf in $workflows; do
+            before="$(gh run list -R "$REPO" --workflow "$wf" --limit 1 \
+              --json databaseId --jq '.[0].databaseId // 0')"
+            echo "$wf $before" >> watermarks.txt
+          done
+
+          for wf in $workflows; do
+            gh workflow run "$wf" -R "$REPO" --ref "$REF"
+            echo "dispatched $wf"
+          done
+
+          # Give the runs time to register before resolving their ids.
+          sleep 20
+
+          : > runs.txt
+          while read -r wf before; do
+            id=""
+            for _ in $(seq 1 12); do
+              # The oldest run above the watermark is the one just dispatched;
+              # taking the newest would prefer a concurrent dispatch instead.
+              id="$(gh run list -R "$REPO" --workflow "$wf" --event workflow_dispatch \
+                --limit 20 --json databaseId \
+                --jq "[.[] | select(.databaseId > $before)] | min_by(.databaseId) | .databaseId // empty")"
+              [ -n "$id" ] && break
+              sleep 10
+            done
+            if [ -z "$id" ]; then
+              echo "::error::$wf never produced a new run after dispatch"
+              exit 1
+            fi
+            echo "$wf $id" >> runs.txt
+            echo "  $wf -> $id"
+          done < watermarks.txt
+
+      - name: Wait for them all and report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Desktop and mobile builds are slow; poll for up to ~2 hours.
+          deadline=$(( $(date +%s) + 7200 ))
+          while :; do
+            pending=0
+            while read -r wf id; do
+              status="$(gh run view -R "$REPO" "$id" --json status --jq '.status')"
+              [ "$status" = "completed" ] || pending=$((pending + 1))
+            done < runs.txt
+            [ "$pending" -eq 0 ] && break
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out with $pending workflow(s) still running."
+              break
+            fi
+            sleep 60
+          done
+
+          {
+            echo "## Release dry run"
+            echo
+            echo "| Workflow | Result | Run |"
+            echo "| --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          while read -r wf id; do
+            meta="$(gh run view -R "$REPO" "$id" --json status,conclusion,workflowName)"
+            status="$(jq -r '.status' <<<"$meta")"
+            conclusion="$(jq -r '.conclusion // "n/a"' <<<"$meta")"
+            name="$(jq -r '.workflowName' <<<"$meta")"
+            if [ "$status" != "completed" ]; then
+              icon=":hourglass:"; failed=$((failed + 1))
+            elif [ "$conclusion" = "success" ]; then
+              icon=":white_check_mark:"
+            else
+              icon=":x:"; failed=$((failed + 1))
+            fi
+            echo "| $name | $icon $conclusion | [$id](https://github.com/$REPO/actions/runs/$id) |" >> "$GITHUB_STEP_SUMMARY"
+          done < runs.txt
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::$failed release workflow(s) did not succeed. Fix these before tagging."
+            exit 1
+          fi
+          echo "All release workflows built cleanly. Safe to tag."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,17 @@ name: Release Desktop App
 on:
   release:
     types: [published]
+  # Build-only trial run, to catch a break before a tag is cut rather than
+  # after. Every step and job that writes anything outside this run (release
+  # assets, Homebrew, AUR, COPR, winget) is gated on the `release` event below,
+  # so a dispatch builds the same artifacts and publishes none of them.
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.event.release.tag_name }}
+  group: release-${{ github.event_name }}-${{ github.event.release.tag_name || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -41,6 +46,7 @@ jobs:
           if-no-files-found: error
 
       - name: Attach Chrome extension to GitHub Release
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
@@ -137,8 +143,8 @@ jobs:
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
         with:
           projectPath: apps/geolibre-desktop
-          releaseId: ${{ github.event.release.id }}
-          tagName: ${{ github.event.release.tag_name }}
+          releaseId: ${{ github.event_name == 'release' && github.event.release.id || '' }}
+          tagName: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
           args: ${{ matrix.args }}
           uploadPlainBinary: true
 
@@ -156,10 +162,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
           image="$(scripts/select-single-appimage.sh "$ARTIFACT_PATHS")"
           scripts/embed-appimage-update-info.sh "$image"
+          if [ "$EVENT_NAME" != "release" ]; then
+            echo "::notice::Trial run: patched $image and generated its .zsync, not uploading."
+            exit 0
+          fi
           gh release upload "$TAG" "$image" "$image.zsync" --clobber
 
       - name: Build MSIX package
@@ -169,7 +180,7 @@ jobs:
         run: ./packaging/msix/build-msix.ps1
 
       - name: Upload MSIX release asset
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && github.event_name == 'release'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -187,7 +198,7 @@ jobs:
         run: ./packaging/portable/build-portable.ps1
 
       - name: Upload portable zip release asset
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && github.event_name == 'release'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -210,7 +221,7 @@ jobs:
       group: homebrew-tap-update
       cancel-in-progress: false
     # Only update the tap for full releases, not prereleases.
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -276,7 +287,7 @@ jobs:
       group: aur-publish
       cancel-in-progress: false
     # Only publish for full releases, not prereleases.
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
     env:
       # Surfaced as an env var so steps can skip cleanly when the secret is
       # absent (forks, or before the maintainer configures it).
@@ -329,7 +340,7 @@ jobs:
     concurrency:
       group: copr-publish
       cancel-in-progress: false
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
     env:
       COPR_API_TOKEN: ${{ secrets.COPR_API_TOKEN }}
     steps:
@@ -399,7 +410,7 @@ jobs:
       group: winget-publish
       cancel-in-progress: false
     # Only publish for full releases, not prereleases.
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
     env:
       WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
     steps:


### PR DESCRIPTION
Yes, this is possible, and here it is.

## Why

The release workflows only run on `release: published`, so a build break can
sit on `main` unnoticed and surface for the first time on the release itself,
with the tag already cut. That is exactly what just happened: a desktop-only
`window.unminimize()` call landed on 2026-08-29 in #2163, took **both** the
Android and iOS builds down on release day, and v2.9.0 published with no mobile
artifacts that then had to be backfilled by hand.

## Usage

```bash
gh workflow run release-dry-run.yml -R opengeos/GeoLibre --ref main
```

It dispatches every release workflow in build-only mode, waits for all of them,
writes a result table to the step summary, and fails if any failed. An optional
`ref` input builds something other than the branch it is run from.

| Workflow | What the dry run exercises |
| --- | --- |
| Release Desktop App | all four desktop targets, MSIX, portable zip, Chrome extension |
| Android | builds and signs the APKs and AAB |
| iOS | builds and signs the `.ipa` |
| Mac App Store | builds the `.pkg` |
| Store MSIX | already dispatch-only |
| Publish Python | builds the wheel |
| Publish core and map | builds and rewrites the manifests |
| Publish embed SDK | same |

## What makes it safe

Nothing here can write a release asset, push to npm or PyPI, or touch Homebrew,
AUR, COPR or winget. Five of those workflows already withheld publishing on a
non-release event and needed no change. Three did not, and every write path in
them is now gated on `github.event_name == 'release'`:

- **`release.yml`** gains `workflow_dispatch`. The Chrome extension, AppImage,
  MSIX and portable-zip uploads are gated. `tauri-action` is handed an empty
  `releaseId` **and** `tagName` on a dispatch, because a `tagName` without a
  `releaseId` makes it *create* a release. And the `homebrew`, `aur`, `copr`
  and `winget` jobs were gated only on `!github.event.release.prerelease`,
  which evaluates **true** on a dispatch since the field is null, so each now
  requires the release event as well. That last one was the sharp edge.
- **`publish-packages.yml`** and **`publish-embed.yml`** gain
  `workflow_dispatch` with their `npm publish` steps gated, so a dispatch
  installs, builds, rewrites the manifests and checks the registry without
  publishing.

Publish Container Image is deliberately excluded: it already runs on every push
to `main`, so it is continuously covered, and dispatching it would push a real
image to the registry.

## Run tracking

`gh workflow run` returns nothing identifying, so the dispatcher watermarks the
newest existing run id per workflow first, then takes the **oldest** id above
that watermark. Taking "the most recent run" would happily pick up a concurrent
unrelated dispatch.

## Verification

- `pre-commit run --files <the four workflows>` passes, including `npm-build`.
- All four parse as valid YAML with the expected triggers.
- The watermark selection was exercised locally against sample payloads for the
  normal case, the not-yet-registered case, the first-ever-run case, and the
  concurrent-dispatch case.
- Confirmed `set -e` does not abort the wait loop on the `[ ... ] && break`
  guard, which would otherwise have made the poll exit on its first iteration.

An audit of `release.yml` after the change shows every `gh release upload` and
every publishing job carrying an event gate; the AppImage step keeps patching
the update info and `.zsync` on a dry run and returns before uploading, so that
path is still exercised.

The honest caveat: the gating is verified by reading and by that audit, not by
having run a dispatch yet. The first real `release-dry-run` will confirm it, and
it is cheap to run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added manual, build-only trial runs for package, embed, and application releases.
  - Added a release dry-run workflow that runs all release checks, monitors completion, and reports failures or timeouts.
  - Trial runs now build artifacts, prepare manifests, and check registries without publishing releases or package updates.

- **Bug Fixes**
  - Prevented non-release workflow runs from accidentally publishing packages, release assets, or distribution updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->