### PR TITLE
ci: derive a tag for the AppImage update info on a release dry run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,22 +161,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
+          # On a release this is the tag. A trial run has none, and the script
+          # requires one: it derives the zsync glob by rewriting `_<version>_`
+          # in the bundle's file name and bails if the tag's version is not in
+          # there. Fall back to the version tauri-action actually stamped, which
+          # is what test-build.yml already feeds this same step.
+          TAG: ${{ github.event.release.tag_name || format('v{0}', steps.tauri.outputs.appVersion) }}
           EVENT_NAME: ${{ github.event_name }}
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
           image="$(scripts/select-single-appimage.sh "$ARTIFACT_PATHS")"
-          # A trial run has no tag, but the script requires one: it derives the
-          # zsync glob by rewriting `_<version>_` in the bundle's file name, and
-          # bails if the tag's version is not in there. Deriving the tag from
-          # the version the bundler actually stamped keeps that guard meaningful
-          # on a dry run instead of skipping the whole update-info path, which
-          # is the fiddly part most worth exercising before a release.
-          if [ -z "$TAG" ]; then
-            TAG="v$(node -p "require('./apps/geolibre-desktop/package.json').version")"
-            export TAG
-            echo "::notice::Trial run: derived tag $TAG from package.json for update-info embedding."
-          fi
           scripts/embed-appimage-update-info.sh "$image"
           if [ "$EVENT_NAME" != "release" ]; then
             echo "::notice::Trial run: patched $image and generated its .zsync, not uploading."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,17 @@ jobs:
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
           image="$(scripts/select-single-appimage.sh "$ARTIFACT_PATHS")"
+          # A trial run has no tag, but the script requires one: it derives the
+          # zsync glob by rewriting `_<version>_` in the bundle's file name, and
+          # bails if the tag's version is not in there. Deriving the tag from
+          # the version the bundler actually stamped keeps that guard meaningful
+          # on a dry run instead of skipping the whole update-info path, which
+          # is the fiddly part most worth exercising before a release.
+          if [ -z "$TAG" ]; then
+            TAG="v$(node -p "require('./apps/geolibre-desktop/package.json').version")"
+            export TAG
+            echo "::notice::Trial run: derived tag $TAG from package.json for update-info embedding."
+          fi
           scripts/embed-appimage-update-info.sh "$image"
           if [ "$EVENT_NAME" != "release" ]; then
             echo "::notice::Trial run: patched $image and generated its .zsync, not uploading."


### PR DESCRIPTION
The first release dry run ([run 33706914637](https://github.com/opengeos/GeoLibre/actions/runs/33706914637)) caught a bug in its own plumbing, which is roughly the point of it.

`Build Linux x64` failed at *Embed AppImage update information*:

```
scripts/embed-appimage-update-info.sh: line 28: TAG: Set TAG to the release tag, e.g. v1.5.0
```

`TAG` comes from `github.event.release.tag_name`, empty on a `workflow_dispatch`, and the script requires it. The build-only guard added in #2223 sits *after* the script call, so it never got the chance to skip.

## Fix

Moving the guard above the call would work but would skip the update-info path entirely, and that is the fiddly part most worth exercising before a release: it patches a 1 KiB ELF section in place and derives a zsync glob by rewriting `_<version>_` in the bundle file name, failing loudly if the name stops matching.

So the tag is derived from the version the bundler actually stamped when there is no release tag. The script runs for real and only the upload is skipped.

A placeholder tag would **not** have worked: the version has to appear in the file name or the script's own guard rejects it.

## Verification

Against the exact bundle name from the failed run:

```
REPO=opengeos/GeoLibre TAG=v2.9.0 scripts/embed-appimage-update-info.sh \
  --print 'GeoLibre Desktop_2.9.0_amd64.AppImage'
-> gh-releases-zsync|opengeos|GeoLibre|latest|GeoLibre Desktop_*_amd64.AppImage.zsync
```

## What the dry run proved otherwise

| | |
| --- | --- |
| Dispatch + run tracking | all 8 workflows dispatched and resolved correctly |
| Wait and report | waited 22 min, failed on the one workflow that failed |
| Publish gating | Homebrew, AUR, winget and COPR all **skipped** |
| Results | 7 of 8 succeeded; nothing was published anywhere |

The publish gating was the sharp edge, since those four jobs were previously gated only on `!github.event.release.prerelease`, which is true on a dispatch. Confirmed skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved release workflow handling for manually triggered or trial builds.
  - Update information now uses the application’s version when a release tag is unavailable, allowing these builds to complete with meaningful version details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->