### PR TITLE
Auto-load more projects in gallery

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
@@ -465,7 +465,13 @@ export function ProjectGalleryDialog({
                       {t("gallery.loadingMore")}
                     </span>
                   ) : (
-                    <Button variant="outline" size="sm" onClick={() => loadPage(rawOffset)}>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        if (abortRef.current === null) void loadPage(rawOffset);
+                      }}
+                    >
                       {t("gallery.loadMore")}
                     </Button>
                   )}

--- a/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
@@ -30,6 +30,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
+import { observeGalleryEnd } from "../../lib/gallery-auto-load";
 import { openExternalLink } from "../../lib/open-external";
 import {
   fetchMyProjects,
@@ -125,6 +126,7 @@ export function ProjectGalleryDialog({
   );
   const [openError, setOpenError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const reloadGenerationRef = useRef(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
 
@@ -249,6 +251,7 @@ export function ProjectGalleryDialog({
   // `loadPage` identity changes with scope); reset transient state and abort any
   // in-flight request when it closes.
   useEffect(() => {
+    reloadGenerationRef.current += 1;
     if (open) {
       setProjects([]);
       setQuery("");
@@ -296,16 +299,15 @@ export function ProjectGalleryDialog({
     const sentinel = loadMoreSentinelRef.current;
     if (!open || !root || !sentinel || !hasMore || trimmedQuery || status !== "idle") return;
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry?.isIntersecting) return;
-        observer.unobserve(sentinel);
-        void loadPage(rawOffset);
-      },
-      { root, rootMargin: "0px 0px 300px 0px" },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
+    const generation = reloadGenerationRef.current;
+    return observeGalleryEnd({
+      root,
+      sentinel,
+      generation,
+      currentGeneration: () => reloadGenerationRef.current,
+      isLoading: () => abortRef.current !== null,
+      onLoad: () => void loadPage(rawOffset),
+    });
   }, [hasMore, loadPage, open, rawOffset, status, trimmedQuery]);
 
   const showInitialSpinner = status === "loading" && projects.length === 0;
@@ -426,41 +428,47 @@ export function ProjectGalleryDialog({
                 {t("gallery.retry")}
               </Button>
             </div>
-          ) : showEmpty ? (
-            <p className="py-16 text-center text-sm text-muted-foreground">
-              {trimmedQuery
-                ? t("gallery.noMatches")
-                : effectiveScope === "mine"
-                  ? t("gallery.emptyMine")
-                  : effectiveScope === "featured"
-                    ? t("gallery.emptyFeatured")
-                    : t("gallery.empty")}
-            </p>
           ) : (
             <>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {visibleProjects.map((project) => (
-                  <GalleryCard
-                    key={project.id}
-                    project={project}
-                    openingAction={openingState?.id === project.id ? openingState.action : null}
-                    disabled={openingState !== null}
-                    onOpen={() => void handleOpen(project)}
-                    onOpenCopy={() => void handleOpen(project, { asCopy: true })}
-                  />
-                ))}
-              </div>
+              {showEmpty ? (
+                <p className="py-16 text-center text-sm text-muted-foreground">
+                  {trimmedQuery
+                    ? t("gallery.noMatches")
+                    : effectiveScope === "mine"
+                      ? t("gallery.emptyMine")
+                      : effectiveScope === "featured"
+                        ? t("gallery.emptyFeatured")
+                        : t("gallery.empty")}
+                </p>
+              ) : (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                  {visibleProjects.map((project) => (
+                    <GalleryCard
+                      key={project.id}
+                      project={project}
+                      openingAction={openingState?.id === project.id ? openingState.action : null}
+                      disabled={openingState !== null}
+                      onOpen={() => void handleOpen(project)}
+                      onOpenCopy={() => void handleOpen(project, { asCopy: true })}
+                    />
+                  ))}
+                </div>
+              )}
               {hasMore && !trimmedQuery ? (
                 <div
                   ref={loadMoreSentinelRef}
-                  className="flex min-h-12 items-center justify-center py-4 text-sm text-muted-foreground"
+                  className="flex min-h-12 items-center justify-center py-4"
                 >
                   {status === "loadingMore" ? (
-                    <>
+                    <span className="flex items-center text-sm text-muted-foreground">
                       <Loader2 className="me-2 h-4 w-4 animate-spin" />
                       {t("gallery.loadingMore")}
-                    </>
-                  ) : null}
+                    </span>
+                  ) : (
+                    <Button variant="outline" size="sm" onClick={() => loadPage(rawOffset)}>
+                      {t("gallery.loadMore")}
+                    </Button>
+                  )}
                 </div>
               ) : null}
             </>

--- a/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
@@ -99,8 +99,8 @@ function galleryErrorMessage(error: unknown, t: TFunction): string {
  * GeoLibre.
  *
  * The listing endpoint only paginates (no server-side search), so this loads
- * pages on demand via "Load more" and filters the already-loaded set in the
- * browser.
+ * pages automatically as the user nears the end of the list and filters the
+ * already-loaded set in the browser.
  */
 export function ProjectGalleryDialog({
   open,
@@ -125,6 +125,8 @@ export function ProjectGalleryDialog({
   );
   const [openError, setOpenError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
 
   // Without a token, the "My projects" scope isn't available; fall back to the
   // featured tab.
@@ -286,6 +288,26 @@ export function ProjectGalleryDialog({
     ? projects.filter((p) => searchHaystack(p).includes(trimmedQuery))
     : projects;
 
+  // Fetch the next page shortly before the end of the gallery scrolls into
+  // view. Recreating the observer after each request also prevents a sentinel
+  // that remains visible from starting the same page more than once.
+  useEffect(() => {
+    const root = scrollContainerRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!open || !root || !sentinel || !hasMore || trimmedQuery || status !== "idle") return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        observer.unobserve(sentinel);
+        void loadPage(rawOffset);
+      },
+      { root, rootMargin: "0px 0px 300px 0px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loadPage, open, rawOffset, status, trimmedQuery]);
+
   const showInitialSpinner = status === "loading" && projects.length === 0;
   const showEmpty = status !== "loading" && !error && visibleProjects.length === 0;
 
@@ -385,7 +407,10 @@ export function ProjectGalleryDialog({
             `touch-pan-y` + `overscroll-contain` keep the vertical gesture on
             this element on iOS Safari, where the dialog's scroll-lock
             (react-remove-scroll) otherwise swallows the touchmove. */}
-        <div className="-mx-1 min-h-0 flex-1 touch-pan-y overflow-y-auto overscroll-contain px-1 [-webkit-overflow-scrolling:touch]">
+        <div
+          ref={scrollContainerRef}
+          className="-mx-1 min-h-0 flex-1 touch-pan-y overflow-y-auto overscroll-contain px-1 [-webkit-overflow-scrolling:touch]"
+        >
           {showInitialSpinner ? (
             <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -426,22 +451,16 @@ export function ProjectGalleryDialog({
                 ))}
               </div>
               {hasMore && !trimmedQuery ? (
-                <div className="flex justify-center py-4">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={status === "loadingMore"}
-                    onClick={() => loadPage(rawOffset)}
-                  >
-                    {status === "loadingMore" ? (
-                      <>
-                        <Loader2 className="me-2 h-4 w-4 animate-spin" />
-                        {t("gallery.loadingMore")}
-                      </>
-                    ) : (
-                      t("gallery.loadMore")
-                    )}
-                  </Button>
+                <div
+                  ref={loadMoreSentinelRef}
+                  className="flex min-h-12 items-center justify-center py-4 text-sm text-muted-foreground"
+                >
+                  {status === "loadingMore" ? (
+                    <>
+                      <Loader2 className="me-2 h-4 w-4 animate-spin" />
+                      {t("gallery.loadingMore")}
+                    </>
+                  ) : null}
                 </div>
               ) : null}
             </>

--- a/apps/geolibre-desktop/src/lib/gallery-auto-load.ts
+++ b/apps/geolibre-desktop/src/lib/gallery-auto-load.ts
@@ -1,0 +1,35 @@
+interface GalleryAutoLoadOptions {
+  root: Element;
+  sentinel: Element;
+  generation: number;
+  currentGeneration: () => number;
+  isLoading: () => boolean;
+  onLoad: () => void;
+}
+
+/** Observe the end of a gallery while rejecting callbacks from an old reload. */
+export function observeGalleryEnd({
+  root,
+  sentinel,
+  generation,
+  currentGeneration,
+  isLoading,
+  onLoad,
+}: GalleryAutoLoadOptions): () => void {
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (
+        !entry?.isIntersecting ||
+        generation !== currentGeneration() ||
+        isLoading()
+      ) {
+        return;
+      }
+      observer.unobserve(sentinel);
+      onLoad();
+    },
+    { root, rootMargin: "0px 0px 300px 0px" },
+  );
+  observer.observe(sentinel);
+  return () => observer.disconnect();
+}

--- a/apps/geolibre-desktop/src/lib/gallery-auto-load.ts
+++ b/apps/geolibre-desktop/src/lib/gallery-auto-load.ts
@@ -18,11 +18,7 @@ export function observeGalleryEnd({
 }: GalleryAutoLoadOptions): () => void {
   const observer = new IntersectionObserver(
     ([entry]) => {
-      if (
-        !entry?.isIntersecting ||
-        generation !== currentGeneration() ||
-        isLoading()
-      ) {
+      if (!entry?.isIntersecting || generation !== currentGeneration() || isLoading()) {
         return;
       }
       observer.unobserve(sentinel);

--- a/tests/gallery-auto-load.test.ts
+++ b/tests/gallery-auto-load.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { observeGalleryEnd } from "../apps/geolibre-desktop/src/lib/gallery-auto-load";
+
+describe("project gallery auto-load observer", () => {
+  const originalObserver = globalThis.IntersectionObserver;
+
+  afterEach(() => {
+    Object.assign(globalThis, { IntersectionObserver: originalObserver });
+  });
+
+  it("ignores a callback from before a scope reload", () => {
+    let fire: (entries: IntersectionObserverEntry[]) => void = () => {};
+    class FakeIntersectionObserver {
+      constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+        fire = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    Object.assign(globalThis, { IntersectionObserver: FakeIntersectionObserver });
+
+    const sentinel = {} as Element;
+    let generation = 1;
+    let loads = 0;
+    observeGalleryEnd({
+      root: {} as Element,
+      sentinel,
+      generation,
+      currentGeneration: () => generation,
+      isLoading: () => false,
+      onLoad: () => {
+        loads += 1;
+      },
+    });
+
+    generation += 1;
+    fire([{ isIntersecting: true, target: sentinel } as IntersectionObserverEntry]);
+    assert.equal(loads, 0, "the stale observer loaded a page from the previous scope");
+  });
+
+  it("does not load while the page-zero reload is active", () => {
+    let fire: (entries: IntersectionObserverEntry[]) => void = () => {};
+    class FakeIntersectionObserver {
+      constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+        fire = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    Object.assign(globalThis, { IntersectionObserver: FakeIntersectionObserver });
+
+    const sentinel = {} as Element;
+    let loads = 0;
+    observeGalleryEnd({
+      root: {} as Element,
+      sentinel,
+      generation: 1,
+      currentGeneration: () => 1,
+      isLoading: () => true,
+      onLoad: () => {
+        loads += 1;
+      },
+    });
+
+    fire([{ isIntersecting: true, target: sentinel } as IntersectionObserverEntry]);
+    assert.equal(loads, 0, "pagination interrupted the initial reload");
+  });
+});

--- a/tests/gallery-auto-load.test.ts
+++ b/tests/gallery-auto-load.test.ts
@@ -9,6 +9,35 @@ describe("project gallery auto-load observer", () => {
     Object.assign(globalThis, { IntersectionObserver: originalObserver });
   });
 
+  it("unobserves the sentinel before loading the next page", () => {
+    let fire: (entries: IntersectionObserverEntry[]) => void = () => {};
+    const events: string[] = [];
+    class FakeIntersectionObserver {
+      constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+        fire = callback;
+      }
+      observe() {}
+      unobserve(target: Element) {
+        events.push(target === sentinel ? "unobserve" : "wrong target");
+      }
+      disconnect() {}
+    }
+    Object.assign(globalThis, { IntersectionObserver: FakeIntersectionObserver });
+
+    const sentinel = {} as Element;
+    observeGalleryEnd({
+      root: {} as Element,
+      sentinel,
+      generation: 1,
+      currentGeneration: () => 1,
+      isLoading: () => false,
+      onLoad: () => events.push("load"),
+    });
+
+    fire([{ isIntersecting: true, target: sentinel } as IntersectionObserverEntry]);
+    assert.deepEqual(events, ["unobserve", "load"]);
+  });
+
   it("ignores a callback from before a scope reload", () => {
     let fire: (entries: IntersectionObserverEntry[]) => void = () => {};
     class FakeIntersectionObserver {


### PR DESCRIPTION
## Summary
- automatically fetch the next gallery page as users approach the bottom
- replace the manual Load more button with an inline loading indicator
- prevent duplicate page requests while preserving gallery search and scope behavior

## Testing
- `npm run build -w geolibre-desktop`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project galleries now automatically load additional public projects as you scroll, replacing the “Load more” button.
  * Additional results are fetched only when more projects are available and the gallery is not filtered.
  * A loading indicator appears at the end of the gallery while more projects are being retrieved.
  * Gallery loading remains reliable when refreshing or changing the current view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->