### PR TITLE
chore(deps): bump maplibre-gl-basemap-control to 0.14.3

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^6.6.0",
     "maplibre-gl-3d-tiles": "^0.5.6",
-    "maplibre-gl-basemap-control": "^0.14.0",
+    "maplibre-gl-basemap-control": "^0.14.3",
     "maplibre-gl-components": "^0.31.1",
     "maplibre-gl-duckdb": "^0.2.4",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^6.6.0",
         "maplibre-gl-3d-tiles": "^0.5.6",
-        "maplibre-gl-basemap-control": "^0.14.0",
+        "maplibre-gl-basemap-control": "^0.14.3",
         "maplibre-gl-components": "^0.31.1",
         "maplibre-gl-duckdb": "^0.2.4",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -19235,9 +19235,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.14.0.tgz",
-      "integrity": "sha512-ZRXy7A+q096B1icHO4ghdp3ldJgfL+z/exch9GPm1dFsT1gooWUplZ03wVrzfxFKA6PZ42AmuSBhPxjRupyGKQ==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.14.3.tgz",
+      "integrity": "sha512-cvZQbZC4rq3lAxqOxv+x927pQVJkZc7tltcZ6rUL4bc3H/m1PxONhWTddNut8anhoQP8zZP+8OPr2dqISi3vcg==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -25492,7 +25492,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^6.6.0",
         "maplibre-gl-3d-tiles": "^0.5.6",
-        "maplibre-gl-basemap-control": "^0.14.0",
+        "maplibre-gl-basemap-control": "^0.14.3",
         "maplibre-gl-components": "^0.31.1",
         "maplibre-gl-duckdb": "^0.2.4",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -50,7 +50,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^6.6.0",
     "maplibre-gl-3d-tiles": "^0.5.6",
-    "maplibre-gl-basemap-control": "^0.14.0",
+    "maplibre-gl-basemap-control": "^0.14.3",
     "maplibre-gl-components": "^0.31.1",
     "maplibre-gl-duckdb": "^0.2.4",
     "maplibre-gl-earth-engine": "^0.4.2",


### PR DESCRIPTION
## Summary

- Bump `maplibre-gl-basemap-control` from 0.14.0 to 0.14.3 in `apps/geolibre-desktop` and `packages/plugins`.
- Picks up two upstream fixes: CARTO basemaps now require an API key, and the active raster is preserved when a credential error occurs. The upstream 0.14.1 and 0.14.2 tags never published to npm, so 0.14.3 is the first release that actually ships either fix.

## Notes on the hand-mirrored DOM constants

Per `docs/maintenance.md`, this package needs a manual check because the DOM it renders is mirrored by hand in `packages/plugins/src/plugins/basemap-thumbnails.ts`. All three still match in 0.14.3:

- `.basemap-control-panel` and `.basemap-control-result` are unchanged.
- `data-basemap-id` is still set via `row.dataset.basemapId`.

The catalog change adds `?key={api-key}` to the CARTO raster tile URLs. `hasUnresolvedPlaceholder` handles this as designed: it matches the complement of the tokens it substitutes, so a keyless CARTO row falls back to its placeholder swatch instead of fetching a URL with a literal token. No change needed there.

GeoLibre's own CARTO references (`carto-light.ts`, `storymap-constants.ts`) point at the `positron-gl-style/style.json` endpoint, which the upstream catalog does not reference and this release does not touch. The default basemap is `liberty`, not CARTO.

## Test plan

- [x] `node --import tsx --test tests/basemap-thumbnails.test.ts` - 14 passed, including the DOM mirror suite built against the real 0.14.3 control
- [x] `npm run test:frontend` - 7471 passed, 0 failed, 1 skipped
- [x] `pre-commit run --files <changed>` - all hooks pass, including the npm build gate
- [x] Lockfile diff is limited to this one package; integrity hash matches the published tarball

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the underlying map basemap controls to a newer version, incorporating the latest available fixes and refinements.
  * No changes were made to the application’s public features or user-facing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
