### PR TITLE
docs: install the R package from CRAN

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,12 +61,10 @@ See the [Python Package](python.md) reference to get started.
 ### In R
 
 The [`geolibre`](r.md) R package embeds GeoLibre as an interactive HTML widget
-in RStudio, Quarto, R Markdown, and Shiny. Install the development release from
-GitHub:
+in RStudio, Quarto, R Markdown, and Shiny. Install it from CRAN:
 
 ```r
-install.packages("pak")
-pak::pak("opengeos/geolibre-r")
+install.packages("geolibre")
 ```
 
 [Read the R package guide](r.md){ .md-button .md-button--primary }

--- a/docs/r.md
+++ b/docs/r.md
@@ -1,5 +1,6 @@
 # R package
 
+[![CRAN status](https://www.r-pkg.org/badges/version/geolibre)](https://CRAN.R-project.org/package=geolibre)
 [![R-CMD-check](https://github.com/opengeos/geolibre-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/opengeos/geolibre-r/actions/workflows/R-CMD-check.yaml)
 
 The **`geolibre`** R package embeds the full GeoLibre map in RStudio, Quarto,
@@ -13,18 +14,18 @@ the GeoLibre web or desktop application.
 
 ## Installation
 
-The package is currently available from GitHub while its first CRAN submission
-is prepared:
+Install the released version from
+[CRAN](https://CRAN.R-project.org/package=geolibre):
+
+```r
+install.packages("geolibre")
+```
+
+Or the development version from GitHub:
 
 ```r
 install.packages("pak")
 pak::pak("opengeos/geolibre-r")
-```
-
-After it is published on CRAN, install the released version with:
-
-```r
-install.packages("geolibre")
 ```
 
 ## Quick start


### PR DESCRIPTION
`geolibre` 0.2.0 is now on CRAN: https://cran.r-project.org/web/packages/geolibre/index.html

- `docs/r.md` and the R section of `docs/getting-started.md` now install from CRAN, with `pak` kept as the development-version path in the R guide.
- Added a CRAN status badge to `docs/r.md`.

https://claude.ai/code/session_01BRUGY3CqphbC1FNhkZJKBt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated R installation instructions to install the released package from CRAN.
  * Added guidance for installing the development version from GitHub.
  * Added a CRAN status badge to the R documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->