### PR TITLE
Add CSW catalog search

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -59,6 +59,9 @@ interface AddDataDialogProps {
   initialStyleUrl?: string;
   /** Search term a saved CSW connection was stored with. */
   initialKeyword?: string;
+  /** Group this dialog session's layers are moved into, when opened via
+   * "Add data to group". */
+  targetGroupId?: string | null;
 }
 
 /**
@@ -142,6 +145,7 @@ export function AddDataDialog({
   initialLayer,
   initialStyleUrl,
   initialKeyword,
+  targetGroupId = null,
 }: AddDataDialogProps) {
   const { t } = useTranslation();
   const open = kind !== null;
@@ -176,8 +180,9 @@ export function AddDataDialog({
       setIsSubmitting,
       closeDialog,
       martin,
+      targetGroupId,
     }),
-    [mapControllerRef, addLayer, existingLayers, isSubmitting, closeDialog, martin],
+    [mapControllerRef, addLayer, existingLayers, isSubmitting, closeDialog, martin, targetGroupId],
   );
 
   return (

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -23,6 +23,7 @@ import { PostgresSource } from "./add-data/sources/PostgresSource";
 import { VideoSource } from "./add-data/sources/VideoSource";
 import { WfsSource } from "./add-data/sources/WfsSource";
 import { WmsSource } from "./add-data/sources/WmsSource";
+import { CswSource } from "./add-data/sources/CswSource";
 import { WmtsSource } from "./add-data/sources/WmtsSource";
 import { XyzSource } from "./add-data/sources/XyzSource";
 import type { AddDataKind } from "./add-data/types";
@@ -76,6 +77,8 @@ function renderSource(
       return <XyzSource initialUrl={initialUrl} />;
     case "wms":
       return <WmsSource initialUrl={initialUrl} initialLayers={initialLayer} />;
+    case "csw":
+      return <CswSource />;
     case "wfs":
       return <WfsSource initialUrl={initialUrl} initialTypeName={initialLayer} />;
     case "wmts":

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -57,6 +57,8 @@ interface AddDataDialogProps {
   initialLayer?: string;
   /** Style document accompanying a deep-linked vector tileset. */
   initialStyleUrl?: string;
+  /** Search term a saved CSW connection was stored with. */
+  initialKeyword?: string;
 }
 
 /**
@@ -71,6 +73,7 @@ function renderSource(
   initialUrl: string | undefined,
   initialLayer: string | undefined,
   initialStyleUrl: string | undefined,
+  initialKeyword: string | undefined,
 ) {
   switch (kind) {
     case "xyz":
@@ -78,7 +81,7 @@ function renderSource(
     case "wms":
       return <WmsSource initialUrl={initialUrl} initialLayers={initialLayer} />;
     case "csw":
-      return <CswSource initialUrl={initialUrl} />;
+      return <CswSource initialUrl={initialUrl} initialKeyword={initialKeyword} />;
     case "wfs":
       return <WfsSource initialUrl={initialUrl} initialTypeName={initialLayer} />;
     case "wmts":
@@ -138,6 +141,7 @@ export function AddDataDialog({
   initialUrl,
   initialLayer,
   initialStyleUrl,
+  initialKeyword,
 }: AddDataDialogProps) {
   const { t } = useTranslation();
   const open = kind !== null;
@@ -196,6 +200,7 @@ export function AddDataDialog({
               initialUrl,
               initialLayer,
               initialStyleUrl,
+              initialKeyword,
             )}
           </AddDataShellProvider>
         ) : null}

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -23,6 +23,7 @@ import { PostgresSource } from "./add-data/sources/PostgresSource";
 import { VideoSource } from "./add-data/sources/VideoSource";
 import { WfsSource } from "./add-data/sources/WfsSource";
 import { WmsSource } from "./add-data/sources/WmsSource";
+import { CswSource } from "./add-data/sources/CswSource";
 import { WmtsSource } from "./add-data/sources/WmtsSource";
 import { XyzSource } from "./add-data/sources/XyzSource";
 import type { AddDataKind } from "./add-data/types";
@@ -76,6 +77,8 @@ function renderSource(
       return <XyzSource initialUrl={initialUrl} />;
     case "wms":
       return <WmsSource initialUrl={initialUrl} initialLayers={initialLayer} />;
+    case "csw":
+      return <CswSource initialUrl={initialUrl} />;
     case "wfs":
       return <WfsSource initialUrl={initialUrl} initialTypeName={initialLayer} />;
     case "wmts":

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1199,7 +1199,9 @@ export function TopToolbar({
       // open a dialog whose backing service is compiled out.
       if (detail?.kind && !masHidesDataSource(detail.kind)) {
         setInitialService(
-          detail.url
+          // An empty string is still a prefill (a saved CSW entry can carry a
+          // keyword and a blank endpoint); only a missing url means "no prefill".
+          detail.url !== undefined
             ? {
                 kind: detail.kind,
                 url: detail.url,

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -2294,6 +2294,7 @@ export function TopToolbar({
         initialKeyword={
           addDataKind === initialService?.kind ? (initialService.keyword ?? undefined) : undefined
         }
+        targetGroupId={addDataTargetGroupId}
         onOpenChange={(open: boolean) => {
           if (!open) {
             if (addDataTargetGroupId) {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -122,7 +122,7 @@ import { pluginDisplayName } from "../../lib/plugin-display-name";
 import { masHidesDataSource } from "../../lib/mas-build";
 import { IS_STORE_BUILD } from "../../lib/updates";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
-import { serviceUrlParameter } from "../../lib/data-url";
+import { serviceUrlParameter, type ServiceUrlParameter } from "../../lib/data-url";
 import {
   OPEN_ADD_DATA_EVENT,
   type OpenAddDataDetail,
@@ -1150,7 +1150,11 @@ export function TopToolbar({
       current.terrain === terrainEnabled ? current : { ...current, terrain: terrainEnabled },
     );
   }, [mapControllerRef, mapReadyGeneration, projectGeneration, terrainEnabled]);
-  const [initialService, setInitialService] = useState(() =>
+  // `keyword` has no deep-link parameter — only the Browser panel's saved CSW
+  // entries carry one — so it widens the parsed shape rather than joining it.
+  const [initialService, setInitialService] = useState<
+    (ServiceUrlParameter & { keyword?: string | null }) | null
+  >(() =>
     viewer || typeof window === "undefined" ? null : serviceUrlParameter(window.location.search),
   );
   const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(() => {
@@ -1196,7 +1200,13 @@ export function TopToolbar({
       if (detail?.kind && !masHidesDataSource(detail.kind)) {
         setInitialService(
           detail.url
-            ? { kind: detail.kind, url: detail.url, layer: detail.layer ?? null, styleUrl: null }
+            ? {
+                kind: detail.kind,
+                url: detail.url,
+                layer: detail.layer ?? null,
+                styleUrl: null,
+                keyword: detail.keyword ?? null,
+              }
             : null,
         );
         setAddDataPostgres(detail.postgres);
@@ -2278,6 +2288,9 @@ export function TopToolbar({
         }
         initialStyleUrl={
           addDataKind === initialService?.kind ? (initialService.styleUrl ?? undefined) : undefined
+        }
+        initialKeyword={
+          addDataKind === initialService?.kind ? (initialService.keyword ?? undefined) : undefined
         }
         onOpenChange={(open: boolean) => {
           if (!open) {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1194,6 +1194,11 @@ export function TopToolbar({
       // Reject kinds the Mac App Store build hides so a stray event cannot
       // open a dialog whose backing service is compiled out.
       if (detail?.kind && !masHidesDataSource(detail.kind)) {
+        setInitialService(
+          detail.url
+            ? { kind: detail.kind, url: detail.url, layer: detail.layer ?? null, styleUrl: null }
+            : null,
+        );
         setAddDataPostgres(detail.postgres);
         setAddDataTargetGroupId(detail.groupId ?? null);
         addDataInitialLayerIdsRef.current = new Set(

--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -455,6 +455,8 @@ export async function applyServiceEntry(
   const { addLayer, mapControllerRef, beforeLayerId = null } = deps;
 
   switch (entry.kind) {
+    case "csw":
+      throw new Error("CSW catalog connections must be opened before choosing a dataset.");
     case "xyz": {
       const request = xyzFieldsToRequest(entry.fields);
       if (!request.url.trim()) throw new Error("This service has no tile URL.");

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -14,6 +14,7 @@ export const DECK_VIZ_SIZE_WARN_BYTES = 10 * 1024 * 1024;
 export type KindI18nKey =
   | "xyz"
   | "wms"
+  | "csw"
   | "wfs"
   | "wmts"
   | "ogcFeatures"
@@ -40,6 +41,7 @@ export type KindI18nKey =
 export const KIND_I18N_KEY: Record<AddDataKind, KindI18nKey> = {
   xyz: "xyz",
   wms: "wms",
+  csw: "csw",
   wfs: "wfs",
   wmts: "wmts",
   "ogc-features": "ogcFeatures",
@@ -144,6 +146,7 @@ export const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 // Keep in sync with WMS_PROXY_PATH in vite.config.ts (the dev proxy binds it
 // there). Used to fetch a WMS GetCapabilities document without tripping CORS.
 export const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
+export const CSW_PROXY_PATH = "/__geolibre_csw_proxy";
 // Keep in sync with WFS_PROXY_PATH in vite.config.ts. Used to fetch a WFS
 // GetCapabilities document (and GetFeature responses) without tripping CORS.
 export const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -146,6 +146,8 @@ export const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 // Keep in sync with WMS_PROXY_PATH in vite.config.ts (the dev proxy binds it
 // there). Used to fetch a WMS GetCapabilities document without tripping CORS.
 export const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
+// Keep in sync with CSW_PROXY_PATH in vite.config.ts. Used to fetch a CSW
+// GetRecords response (and a record's GeoJSON) without tripping CORS.
 export const CSW_PROXY_PATH = "/__geolibre_csw_proxy";
 // Keep in sync with WFS_PROXY_PATH in vite.config.ts. Used to fetch a WFS
 // GetCapabilities document (and GetFeature responses) without tripping CORS.

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -204,6 +204,46 @@ export const CAD_SAMPLES: readonly {
   },
 ];
 
+// Public CSW catalogs offered in the Add CSW Catalog dialog's "Load sample data"
+// dropdown. A CSW endpoint is unguessable, so without these the panel opens on an
+// empty field with nothing to try. Each entry was checked to answer an anonymous
+// GetRecords over CORS *and* to return records carrying WMS/WFS/ArcGIS/GeoJSON
+// online resources, which is what makes the result list's Add buttons appear —
+// a conforming catalog whose records advertise no services (the pycsw demo
+// servers, for one) searches fine but offers nothing to add. A broad listing
+// buries those records, so three entries ship the keyword "WMS": it is the word
+// service-backed records carry in their own metadata, and searching it fills the
+// first page with entries that have something to add. Open Canada needs no
+// keyword and its unfiltered listing also advertises GeoJSON, which the dialog
+// adds to the map directly instead of handing off to another source. Labels are
+// organization names, so like CAD_SAMPLES above they stay untranslated.
+export const CSW_SAMPLES: readonly {
+  label: string;
+  endpoint: string;
+  keyword: string;
+}[] = [
+  {
+    label: "Open Canada (Government of Canada)",
+    endpoint: "https://csw.open.canada.ca/geonetwork/srv/csw",
+    keyword: "",
+  },
+  {
+    label: "European Environment Agency (SDI)",
+    endpoint: "https://sdi.eea.europa.eu/catalogue/srv/eng/csw",
+    keyword: "WMS",
+  },
+  {
+    label: "geocat.ch (Swiss geodata catalog)",
+    endpoint: "https://www.geocat.ch/geonetwork/srv/eng/csw",
+    keyword: "WMS",
+  },
+  {
+    label: "Nationaal Georegister (Netherlands)",
+    endpoint: "https://nationaalgeoregister.nl/geonetwork/srv/dut/csw",
+    keyword: "WMS",
+  },
+];
+
 export const DELIMITED_TEXT_DELIMITERS: Record<
   Exclude<DelimitedTextDelimiter, "custom">,
   string

--- a/apps/geolibre-desktop/src/components/layout/add-data/context.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/context.tsx
@@ -18,6 +18,13 @@ export interface AddDataShellContextValue {
   setIsSubmitting: (value: boolean) => void;
   /** Run close cleanups (e.g. transient Martin shutdown) and close the dialog. */
   closeDialog: () => void;
+  /**
+   * Group the layers added in this dialog session are moved into ("Add data to
+   * group"), or null. A source that closes and reopens the dialog on another
+   * kind must pass this back through {@link openAddData}, since closing clears
+   * the shell's copy.
+   */
+  targetGroupId: string | null;
   martin: MartinConnection;
 }
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
@@ -40,7 +40,10 @@ export function classifyCswResource(url: string, scheme = ""): CswResourceKind {
   }
   if (/\bwfs\b/.test(protocol) || /service=wfs|\/wfs(?:[/?]|$)/.test(value)) return "wfs";
   const both = `${protocol} ${value}`;
-  if (/arcgis|featureserver|mapserver|imageserver/.test(both)) return "arcgis";
+  // Esri REST endpoints end in a /MapServer, /FeatureServer or /ImageServer
+  // path segment. A bare substring would also claim UMN MapServer's
+  // "/cgi-bin/mapserver.cgi", which ArcGISSource cannot open.
+  if (/arcgis|\/(?:feature|map|image)server(?:[/?]|$)/.test(both)) return "arcgis";
   if (/geojson|\.geojson(?:[?#]|$)|[?&](?:f|format)=geojson/.test(both)) return "geojson";
   return "unknown";
 }
@@ -202,5 +205,11 @@ export async function fetchCswGeoJson(url: string): Promise<GeoJSON.FeatureColle
     if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
     text = await response.text();
   }
-  return JSON.parse(text) as GeoJSON.FeatureCollection;
+  try {
+    return JSON.parse(text) as GeoJSON.FeatureCollection;
+  } catch {
+    // A misconfigured host can answer 200 with an HTML error page; a raw
+    // SyntaxError ("Unexpected token '<'") would surface verbatim to the user.
+    throw new Error("The resource did not return GeoJSON.");
+  }
 }

--- a/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
@@ -155,6 +155,14 @@ export async function searchCsw(endpoint: string, keyword: string, signal?: Abor
   }
 }
 
+/** A catalog can advertise any JSON under a GeoJSON scheme, so check the shape
+ * the map actually needs — `type` alone leaves `features` free to be missing. */
+export function isCswFeatureCollection(value: unknown): value is GeoJSON.FeatureCollection {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { type?: unknown; features?: unknown };
+  return candidate.type === "FeatureCollection" && Array.isArray(candidate.features);
+}
+
 /** Downloads a GeoJSON resource advertised by a CSW record using the same
  * CORS-safe desktop/dev transport as catalog requests. */
 export async function fetchCswGeoJson(url: string): Promise<GeoJSON.FeatureCollection> {

--- a/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
@@ -1,0 +1,144 @@
+import { fetchUrlBytes } from "../../../lib/native-http";
+import { isTauri } from "../../../lib/is-tauri";
+import { CSW_PROXY_PATH } from "./constants";
+
+export type CswResourceKind = "wms" | "wfs" | "arcgis" | "geojson" | "unknown";
+
+export interface CswResource {
+  url: string;
+  kind: CswResourceKind;
+  name?: string;
+}
+
+export interface CswRecord {
+  identifier: string;
+  title: string;
+  abstract: string;
+  resources: CswResource[];
+}
+
+function hasLocalName(element: Element, name: string): boolean {
+  return element.localName === name || element.tagName.split(":").pop() === name;
+}
+
+function childText(element: Element, localName: string): string {
+  const node = Array.from(element.querySelectorAll("*")).find((candidate) =>
+    hasLocalName(candidate, localName),
+  );
+  return (node?.textContent ?? "").trim();
+}
+
+export function classifyCswResource(url: string, scheme = ""): CswResourceKind {
+  const value = `${scheme} ${url}`.toLowerCase();
+  if (/\bwms\b|service=wms|\/wms(?:server)?(?:[/?]|$)/.test(value)) return "wms";
+  if (/\bwfs\b|service=wfs|\/wfs(?:[/?]|$)/.test(value)) return "wfs";
+  if (/arcgis|featureserver|mapserver|imageserver/.test(value)) return "arcgis";
+  if (/geojson|\.geojson(?:[?#]|$)|[?&](?:f|format)=geojson/.test(value)) return "geojson";
+  return "unknown";
+}
+
+export function parseCswRecords(xmlText: string): CswRecord[] {
+  const doc = new DOMParser().parseFromString(xmlText, "application/xml");
+  if (doc.querySelector("parsererror")) throw new Error("Could not parse the CSW response.");
+  const root = doc.documentElement;
+  if (root?.localName === "ExceptionReport" || root?.localName === "ServiceExceptionReport") {
+    throw new Error(
+      (root.textContent ?? "The CSW service returned an error.").trim().slice(0, 500),
+    );
+  }
+  const elements = Array.from(doc.querySelectorAll("*")).filter((element) =>
+    hasLocalName(element, "Record"),
+  );
+  return elements.map((record, index) => {
+    const resources: CswResource[] = [];
+    for (const localName of ["URI", "references"]) {
+      for (const node of Array.from(record.querySelectorAll("*")).filter((element) =>
+        hasLocalName(element, localName),
+      )) {
+        const url = (node.textContent ?? "").trim();
+        if (!/^https?:\/\//i.test(url) || resources.some((item) => item.url === url)) continue;
+        const scheme = node.getAttribute("protocol") ?? node.getAttribute("scheme") ?? "";
+        resources.push({
+          url,
+          kind: classifyCswResource(url, scheme),
+          name: node.getAttribute("name") ?? undefined,
+        });
+      }
+    }
+    return {
+      identifier: childText(record, "identifier") || `record-${index}`,
+      title: childText(record, "title") || childText(record, "identifier") || "Untitled dataset",
+      abstract: childText(record, "abstract"),
+      resources,
+    };
+  });
+}
+
+export function createCswGetRecordsUrl(endpoint: string, keyword: string, maxRecords = 20): string {
+  const url = new URL(endpoint);
+  const operationKeys = new Set([
+    "service",
+    "request",
+    "version",
+    "typenames",
+    "elementsetname",
+    "resulttype",
+    "maxrecords",
+    "startposition",
+    "constraint",
+    "constraintlanguage",
+    "constraint_language_version",
+  ]);
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (operationKeys.has(key.toLowerCase())) url.searchParams.delete(key);
+  }
+  url.searchParams.set("service", "CSW");
+  url.searchParams.set("request", "GetRecords");
+  url.searchParams.set("version", "2.0.2");
+  url.searchParams.set("typeNames", "csw:Record");
+  url.searchParams.set("elementSetName", "full");
+  url.searchParams.set("resultType", "results");
+  url.searchParams.set("maxRecords", String(maxRecords));
+  const term = keyword.trim();
+  if (term) {
+    url.searchParams.set("constraintLanguage", "CQL_TEXT");
+    url.searchParams.set("constraint_language_version", "1.1.0");
+    url.searchParams.set("constraint", `csw:AnyText LIKE '%${term.replaceAll("'", "''")}%'`);
+  }
+  return url.toString();
+}
+
+export async function searchCsw(endpoint: string, keyword: string, signal?: AbortSignal) {
+  const fetchRecords = async (requestUrl: string) => {
+    let text: string;
+    if (isTauri()) {
+      const bytes = await fetchUrlBytes(requestUrl, { context: "CSW GetRecords" });
+      text = new TextDecoder().decode(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes));
+    } else {
+      const url = import.meta.env.DEV
+        ? `${CSW_PROXY_PATH}?url=${encodeURIComponent(requestUrl)}`
+        : requestUrl;
+      const response = await fetch(url, { signal });
+      if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+      text = await response.text();
+    }
+    return parseCswRecords(text);
+  };
+
+  const term = keyword.trim();
+  try {
+    return await fetchRecords(createCswGetRecordsUrl(endpoint, term));
+  } catch (error) {
+    // A number of otherwise conforming CSW 2.0.2 servers reject wildcard CQL.
+    // Fall back to a larger unfiltered page and filter locally so keyword search
+    // remains useful rather than exposing the server's parser limitation.
+    if (!term || signal?.aborted) throw error;
+    const records = await fetchRecords(createCswGetRecordsUrl(endpoint, "", 100));
+    const needle = term.toLocaleLowerCase();
+    return records.filter((record) =>
+      `${record.title} ${record.abstract} ${record.identifier}`
+        .toLocaleLowerCase()
+        .includes(needle),
+    );
+  }
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
@@ -29,11 +29,19 @@ function childText(element: Element, localName: string): string {
 }
 
 export function classifyCswResource(url: string, scheme = ""): CswResourceKind {
-  const value = `${scheme} ${url}`.toLowerCase();
-  if (/\bwms\b|service=wms|\/wms(?:server)?(?:[/?]|$)/.test(value)) return "wms";
-  if (/\bwfs\b|service=wfs|\/wfs(?:[/?]|$)/.test(value)) return "wfs";
-  if (/arcgis|featureserver|mapserver|imageserver/.test(value)) return "arcgis";
-  if (/geojson|\.geojson(?:[?#]|$)|[?&](?:f|format)=geojson/.test(value)) return "geojson";
+  // The protocol/scheme attribute is a service token ("OGC:WMS"), so a bare
+  // word match belongs there. A URL is not: ".../wms-user-guide.pdf" is a
+  // document, so require the service parameter or a /wms path segment instead,
+  // or the button offered would fail on click.
+  const protocol = scheme.toLowerCase();
+  const value = url.toLowerCase();
+  if (/\bwms\b/.test(protocol) || /service=wms|\/wms(?:server)?(?:[/?]|$)/.test(value)) {
+    return "wms";
+  }
+  if (/\bwfs\b/.test(protocol) || /service=wfs|\/wfs(?:[/?]|$)/.test(value)) return "wfs";
+  const both = `${protocol} ${value}`;
+  if (/arcgis|featureserver|mapserver|imageserver/.test(both)) return "arcgis";
+  if (/geojson|\.geojson(?:[?#]|$)|[?&](?:f|format)=geojson/.test(both)) return "geojson";
   return "unknown";
 }
 
@@ -145,7 +153,15 @@ export async function searchCsw(endpoint: string, keyword: string, signal?: Abor
     // Fall back to a larger unfiltered page and filter locally so keyword search
     // remains useful rather than exposing the server's parser limitation.
     if (!term || signal?.aborted) throw error;
-    const records = await fetchRecords(createCswGetRecordsUrl(endpoint, "", 100));
+    let records: CswRecord[];
+    try {
+      records = await fetchRecords(createCswGetRecordsUrl(endpoint, "", 100));
+    } catch {
+      // The retry only exists to work around wildcard-CQL rejection. When it
+      // fails too the endpoint is unreachable or wrong, and the first error
+      // describes that far better than the retry's, so report the original.
+      throw error;
+    }
     const needle = term.toLocaleLowerCase();
     return records.filter((record) =>
       `${record.title} ${record.abstract} ${record.identifier}`
@@ -160,7 +176,10 @@ export async function searchCsw(endpoint: string, keyword: string, signal?: Abor
 export function isCswFeatureCollection(value: unknown): value is GeoJSON.FeatureCollection {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as { type?: unknown; features?: unknown };
-  return candidate.type === "FeatureCollection" && Array.isArray(candidate.features);
+  if (candidate.type !== "FeatureCollection" || !Array.isArray(candidate.features)) return false;
+  // A member that isn't an object (a `null` placeholder, a bare id) would reach
+  // the layer store and break rendering, so reject the whole document.
+  return candidate.features.every((feature) => typeof feature === "object" && feature !== null);
 }
 
 /** Downloads a GeoJSON resource advertised by a CSW record using the same

--- a/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
@@ -54,8 +54,13 @@ export function parseCswRecords(xmlText: string): CswRecord[] {
       (root.textContent ?? "The CSW service returned an error.").trim().slice(0, 500),
     );
   }
-  const elements = Array.from(doc.querySelectorAll("*")).filter((element) =>
-    hasLocalName(element, "Record"),
+  // A server may answer elementSetName=full with SummaryRecord/BriefRecord
+  // instead; parsing only "Record" would report those catalogs as empty.
+  const elements = Array.from(doc.querySelectorAll("*")).filter(
+    (element) =>
+      hasLocalName(element, "Record") ||
+      hasLocalName(element, "SummaryRecord") ||
+      hasLocalName(element, "BriefRecord"),
   );
   return elements.map((record, index) => {
     const resources: CswResource[] = [];

--- a/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
@@ -142,3 +142,21 @@ export async function searchCsw(endpoint: string, keyword: string, signal?: Abor
     );
   }
 }
+
+/** Downloads a GeoJSON resource advertised by a CSW record using the same
+ * CORS-safe desktop/dev transport as catalog requests. */
+export async function fetchCswGeoJson(url: string): Promise<GeoJSON.FeatureCollection> {
+  let text: string;
+  if (isTauri()) {
+    const bytes = await fetchUrlBytes(url, { context: "CSW GeoJSON resource" });
+    text = new TextDecoder().decode(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes));
+  } else {
+    const requestUrl = import.meta.env.DEV
+      ? `${CSW_PROXY_PATH}?url=${encodeURIComponent(url)}`
+      : url;
+    const response = await fetch(requestUrl);
+    if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+    text = await response.text();
+  }
+  return JSON.parse(text) as GeoJSON.FeatureCollection;
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/csw.ts
@@ -74,6 +74,18 @@ export function parseCswRecords(xmlText: string): CswRecord[] {
   });
 }
 
+/** True when the endpoint is an absolute http(s) URL. A bare `https://` passes a
+ * `^https?://` regex but makes {@link createCswGetRecordsUrl} throw, so callers
+ * validate here to surface their own message instead of a raw `TypeError`. */
+export function isHttpCswEndpoint(endpoint: string): boolean {
+  try {
+    const { protocol } = new URL(endpoint);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function createCswGetRecordsUrl(endpoint: string, keyword: string, maxRecords = 20): string {
   const url = new URL(endpoint);
   const operationKeys = new Set([

--- a/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
@@ -24,6 +24,10 @@ export interface OpenAddDataDetail {
   postgres?: OpenAddDataPostgres;
   /** Layers created before this dialog closes are moved into this group. */
   groupId?: string;
+  /** Service URL used to prefill URL-based Add Data forms. */
+  url?: string;
+  /** Optional WMS layer or WFS feature type advertised by a catalog. */
+  layer?: string;
 }
 
 /**
@@ -37,12 +41,18 @@ export interface OpenAddDataDetail {
  */
 export function openAddData(
   kind: AddDataKind,
-  options?: { postgres?: OpenAddDataPostgres; groupId?: string },
+  options?: { postgres?: OpenAddDataPostgres; groupId?: string; url?: string; layer?: string },
 ): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(
     new CustomEvent<OpenAddDataDetail>(OPEN_ADD_DATA_EVENT, {
-      detail: { kind, postgres: options?.postgres, groupId: options?.groupId },
+      detail: {
+        kind,
+        postgres: options?.postgres,
+        groupId: options?.groupId,
+        url: options?.url,
+        layer: options?.layer,
+      },
     }),
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
@@ -28,6 +28,8 @@ export interface OpenAddDataDetail {
   url?: string;
   /** Optional WMS layer or WFS feature type advertised by a catalog. */
   layer?: string;
+  /** Saved search term for the CSW source (only meaningful when `kind` is "csw"). */
+  keyword?: string;
 }
 
 /**
@@ -41,7 +43,13 @@ export interface OpenAddDataDetail {
  */
 export function openAddData(
   kind: AddDataKind,
-  options?: { postgres?: OpenAddDataPostgres; groupId?: string; url?: string; layer?: string },
+  options?: {
+    postgres?: OpenAddDataPostgres;
+    groupId?: string;
+    url?: string;
+    layer?: string;
+    keyword?: string;
+  },
 ): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(
@@ -52,6 +60,7 @@ export function openAddData(
         groupId: options?.groupId,
         url: options?.url,
         layer: options?.layer,
+        keyword: options?.keyword,
       },
     }),
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -27,7 +27,7 @@ import {
 } from "./constants";
 
 /** The web-service source kinds that participate in the saved library. */
-export type ServiceLibraryKind = "wms" | "wfs" | "wmts" | "xyz" | "arcgis";
+export type ServiceLibraryKind = "wms" | "wfs" | "wmts" | "xyz" | "arcgis" | "csw";
 
 export type ServiceFieldValue = string | number | boolean;
 
@@ -48,7 +48,7 @@ export interface ServiceLibraryEntry {
   builtin?: boolean;
 }
 
-const SERVICE_KINDS: readonly ServiceLibraryKind[] = ["wms", "wfs", "wmts", "xyz", "arcgis"];
+const SERVICE_KINDS: readonly ServiceLibraryKind[] = ["wms", "wfs", "wmts", "xyz", "arcgis", "csw"];
 
 /** Label used for entries that have no category set. */
 export const UNCATEGORIZED_LABEL = "Uncategorized";

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -7,7 +7,13 @@ import { openAddData } from "../open-add-data";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import { serviceFieldString, type ServiceLibraryEntry } from "../service-library";
 import { AddDataError, useAddDataSource } from "../shared";
-import { fetchCswGeoJson, searchCsw, type CswRecord, type CswResource } from "../csw";
+import {
+  fetchCswGeoJson,
+  isHttpCswEndpoint,
+  searchCsw,
+  type CswRecord,
+  type CswResource,
+} from "../csw";
 
 export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
   const { t } = useTranslation();
@@ -25,7 +31,7 @@ export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
   const handleSearch = async (event: FormEvent) => {
     event.preventDefault();
     source.setError(null);
-    if (!/^https?:\/\//i.test(endpoint.trim())) {
+    if (!isHttpCswEndpoint(endpoint.trim())) {
       source.setError(t("addData.csw.errorUrl"));
       return;
     }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -49,13 +49,23 @@ export function CswSource({
   // list, so abandon the request when the source unmounts.
   useEffect(() => () => searchAbortRef.current?.abort(), []);
 
+  // Abandon a request still in flight. An aborted search skips the spinner reset
+  // in its own `finally` (so it cannot clear a spinner a newer search turned
+  // on), which leaves this the only place that clears it when nothing replaces
+  // the abandoned request.
+  const abortSearch = () => {
+    searchAbortRef.current?.abort();
+    searchAbortRef.current = null;
+    setIsSearching(false);
+  };
+
   const applySaved = (entry: ServiceLibraryEntry) => {
     setEndpoint(serviceFieldString(entry.fields, "endpoint"));
     setKeyword(serviceFieldString(entry.fields, "keyword"));
     // The results belong to the previous catalog and their resource URLs would
     // still be addable, so drop them — and any search still in flight for that
     // catalog — until the new endpoint is searched.
-    searchAbortRef.current?.abort();
+    abortSearch();
     setRecords([]);
     setRecordsEndpoint("");
     source.setError(null);
@@ -66,7 +76,7 @@ export function CswSource({
     source.setError(null);
     const target = endpoint.trim();
     // Whatever the previous search was about to return is now stale.
-    searchAbortRef.current?.abort();
+    abortSearch();
     setRecords([]);
     setRecordsEndpoint("");
     if (!isHttpCswEndpoint(target)) {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Label } from "@geolibre/ui";
 import { ExternalLink, Loader2, Search } from "lucide-react";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createBaseLayer } from "../helpers";
 import { openAddData } from "../open-add-data";
@@ -38,34 +38,57 @@ export function CswSource({
   const [endpoint, setEndpoint] = useState(initialUrl);
   const [keyword, setKeyword] = useState(initialKeyword);
   const [records, setRecords] = useState<CswRecord[]>([]);
+  // The endpoint these records came from. Results are only shown (and only
+  // recorded as a layer's catalog) while it still matches the field, so an
+  // edited endpoint can never leave another catalog's resources addable.
+  const [recordsEndpoint, setRecordsEndpoint] = useState("");
   const [isSearching, setIsSearching] = useState(false);
+  const searchAbortRef = useRef<AbortController | null>(null);
+
+  // A response that arrives after the form moved on must not repopulate the
+  // list, so abandon the request when the source unmounts.
+  useEffect(() => () => searchAbortRef.current?.abort(), []);
 
   const applySaved = (entry: ServiceLibraryEntry) => {
     setEndpoint(serviceFieldString(entry.fields, "endpoint"));
     setKeyword(serviceFieldString(entry.fields, "keyword"));
     // The results belong to the previous catalog and their resource URLs would
-    // still be addable, so drop them until the new endpoint is searched.
+    // still be addable, so drop them — and any search still in flight for that
+    // catalog — until the new endpoint is searched.
+    searchAbortRef.current?.abort();
     setRecords([]);
+    setRecordsEndpoint("");
     source.setError(null);
   };
 
   const handleSearch = async (event: FormEvent) => {
     event.preventDefault();
     source.setError(null);
-    if (!isHttpCswEndpoint(endpoint.trim())) {
+    const target = endpoint.trim();
+    // Whatever the previous search was about to return is now stale.
+    searchAbortRef.current?.abort();
+    setRecords([]);
+    setRecordsEndpoint("");
+    if (!isHttpCswEndpoint(target)) {
       source.setError(t("addData.csw.errorUrl"));
       return;
     }
+    const controller = new AbortController();
+    searchAbortRef.current = controller;
     setIsSearching(true);
     try {
-      const next = await searchCsw(endpoint.trim(), keyword);
+      const next = await searchCsw(target, keyword, controller.signal);
+      if (controller.signal.aborted) return;
       setRecords(next);
+      setRecordsEndpoint(target);
       if (next.length === 0) source.setError(t("addData.csw.noResults"));
     } catch (error) {
+      if (controller.signal.aborted) return;
       source.setError(error instanceof Error ? error.message : t("addData.csw.searchError"));
       setRecords([]);
     } finally {
-      setIsSearching(false);
+      // A superseded search must not clear the spinner the newer one turned on.
+      if (!controller.signal.aborted) setIsSearching(false);
     }
   };
 
@@ -83,7 +106,7 @@ export function CswSource({
               { type: "geojson", data: geojson },
               {
                 sourceKind: "csw",
-                catalogUrl: endpoint,
+                catalogUrl: recordsEndpoint,
               },
               { geojson },
             ),
@@ -110,6 +133,10 @@ export function CswSource({
       window.setTimeout(() => openAddData(kind, { url: resource.url, layer }), 0);
     }
   };
+
+  // Typing a new endpoint without searching leaves the old results on screen;
+  // they describe a catalog the form no longer points at, so hide them.
+  const visibleRecords = recordsEndpoint === endpoint.trim() ? records : [];
 
   return (
     <form className="space-y-4" onSubmit={handleSearch}>
@@ -143,9 +170,9 @@ export function CswSource({
         </div>
       </div>
       {source.error ? <AddDataError message={source.error} /> : null}
-      {records.length > 0 ? (
+      {visibleRecords.length > 0 ? (
         <div className="max-h-80 space-y-2 overflow-y-auto" aria-label={t("addData.csw.results")}>
-          {records.map((record) => (
+          {visibleRecords.map((record) => (
             <article key={record.identifier} className="space-y-2 rounded-md border p-3">
               <div className="font-medium">{record.title}</div>
               {record.abstract ? (

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -9,6 +9,7 @@ import { serviceFieldString, type ServiceLibraryEntry } from "../service-library
 import { AddDataError, useAddDataSource } from "../shared";
 import {
   fetchCswGeoJson,
+  isCswFeatureCollection,
   isHttpCswEndpoint,
   searchCsw,
   type CswRecord,
@@ -25,11 +26,17 @@ const RESOURCE_LABEL: Record<CswResource["kind"], string> = {
   unknown: "",
 };
 
-export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
+export function CswSource({
+  initialUrl = "",
+  initialKeyword = "",
+}: {
+  initialUrl?: string;
+  initialKeyword?: string;
+}) {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.csw.defaultName"));
   const [endpoint, setEndpoint] = useState(initialUrl);
-  const [keyword, setKeyword] = useState("");
+  const [keyword, setKeyword] = useState(initialKeyword);
   const [records, setRecords] = useState<CswRecord[]>([]);
   const [isSearching, setIsSearching] = useState(false);
 
@@ -67,7 +74,7 @@ export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
     if (resource.kind === "geojson") {
       try {
         const geojson = await fetchCswGeoJson(resource.url);
-        if (geojson.type !== "FeatureCollection") throw new Error(t("addData.csw.invalidGeoJson"));
+        if (!isCswFeatureCollection(geojson)) throw new Error(t("addData.csw.invalidGeoJson"));
         source.addAndClose(
           {
             ...createBaseLayer(

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -2,11 +2,12 @@ import { Button, Input, Label } from "@geolibre/ui";
 import { ExternalLink, Loader2, Search } from "lucide-react";
 import { type FormEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { CSW_SAMPLES } from "../constants";
 import { createBaseLayer } from "../helpers";
 import { openAddData } from "../open-add-data";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import { serviceFieldString, type ServiceLibraryEntry } from "../service-library";
-import { AddDataError, useAddDataSource } from "../shared";
+import { AddDataError, SampleDataSelect, useAddDataSource } from "../shared";
 import {
   fetchCswGeoJson,
   isCswFeatureCollection,
@@ -59,16 +60,24 @@ export function CswSource({
     setIsSearching(false);
   };
 
-  const applySaved = (entry: ServiceLibraryEntry) => {
-    setEndpoint(serviceFieldString(entry.fields, "endpoint"));
-    setKeyword(serviceFieldString(entry.fields, "keyword"));
-    // The results belong to the previous catalog and their resource URLs would
-    // still be addable, so drop them — and any search still in flight for that
-    // catalog — until the new endpoint is searched.
+  // Points the form at another catalog. The results on screen belong to the
+  // previous one and their resource URLs would still be addable, so drop them —
+  // and any search still in flight for that catalog — until the new endpoint is
+  // searched.
+  const applyCatalog = (next: { endpoint: string; keyword: string }) => {
+    setEndpoint(next.endpoint);
+    setKeyword(next.keyword);
     abortSearch();
     setRecords([]);
     setRecordsEndpoint("");
     source.setError(null);
+  };
+
+  const applySaved = (entry: ServiceLibraryEntry) => {
+    applyCatalog({
+      endpoint: serviceFieldString(entry.fields, "endpoint"),
+      keyword: serviceFieldString(entry.fields, "keyword"),
+    });
   };
 
   const handleSearch = async (event: FormEvent) => {
@@ -217,6 +226,13 @@ export function CswSource({
           ))}
         </div>
       ) : null}
+      <SampleDataSelect
+        samples={CSW_SAMPLES.map((sample) => ({
+          label: sample.label,
+          value: { endpoint: sample.endpoint, keyword: sample.keyword },
+        }))}
+        onSelect={applyCatalog}
+      />
       <div className="flex justify-end">
         <Button type="button" variant="outline" onClick={source.shell.closeDialog}>
           {t("common.close")}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -136,11 +136,15 @@ export function CswSource({
       // sublayer ids, not the catalog's human-readable resource name — so only
       // WMS/WFS get the layer hint.
       const layer = kind === "arcgis" ? undefined : resource.name;
+      // Closing clears the shell's target group (no layer was added yet), so
+      // carry it into the reopened dialog or an "Add data to group" session
+      // would silently drop the layer outside the group.
+      const groupId = source.shell.targetGroupId ?? undefined;
       // Close first so the dialog remounts on the new kind, then reopen on the
       // next tick: openAddData sets the kind through the same shell state the
       // close is clearing, and a same-tick call would be overwritten.
       source.shell.closeDialog();
-      window.setTimeout(() => openAddData(kind, { url: resource.url, layer }), 0);
+      window.setTimeout(() => openAddData(kind, { url: resource.url, layer, groupId }), 0);
     }
   };
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -1,0 +1,154 @@
+import { Button, Input, Label } from "@geolibre/ui";
+import { ExternalLink, Loader2, Search } from "lucide-react";
+import { type FormEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { createBaseLayer } from "../helpers";
+import { openAddData } from "../open-add-data";
+import { ServiceLibrarySection } from "../ServiceLibrarySection";
+import { serviceFieldString, type ServiceLibraryEntry } from "../service-library";
+import { AddDataError, useAddDataSource } from "../shared";
+import { searchCsw, type CswRecord, type CswResource } from "../csw";
+
+export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.csw.defaultName"));
+  const [endpoint, setEndpoint] = useState(initialUrl);
+  const [keyword, setKeyword] = useState("");
+  const [records, setRecords] = useState<CswRecord[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const applySaved = (entry: ServiceLibraryEntry) => {
+    setEndpoint(serviceFieldString(entry.fields, "endpoint"));
+    setKeyword(serviceFieldString(entry.fields, "keyword"));
+  };
+
+  const handleSearch = async (event: FormEvent) => {
+    event.preventDefault();
+    source.setError(null);
+    if (!/^https?:\/\//i.test(endpoint.trim())) {
+      source.setError(t("addData.csw.errorUrl"));
+      return;
+    }
+    setIsSearching(true);
+    try {
+      const next = await searchCsw(endpoint.trim(), keyword);
+      setRecords(next);
+      if (next.length === 0) source.setError(t("addData.csw.noResults"));
+    } catch (error) {
+      source.setError(error instanceof Error ? error.message : t("addData.csw.searchError"));
+      setRecords([]);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const addResource = async (record: CswRecord, resource: CswResource) => {
+    source.setError(null);
+    if (resource.kind === "geojson") {
+      try {
+        const response = await fetch(resource.url);
+        if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+        const geojson = (await response.json()) as GeoJSON.FeatureCollection;
+        if (geojson.type !== "FeatureCollection") throw new Error(t("addData.csw.invalidGeoJson"));
+        source.addAndClose(
+          {
+            ...createBaseLayer(
+              record.title,
+              "geojson",
+              { type: "geojson", data: geojson },
+              {
+                sourceKind: "csw",
+                catalogUrl: endpoint,
+              },
+              { geojson },
+            ),
+            geojson,
+            sourcePath: resource.url,
+          },
+          { fit: true },
+        );
+      } catch (error) {
+        source.setError(error instanceof Error ? error.message : t("addData.csw.addError"));
+      }
+      return;
+    }
+    if (resource.kind === "wms" || resource.kind === "wfs" || resource.kind === "arcgis") {
+      const kind = resource.kind;
+      source.shell.closeDialog();
+      window.setTimeout(() => openAddData(kind, { url: resource.url, layer: resource.name }), 0);
+    }
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSearch}>
+      <ServiceLibrarySection
+        kind="csw"
+        layerName={t("addData.csw.defaultName")}
+        getFields={() => ({ endpoint, keyword })}
+        onApply={applySaved}
+      />
+      <div className="space-y-1.5">
+        <Label htmlFor="csw-endpoint">{t("addData.common.serviceUrl")}</Label>
+        <Input
+          id="csw-endpoint"
+          value={endpoint}
+          onChange={(e) => setEndpoint(e.target.value)}
+          placeholder={t("addData.csw.urlPlaceholder")}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="csw-keyword">{t("addData.csw.keyword")}</Label>
+        <div className="flex gap-2">
+          <Input id="csw-keyword" value={keyword} onChange={(e) => setKeyword(e.target.value)} />
+          <Button type="submit" disabled={isSearching || !endpoint.trim()}>
+            {isSearching ? (
+              <Loader2 className="me-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Search className="me-2 h-4 w-4" />
+            )}
+            {isSearching ? t("addData.csw.searching") : t("addData.csw.search")}
+          </Button>
+        </div>
+      </div>
+      {source.error ? <AddDataError message={source.error} /> : null}
+      {records.length > 0 ? (
+        <div className="max-h-80 space-y-2 overflow-y-auto" aria-label={t("addData.csw.results")}>
+          {records.map((record) => (
+            <article key={record.identifier} className="space-y-2 rounded-md border p-3">
+              <div className="font-medium">{record.title}</div>
+              {record.abstract ? (
+                <p className="line-clamp-3 text-sm text-muted-foreground">{record.abstract}</p>
+              ) : null}
+              <div className="flex flex-wrap gap-2">
+                {record.resources
+                  .filter((item) => item.kind !== "unknown")
+                  .map((resource) => (
+                    <Button
+                      key={resource.url}
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void addResource(record, resource)}
+                    >
+                      <ExternalLink className="me-1.5 h-3.5 w-3.5" />
+                      {t("addData.csw.addResource", { kind: resource.kind.toUpperCase() })}
+                    </Button>
+                  ))}
+                {record.resources.every((item) => item.kind === "unknown") ? (
+                  <span className="text-xs text-muted-foreground">
+                    {t("addData.csw.noSupportedResources")}
+                  </span>
+                ) : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+      <div className="flex justify-end">
+        <Button type="button" variant="outline" onClick={source.shell.closeDialog}>
+          {t("common.close")}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -15,6 +15,16 @@ import {
   type CswResource,
 } from "../csw";
 
+/** Display casing for resource buttons; `kind.toUpperCase()` would render
+ * "ARCGIS"/"GEOJSON" instead of the casing used elsewhere in the UI. */
+const RESOURCE_LABEL: Record<CswResource["kind"], string> = {
+  wms: "WMS",
+  wfs: "WFS",
+  arcgis: "ArcGIS",
+  geojson: "GeoJSON",
+  unknown: "",
+};
+
 export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.csw.defaultName"));
@@ -26,6 +36,10 @@ export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
   const applySaved = (entry: ServiceLibraryEntry) => {
     setEndpoint(serviceFieldString(entry.fields, "endpoint"));
     setKeyword(serviceFieldString(entry.fields, "keyword"));
+    // The results belong to the previous catalog and their resource URLs would
+    // still be addable, so drop them until the new endpoint is searched.
+    setRecords([]);
+    source.setError(null);
   };
 
   const handleSearch = async (event: FormEvent) => {
@@ -78,8 +92,15 @@ export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
     }
     if (resource.kind === "wms" || resource.kind === "wfs" || resource.kind === "arcgis") {
       const kind = resource.kind;
+      // ArcGISSource has no layer prop — its equivalent field takes numeric
+      // sublayer ids, not the catalog's human-readable resource name — so only
+      // WMS/WFS get the layer hint.
+      const layer = kind === "arcgis" ? undefined : resource.name;
+      // Close first so the dialog remounts on the new kind, then reopen on the
+      // next tick: openAddData sets the kind through the same shell state the
+      // close is clearing, and a same-tick call would be overwritten.
       source.shell.closeDialog();
-      window.setTimeout(() => openAddData(kind, { url: resource.url, layer: resource.name }), 0);
+      window.setTimeout(() => openAddData(kind, { url: resource.url, layer }), 0);
     }
   };
 
@@ -135,7 +156,7 @@ export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
                       onClick={() => void addResource(record, resource)}
                     >
                       <ExternalLink className="me-1.5 h-3.5 w-3.5" />
-                      {t("addData.csw.addResource", { kind: resource.kind.toUpperCase() })}
+                      {t("addData.csw.addResource", { kind: RESOURCE_LABEL[resource.kind] })}
                     </Button>
                   ))}
                 {record.resources.every((item) => item.kind === "unknown") ? (

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -1,0 +1,154 @@
+import { Button, Input, Label } from "@geolibre/ui";
+import { ExternalLink, Loader2, Search } from "lucide-react";
+import { type FormEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { createBaseLayer } from "../helpers";
+import { openAddData } from "../open-add-data";
+import { ServiceLibrarySection } from "../ServiceLibrarySection";
+import { serviceFieldString, type ServiceLibraryEntry } from "../service-library";
+import { AddDataError, useAddDataSource } from "../shared";
+import { searchCsw, type CswRecord, type CswResource } from "../csw";
+
+export function CswSource() {
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.csw.defaultName"));
+  const [endpoint, setEndpoint] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [records, setRecords] = useState<CswRecord[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const applySaved = (entry: ServiceLibraryEntry) => {
+    setEndpoint(serviceFieldString(entry.fields, "endpoint"));
+    setKeyword(serviceFieldString(entry.fields, "keyword"));
+  };
+
+  const handleSearch = async (event: FormEvent) => {
+    event.preventDefault();
+    source.setError(null);
+    if (!/^https?:\/\//i.test(endpoint.trim())) {
+      source.setError(t("addData.csw.errorUrl"));
+      return;
+    }
+    setIsSearching(true);
+    try {
+      const next = await searchCsw(endpoint.trim(), keyword);
+      setRecords(next);
+      if (next.length === 0) source.setError(t("addData.csw.noResults"));
+    } catch (error) {
+      source.setError(error instanceof Error ? error.message : t("addData.csw.searchError"));
+      setRecords([]);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const addResource = async (record: CswRecord, resource: CswResource) => {
+    source.setError(null);
+    if (resource.kind === "geojson") {
+      try {
+        const response = await fetch(resource.url);
+        if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+        const geojson = (await response.json()) as GeoJSON.FeatureCollection;
+        if (geojson.type !== "FeatureCollection") throw new Error(t("addData.csw.invalidGeoJson"));
+        source.addAndClose(
+          {
+            ...createBaseLayer(
+              record.title,
+              "geojson",
+              { type: "geojson", data: geojson },
+              {
+                sourceKind: "csw",
+                catalogUrl: endpoint,
+              },
+              { geojson },
+            ),
+            geojson,
+            sourcePath: resource.url,
+          },
+          { fit: true },
+        );
+      } catch (error) {
+        source.setError(error instanceof Error ? error.message : t("addData.csw.addError"));
+      }
+      return;
+    }
+    if (resource.kind === "wms" || resource.kind === "wfs" || resource.kind === "arcgis") {
+      const kind = resource.kind;
+      source.shell.closeDialog();
+      window.setTimeout(() => openAddData(kind, { url: resource.url, layer: resource.name }), 0);
+    }
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSearch}>
+      <ServiceLibrarySection
+        kind="csw"
+        layerName={t("addData.csw.defaultName")}
+        getFields={() => ({ endpoint, keyword })}
+        onApply={applySaved}
+      />
+      <div className="space-y-1.5">
+        <Label htmlFor="csw-endpoint">{t("addData.common.serviceUrl")}</Label>
+        <Input
+          id="csw-endpoint"
+          value={endpoint}
+          onChange={(e) => setEndpoint(e.target.value)}
+          placeholder={t("addData.csw.urlPlaceholder")}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="csw-keyword">{t("addData.csw.keyword")}</Label>
+        <div className="flex gap-2">
+          <Input id="csw-keyword" value={keyword} onChange={(e) => setKeyword(e.target.value)} />
+          <Button type="submit" disabled={isSearching || !endpoint.trim()}>
+            {isSearching ? (
+              <Loader2 className="me-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Search className="me-2 h-4 w-4" />
+            )}
+            {isSearching ? t("addData.csw.searching") : t("addData.csw.search")}
+          </Button>
+        </div>
+      </div>
+      {source.error ? <AddDataError message={source.error} /> : null}
+      {records.length > 0 ? (
+        <div className="max-h-80 space-y-2 overflow-y-auto" aria-label={t("addData.csw.results")}>
+          {records.map((record) => (
+            <article key={record.identifier} className="space-y-2 rounded-md border p-3">
+              <div className="font-medium">{record.title}</div>
+              {record.abstract ? (
+                <p className="line-clamp-3 text-sm text-muted-foreground">{record.abstract}</p>
+              ) : null}
+              <div className="flex flex-wrap gap-2">
+                {record.resources
+                  .filter((item) => item.kind !== "unknown")
+                  .map((resource) => (
+                    <Button
+                      key={resource.url}
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void addResource(record, resource)}
+                    >
+                      <ExternalLink className="me-1.5 h-3.5 w-3.5" />
+                      {t("addData.csw.addResource", { kind: resource.kind.toUpperCase() })}
+                    </Button>
+                  ))}
+                {record.resources.every((item) => item.kind === "unknown") ? (
+                  <span className="text-xs text-muted-foreground">
+                    {t("addData.csw.noSupportedResources")}
+                  </span>
+                ) : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+      <div className="flex justify-end">
+        <Button type="button" variant="outline" onClick={source.shell.closeDialog}>
+          {t("common.close")}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CswSource.tsx
@@ -7,7 +7,7 @@ import { openAddData } from "../open-add-data";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import { serviceFieldString, type ServiceLibraryEntry } from "../service-library";
 import { AddDataError, useAddDataSource } from "../shared";
-import { searchCsw, type CswRecord, type CswResource } from "../csw";
+import { fetchCswGeoJson, searchCsw, type CswRecord, type CswResource } from "../csw";
 
 export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
   const { t } = useTranslation();
@@ -46,9 +46,7 @@ export function CswSource({ initialUrl = "" }: { initialUrl?: string }) {
     source.setError(null);
     if (resource.kind === "geojson") {
       try {
-        const response = await fetch(resource.url);
-        if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
-        const geojson = (await response.json()) as GeoJSON.FeatureCollection;
+        const geojson = await fetchCswGeoJson(resource.url);
         if (geojson.type !== "FeatureCollection") throw new Error(t("addData.csw.invalidGeoJson"));
         source.addAndClose(
           {

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -5,6 +5,7 @@
 export type AddDataKind =
   | "xyz"
   | "wms"
+  | "csw"
   | "wfs"
   | "wmts"
   | "ogc-features"

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -67,6 +67,7 @@ export function AddDataMenu({
     "osm-pbf": { onSelect: onOpenOsmPbfDialog, disabled: osmPbfBusy },
     xyz: { onSelect: () => onSetAddDataKind("xyz") },
     wms: { onSelect: () => onSetAddDataKind("wms") },
+    csw: { onSelect: () => onSetAddDataKind("csw") },
     wfs: { onSelect: () => onSetAddDataKind("wfs") },
     wmts: { onSelect: () => onSetAddDataKind("wmts") },
     "ogc-features": { onSelect: () => onSetAddDataKind("ogc-features") },

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -442,6 +442,12 @@ export function BrowserPanel({
         }
         return;
       }
+      if (entry.kind === "csw") {
+        openAddData("csw", {
+          url: typeof entry.fields.endpoint === "string" ? entry.fields.endpoint : undefined,
+        });
+        return;
+      }
       beginBusy(node.id);
       try {
         await applyServiceEntry(entry, { addLayer, mapControllerRef });

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -445,6 +445,9 @@ export function BrowserPanel({
       if (entry.kind === "csw") {
         openAddData("csw", {
           url: typeof entry.fields.endpoint === "string" ? entry.fields.endpoint : undefined,
+          // The entry saves the search term alongside the endpoint, so restore
+          // it too rather than reopening on an empty keyword field.
+          keyword: typeof entry.fields.keyword === "string" ? entry.fields.keyword : undefined,
         });
         return;
       }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -276,6 +276,10 @@
         "label": "Add WMS Layer",
         "description": "Add a WMS GetMap service as a tiled raster layer."
       },
+      "csw": {
+        "label": "Search CSW Catalog",
+        "description": "Search an OGC Catalogue Service for datasets and add supported web resources to the map."
+      },
       "wfs": {
         "label": "Add WFS Layer",
         "description": "Add WFS features by requesting GeoJSON from a GetFeature service."
@@ -426,6 +430,21 @@
       "noLayersFound": "No layers were found for this service.",
       "retrieveError": "Could not retrieve layers from this service.",
       "version": "WMS version"
+    },
+    "csw": {
+      "defaultName": "CSW Catalog",
+      "urlPlaceholder": "https://example.com/csw",
+      "keyword": "Keyword",
+      "search": "Search",
+      "searching": "Searching...",
+      "results": "Catalog results",
+      "errorUrl": "Enter a valid HTTP or HTTPS CSW service URL.",
+      "searchError": "Could not search this catalog.",
+      "noResults": "No matching datasets were found.",
+      "invalidGeoJson": "The selected resource is not a GeoJSON FeatureCollection.",
+      "addError": "Could not add this catalog resource.",
+      "addResource": "Add {{kind}}",
+      "noSupportedResources": "No supported WMS, WFS, ArcGIS, or GeoJSON resource was advertised."
     },
     "wfs": {
       "defaultName": "WFS Layer",
@@ -2437,6 +2456,7 @@
       "mbtiles": "MBTiles Layer",
       "xyz": "XYZ Layer",
       "wms": "WMS Layer",
+      "csw": "CSW Catalog",
       "wfs": "WFS Layer",
       "wmts": "WMTS Layer",
       "ogcFeatures": "OGC API - Features",

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -162,10 +162,11 @@ const KIND_LABEL: Record<ServiceLibraryKind, string> = {
   wfs: "WFS",
   wmts: "WMTS",
   arcgis: "ArcGIS",
+  csw: "CSW",
 };
 
 /** Kind grouping order under Services, mirroring the Add Data source order. */
-const KIND_ORDER: readonly ServiceLibraryKind[] = ["xyz", "wms", "wfs", "wmts", "arcgis"];
+const KIND_ORDER: readonly ServiceLibraryKind[] = ["xyz", "wms", "wfs", "wmts", "arcgis", "csw"];
 
 /**
  * Groups services by kind (XYZ / WMS / WFS / WMTS / ArcGIS) so the tree mirrors

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -166,7 +166,7 @@ const KIND_LABEL: Record<ServiceLibraryKind, string> = {
 };
 
 /** Kind grouping order under Services, mirroring the Add Data source order. */
-const KIND_ORDER: readonly ServiceLibraryKind[] = ["xyz", "wms", "wfs", "wmts", "arcgis", "csw"];
+const KIND_ORDER: readonly ServiceLibraryKind[] = ["xyz", "wms", "csw", "wfs", "wmts", "arcgis"];
 
 /**
  * Groups services by kind (XYZ / WMS / WFS / WMTS / ArcGIS) so the tree mirrors

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -15,6 +15,12 @@ import { isIcebergLayer } from "./iceberg";
 // GeoRSS refreshes; the name is historical.
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
 const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
+const CSW_PROXY_PATH = "/__geolibre_csw_proxy";
+// Add Data tags a layer built from a CSW record's GeoJSON resource with this
+// sourceKind. Canonical copy is CSW_SOURCE_KIND-equivalent literal in
+// components/layout/add-data/sources/CswSource.tsx; kept local for the same
+// reason as the WFS/GPX proxy paths above.
+const CSW_SOURCE_KIND = "csw";
 const FETCH_TIMEOUT_MS = 30_000;
 // Feature cap for refreshing an OGC API - Features layer whose stored request
 // carries no `maxFeatures` (added before it was persisted, or hand-edited).
@@ -36,6 +42,7 @@ const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
   GEORSS_SOURCE_KIND,
   OGC_FEATURES_SOURCE_KIND,
   ARCGIS_FEATURE_SOURCE_KIND,
+  CSW_SOURCE_KIND,
 ]);
 
 // Add Vector Layer (maplibre-gl-vector) tags its store layers with this
@@ -130,11 +137,16 @@ export function createWfsGetFeatureUrl(options: {
 
 export async function fetchGeoJsonFeatureCollection(
   url: string,
-  options: { useWfsProxy?: boolean; signal?: AbortSignal } = {},
+  options: { useWfsProxy?: boolean; useCswProxy?: boolean; signal?: AbortSignal } = {},
 ): Promise<FeatureCollection> {
   let response: Response;
+  const requestUrl = options.useWfsProxy
+    ? proxyWfsRequestUrl(url)
+    : options.useCswProxy
+      ? proxyCswRequestUrl(url)
+      : url;
   try {
-    response = await fetch(options.useWfsProxy ? proxyWfsRequestUrl(url) : url, {
+    response = await fetch(requestUrl, {
       // Combine signals so a caller-supplied signal does not drop the timeout.
       signal: options.signal
         ? AbortSignal.any([options.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
@@ -286,6 +298,9 @@ export async function refreshGeoJsonLayer(layer: GeoLibreLayer): Promise<GeoJson
 
   const data = await fetchGeoJsonFeatureCollection(sourceUrl, {
     useWfsProxy: isWfsLayer(layer),
+    // A catalog's GeoJSON resource is usually a third-party host with no CORS
+    // headers, the same reason the CSW source fetches it through the proxy.
+    useCswProxy: layer.metadata.sourceKind === CSW_SOURCE_KIND,
   });
 
   return {
@@ -656,6 +671,10 @@ function isViteDevServer(): boolean {
 
 function proxyWfsRequestUrl(url: string): string {
   return isViteDevServer() ? `${WFS_PROXY_PATH}?url=${encodeURIComponent(url)}` : url;
+}
+
+function proxyCswRequestUrl(url: string): string {
+  return isViteDevServer() ? `${CSW_PROXY_PATH}?url=${encodeURIComponent(url)}` : url;
 }
 
 function proxyFeedRequestUrl(url: string): string {

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -93,6 +93,7 @@ export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
   // Web services
   { id: "xyz", section: "webServices", labelKey: "toolbar.layerType.xyz", tier: "basic" },
   { id: "wms", section: "webServices", labelKey: "toolbar.layerType.wms", tier: "basic" },
+  { id: "csw", section: "webServices", labelKey: "toolbar.layerType.csw", tier: "intermediate" },
   { id: "wfs", section: "webServices", labelKey: "toolbar.layerType.wfs", tier: "intermediate" },
   { id: "wmts", section: "webServices", labelKey: "toolbar.layerType.wmts", tier: "intermediate" },
   {

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -487,6 +487,7 @@ function gdal3CdnPaths(): { wasm: string; data: string } | null {
 const GDAL3_CDN_PATHS = gdal3CdnPaths();
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
+const CSW_PROXY_PATH = "/__geolibre_csw_proxy";
 const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 const DUCKDB_WORKER_PATH_PART = "/@duckdb/duckdb-wasm/dist/";
@@ -621,6 +622,16 @@ function wmsProxyPlugin(): Plugin {
           await proxyBinaryRequestGuarded(req, res, WFS_PROXY_PATH);
         } catch (error) {
           const message = error instanceof Error ? error.message : "WFS proxy request failed";
+          res.statusCode = 502;
+          res.setHeader("content-type", "text/plain");
+          res.end(message);
+        }
+      });
+      server.middlewares.use(CSW_PROXY_PATH, async (req, res) => {
+        try {
+          await proxyBinaryRequestGuarded(req, res, CSW_PROXY_PATH);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "CSW proxy request failed";
           res.statusCode = 502;
           res.setHeader("content-type", "text/plain");
           res.end(message);

--- a/tests/csw.test.ts
+++ b/tests/csw.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DOMParser } from "linkedom";
+import {
+  classifyCswResource,
+  createCswGetRecordsUrl,
+  parseCswRecords,
+} from "../apps/geolibre-desktop/src/components/layout/add-data/csw";
+
+globalThis.DOMParser = DOMParser as unknown as typeof globalThis.DOMParser;
+
+describe("CSW catalog helpers", () => {
+  it("builds a keyword GetRecords request and replaces stale operation parameters", () => {
+    const url = new URL(
+      createCswGetRecordsUrl("https://catalog.test/csw?request=GetCapabilities", "water"),
+    );
+    assert.equal(url.searchParams.get("request"), "GetRecords");
+    assert.equal(url.searchParams.get("typeNames"), "csw:Record");
+    assert.match(url.searchParams.get("constraint") ?? "", /water/);
+  });
+
+  it("parses Dublin Core records and classifies their online resources", () => {
+    const records = parseCswRecords(`
+      <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+        xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/">
+        <csw:SearchResults>
+          <csw:Record>
+            <dc:identifier>roads</dc:identifier><dc:title>Roads</dc:title>
+            <dct:abstract>Road centerlines</dct:abstract>
+            <dc:URI protocol="OGC:WMS" name="transport:roads">https://maps.test/ows</dc:URI>
+            <dc:references scheme="WWW:DOWNLOAD-1.0-http--download">https://data.test/roads.geojson</dc:references>
+          </csw:Record>
+        </csw:SearchResults>
+      </csw:GetRecordsResponse>`);
+    assert.equal(records[0].title, "Roads");
+    assert.deepEqual(
+      records[0].resources.map(({ kind }) => kind),
+      ["wms", "geojson"],
+    );
+    assert.equal(records[0].resources[0].name, "transport:roads");
+  });
+
+  it("recognizes ArcGIS and WFS resource URLs", () => {
+    assert.equal(classifyCswResource("https://x.test/FeatureServer/0"), "arcgis");
+    assert.equal(classifyCswResource("https://x.test/ows?service=WFS"), "wfs");
+  });
+});

--- a/tests/csw.test.ts
+++ b/tests/csw.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { DOMParser } from "linkedom";
+import { CSW_SAMPLES } from "../apps/geolibre-desktop/src/components/layout/add-data/constants";
 import {
   classifyCswResource,
   createCswGetRecordsUrl,
@@ -88,4 +89,42 @@ describe("CSW catalog helpers", () => {
     assert.equal(classifyCswResource("https://x.test/rest/services/A/MapServer/0"), "arcgis");
     assert.equal(classifyCswResource("http://x.test/cgi-bin/mapserver.cgi?map=foo"), "unknown");
   });
+});
+
+/**
+ * The Add CSW Catalog dialog offers these as one-click samples. A CSW endpoint
+ * is unguessable, so a sample the search step rejects before it ever leaves the
+ * browser reads as a broken panel. These checks run the entries through the same
+ * validation and request builder the dialog uses; whether a catalog is reachable
+ * is a network question the suite deliberately leaves alone.
+ */
+describe("Add Data CSW catalog samples", () => {
+  it("offers samples with unique labels and endpoints", () => {
+    assert.ok(CSW_SAMPLES.length > 0, "no CSW samples are offered");
+    assert.equal(new Set(CSW_SAMPLES.map((s) => s.label)).size, CSW_SAMPLES.length);
+    assert.equal(new Set(CSW_SAMPLES.map((s) => s.endpoint)).size, CSW_SAMPLES.length);
+  });
+
+  for (const sample of CSW_SAMPLES) {
+    it(`builds a GetRecords request for ${sample.label}`, () => {
+      // The dialog trims before validating, so a stray space would still search;
+      // it would also be a typo, and every other field is compared untrimmed.
+      assert.equal(sample.endpoint, sample.endpoint.trim());
+      assert.ok(isHttpCswEndpoint(sample.endpoint), "endpoint is not an http(s) URL");
+      const url = new URL(createCswGetRecordsUrl(sample.endpoint, sample.keyword));
+      const endpoint = new URL(sample.endpoint);
+      assert.equal(url.origin, endpoint.origin);
+      assert.equal(url.pathname, endpoint.pathname);
+      assert.equal(url.searchParams.get("request"), "GetRecords");
+      assert.equal(url.searchParams.get("service"), "CSW");
+      // A keyword only reaches the server as a CQL constraint, so an entry that
+      // ships one must produce it (and one that doesn't must not send an empty
+      // constraint the server would reject).
+      if (sample.keyword) {
+        assert.match(url.searchParams.get("constraint") ?? "", new RegExp(sample.keyword, "i"));
+      } else {
+        assert.equal(url.searchParams.get("constraint"), null);
+      }
+    });
+  }
 });

--- a/tests/csw.test.ts
+++ b/tests/csw.test.ts
@@ -53,11 +53,18 @@ describe("CSW catalog helpers", () => {
     assert.equal(isCswFeatureCollection({ type: "FeatureCollection", features: [] }), true);
     assert.equal(isCswFeatureCollection({ type: "FeatureCollection" }), false);
     assert.equal(isCswFeatureCollection({ type: "Feature", geometry: null }), false);
+    assert.equal(isCswFeatureCollection({ type: "FeatureCollection", features: [null] }), false);
     assert.equal(isCswFeatureCollection(null), false);
   });
 
   it("recognizes ArcGIS and WFS resource URLs", () => {
     assert.equal(classifyCswResource("https://x.test/FeatureServer/0"), "arcgis");
     assert.equal(classifyCswResource("https://x.test/ows?service=WFS"), "wfs");
+  });
+
+  it("reads a bare service token from the scheme but not from the URL", () => {
+    assert.equal(classifyCswResource("https://x.test/ows", "OGC:WMS"), "wms");
+    assert.equal(classifyCswResource("https://x.test/docs/wms-user-guide.pdf"), "unknown");
+    assert.equal(classifyCswResource("https://x.test/geoserver/wms"), "wms");
   });
 });

--- a/tests/csw.test.ts
+++ b/tests/csw.test.ts
@@ -62,6 +62,22 @@ describe("CSW catalog helpers", () => {
     assert.equal(classifyCswResource("https://x.test/ows?service=WFS"), "wfs");
   });
 
+  it("parses SummaryRecord responses from servers that ignore elementSetName", () => {
+    const records = parseCswRecords(`
+      <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <csw:SearchResults>
+          <csw:SummaryRecord>
+            <dc:identifier>rivers</dc:identifier><dc:title>Rivers</dc:title>
+            <dc:URI protocol="OGC:WFS">https://maps.test/ows</dc:URI>
+          </csw:SummaryRecord>
+        </csw:SearchResults>
+      </csw:GetRecordsResponse>`);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].title, "Rivers");
+    assert.equal(records[0].resources[0].kind, "wfs");
+  });
+
   it("reads a bare service token from the scheme but not from the URL", () => {
     assert.equal(classifyCswResource("https://x.test/ows", "OGC:WMS"), "wms");
     assert.equal(classifyCswResource("https://x.test/docs/wms-user-guide.pdf"), "unknown");

--- a/tests/csw.test.ts
+++ b/tests/csw.test.ts
@@ -83,4 +83,9 @@ describe("CSW catalog helpers", () => {
     assert.equal(classifyCswResource("https://x.test/docs/wms-user-guide.pdf"), "unknown");
     assert.equal(classifyCswResource("https://x.test/geoserver/wms"), "wms");
   });
+
+  it("claims Esri REST endpoints but not UMN MapServer CGI", () => {
+    assert.equal(classifyCswResource("https://x.test/rest/services/A/MapServer/0"), "arcgis");
+    assert.equal(classifyCswResource("http://x.test/cgi-bin/mapserver.cgi?map=foo"), "unknown");
+  });
 });

--- a/tests/csw.test.ts
+++ b/tests/csw.test.ts
@@ -4,6 +4,7 @@ import { DOMParser } from "linkedom";
 import {
   classifyCswResource,
   createCswGetRecordsUrl,
+  isCswFeatureCollection,
   isHttpCswEndpoint,
   parseCswRecords,
 } from "../apps/geolibre-desktop/src/components/layout/add-data/csw";
@@ -46,6 +47,13 @@ describe("CSW catalog helpers", () => {
     assert.equal(isHttpCswEndpoint("https://"), false);
     assert.equal(isHttpCswEndpoint("ftp://catalog.test/csw"), false);
     assert.equal(isHttpCswEndpoint("catalog.test/csw"), false);
+  });
+
+  it("requires a features array, not just a FeatureCollection type", () => {
+    assert.equal(isCswFeatureCollection({ type: "FeatureCollection", features: [] }), true);
+    assert.equal(isCswFeatureCollection({ type: "FeatureCollection" }), false);
+    assert.equal(isCswFeatureCollection({ type: "Feature", geometry: null }), false);
+    assert.equal(isCswFeatureCollection(null), false);
   });
 
   it("recognizes ArcGIS and WFS resource URLs", () => {

--- a/tests/csw.test.ts
+++ b/tests/csw.test.ts
@@ -4,6 +4,7 @@ import { DOMParser } from "linkedom";
 import {
   classifyCswResource,
   createCswGetRecordsUrl,
+  isHttpCswEndpoint,
   parseCswRecords,
 } from "../apps/geolibre-desktop/src/components/layout/add-data/csw";
 
@@ -38,6 +39,13 @@ describe("CSW catalog helpers", () => {
       ["wms", "geojson"],
     );
     assert.equal(records[0].resources[0].name, "transport:roads");
+  });
+
+  it("rejects endpoints that createCswGetRecordsUrl cannot parse", () => {
+    assert.equal(isHttpCswEndpoint("https://catalog.test/csw"), true);
+    assert.equal(isHttpCswEndpoint("https://"), false);
+    assert.equal(isHttpCswEndpoint("ftp://catalog.test/csw"), false);
+    assert.equal(isHttpCswEndpoint("catalog.test/csw"), false);
   });
 
   it("recognizes ArcGIS and WFS resource URLs", () => {


### PR DESCRIPTION
## Summary

- add an OGC CSW 2.0.2 catalog source to the Add Data menu
- save and restore CSW connections through the existing service library
- search records by keyword and parse Dublin Core resource links
- hand WMS, WFS, and ArcGIS results to their prefilled Add Data forms
- add GeoJSON resources directly to the map
- proxy CSW requests during local web development and use native HTTP in the desktop app

## Verification

- searched the live pycsw demo catalog and retrieved 12 records
- verified keyword fallback with 5 matching live records
- verified result rendering in light and dark themes
- verified WMS handoff prefills both the service URL and advertised layer name
- `node --import tsx --test tests/csw.test.ts`
- `npm run build -w geolibre-desktop`
- scoped pre-commit checks

Fixes #2233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSW (OGC Catalogue Service) support to the Add Data menu.
  * Search catalogs by keyword and browse available datasets and resources.
  * Add WMS, WFS, ArcGIS, and GeoJSON resources from catalog results.
  * Saved CSW services appear in the service library and Browser tree.
  * Open Add Data dialogs with service URLs, layers, and keywords prefilled.
  * Added sample public catalogs for quick searching.

* **Bug Fixes**
  * Saved CSW catalog connections now direct users to open the catalog before selecting a dataset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->