### PR TITLE
fix: load RTL text shaping before map labels

### DIFF
--- a/apps/geolibre-desktop/src/lib/rtl-text.ts
+++ b/apps/geolibre-desktop/src/lib/rtl-text.ts
@@ -19,10 +19,10 @@ if (typeof maplibregl.setRTLTextPlugin === "function") {
   // setRTLTextPlugin rejects if a plugin was already registered for the page;
   // only register when none is set yet ("unavailable" is the initial state).
   if (!status || status === "unavailable") {
-    // Lazy (second arg `true`): defer downloading the plugin worker until a map
-    // actually encounters RTL text, so the bytes are not paid for on LTR-only
-    // maps. Returns a promise that resolves once the plugin is requested.
-    maplibregl.setRTLTextPlugin(rtlTextPluginUrl, true).catch((error: unknown) => {
+    // Load eagerly so the worker can shape text before the first symbol bucket is
+    // built. With lazy loading, dynamically added RTL labels can remain unshaped
+    // because their bucket is not rebuilt after the plugin becomes available.
+    maplibregl.setRTLTextPlugin(rtlTextPluginUrl, false).catch((error: unknown) => {
       console.error("[GeoLibre] Failed to load RTL text plugin", error);
     });
   }


### PR DESCRIPTION
## Summary
- load the bundled RTL text plugin before MapLibre builds symbol buckets
- prevent dynamically added Kurdish and other RTL labels from remaining visually reversed
- intentionally trade lazy loading for correctness, so the bundled RTL worker is fetched and initialized on every app startup

## Test plan
- [x] reproduce the Sorani Kurdish annotation issue before the change
- [x] verify the annotation label renders correctly in light and dark themes
- [x] run `npm run lint`
- [x] run `npm run build`
- [x] run `npm run test:frontend`
- [x] run scoped pre-commit checks

Fixes #2228