### PR TITLE
feat: add heatmap palette and weighting controls

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -4321,6 +4321,12 @@ export function StylePanel({
                       {property}
                     </option>
                   ))}
+                  {styleValue(style, "heatmapWeightProperty") !== "" &&
+                  !numericPropertyOptions.includes(styleValue(style, "heatmapWeightProperty")) ? (
+                    <option value={styleValue(style, "heatmapWeightProperty")}>
+                      {styleValue(style, "heatmapWeightProperty")}
+                    </option>
+                  ) : null}
                 </Select>
               </div>
               <NumericStyleInput

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -4292,43 +4292,49 @@ export function StylePanel({
           </div>
           {pointRenderer === "heatmap" ? (
             <>
-              <div className="space-y-2">
-                <Label htmlFor="heatmapColorRamp">{t("style.symbology.colormap")}</Label>
-                <ColorRampSelect
-                  id="heatmapColorRamp"
-                  aria-label={t("style.symbology.colormap")}
-                  value={styleValue(style, "heatmapColorRamp")}
-                  onValueChange={(heatmapColorRamp) =>
-                    setLayerStyle(layer.id, { heatmapColorRamp })
-                  }
-                  ramps={VECTOR_COLOR_RAMPS}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="heatmapWeightProperty">
-                  {t("style.symbology.heatmapWeightField")}
-                </Label>
-                <Select
-                  id="heatmapWeightProperty"
-                  value={styleValue(style, "heatmapWeightProperty")}
-                  onChange={(event) =>
-                    setLayerStyle(layer.id, { heatmapWeightProperty: event.target.value })
-                  }
-                >
-                  <option value="">{t("style.symbology.heatmapEqualWeight")}</option>
-                  {numericPropertyOptions.map((property) => (
-                    <option key={property} value={property}>
-                      {property}
-                    </option>
-                  ))}
-                  {styleValue(style, "heatmapWeightProperty") !== "" &&
-                  !numericPropertyOptions.includes(styleValue(style, "heatmapWeightProperty")) ? (
-                    <option value={styleValue(style, "heatmapWeightProperty")}>
-                      {styleValue(style, "heatmapWeightProperty")}
-                    </option>
-                  ) : null}
-                </Select>
-              </div>
+              {!controlRendersLayer(layer) ? (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="heatmapColorRamp">{t("style.symbology.colormap")}</Label>
+                    <ColorRampSelect
+                      id="heatmapColorRamp"
+                      aria-label={t("style.symbology.colormap")}
+                      value={styleValue(style, "heatmapColorRamp")}
+                      onValueChange={(heatmapColorRamp) =>
+                        setLayerStyle(layer.id, { heatmapColorRamp })
+                      }
+                      ramps={VECTOR_COLOR_RAMPS}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="heatmapWeightProperty">
+                      {t("style.symbology.heatmapWeightField")}
+                    </Label>
+                    <Select
+                      id="heatmapWeightProperty"
+                      value={styleValue(style, "heatmapWeightProperty")}
+                      onChange={(event) =>
+                        setLayerStyle(layer.id, { heatmapWeightProperty: event.target.value })
+                      }
+                    >
+                      <option value="">{t("style.symbology.heatmapEqualWeight")}</option>
+                      {numericPropertyOptions.map((property) => (
+                        <option key={property} value={property}>
+                          {property}
+                        </option>
+                      ))}
+                      {styleValue(style, "heatmapWeightProperty") !== "" &&
+                      !numericPropertyOptions.includes(
+                        styleValue(style, "heatmapWeightProperty"),
+                      ) ? (
+                        <option value={styleValue(style, "heatmapWeightProperty")}>
+                          {styleValue(style, "heatmapWeightProperty")}
+                        </option>
+                      ) : null}
+                    </Select>
+                  </div>
+                </>
+              ) : null}
               <NumericStyleInput
                 id="heatmapRadius"
                 label={t("style.symbology.heatmapRadius")}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -3500,6 +3500,7 @@ export function StylePanel({
     label: string,
     value: string,
     onSelect: (property: string) => void,
+    emptyLabel = t("style.generator.fieldNone"),
   ) => (
     <div className="space-y-2">
       <Label htmlFor={id}>{label}</Label>
@@ -3513,7 +3514,7 @@ export function StylePanel({
           <option value="">{t("style.labels.noAttributes")}</option>
         ) : (
           <>
-            <option value="">{t("style.generator.fieldNone")}</option>
+            <option value="">{emptyLabel}</option>
             {numericPropertyOptions.map((property) => (
               <option key={property} value={property}>
                 {property}
@@ -4306,33 +4307,13 @@ export function StylePanel({
                       ramps={VECTOR_COLOR_RAMPS}
                     />
                   </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="heatmapWeightProperty">
-                      {t("style.symbology.heatmapWeightField")}
-                    </Label>
-                    <Select
-                      id="heatmapWeightProperty"
-                      value={styleValue(style, "heatmapWeightProperty")}
-                      onChange={(event) =>
-                        setLayerStyle(layer.id, { heatmapWeightProperty: event.target.value })
-                      }
-                    >
-                      <option value="">{t("style.symbology.heatmapEqualWeight")}</option>
-                      {numericPropertyOptions.map((property) => (
-                        <option key={property} value={property}>
-                          {property}
-                        </option>
-                      ))}
-                      {styleValue(style, "heatmapWeightProperty") !== "" &&
-                      !numericPropertyOptions.includes(
-                        styleValue(style, "heatmapWeightProperty"),
-                      ) ? (
-                        <option value={styleValue(style, "heatmapWeightProperty")}>
-                          {styleValue(style, "heatmapWeightProperty")}
-                        </option>
-                      ) : null}
-                    </Select>
-                  </div>
+                  {generatorFieldSelect(
+                    "heatmapWeightProperty",
+                    t("style.symbology.heatmapWeightField"),
+                    styleValue(style, "heatmapWeightProperty"),
+                    (heatmapWeightProperty) => setLayerStyle(layer.id, { heatmapWeightProperty }),
+                    t("style.symbology.heatmapEqualWeight"),
+                  )}
                 </>
               ) : null}
               <NumericStyleInput

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -4292,6 +4292,37 @@ export function StylePanel({
           </div>
           {pointRenderer === "heatmap" ? (
             <>
+              <div className="space-y-2">
+                <Label htmlFor="heatmapColorRamp">{t("style.symbology.colormap")}</Label>
+                <ColorRampSelect
+                  id="heatmapColorRamp"
+                  aria-label={t("style.symbology.colormap")}
+                  value={styleValue(style, "heatmapColorRamp")}
+                  onValueChange={(heatmapColorRamp) =>
+                    setLayerStyle(layer.id, { heatmapColorRamp })
+                  }
+                  ramps={VECTOR_COLOR_RAMPS}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="heatmapWeightProperty">
+                  {t("style.symbology.heatmapWeightField")}
+                </Label>
+                <Select
+                  id="heatmapWeightProperty"
+                  value={styleValue(style, "heatmapWeightProperty")}
+                  onChange={(event) =>
+                    setLayerStyle(layer.id, { heatmapWeightProperty: event.target.value })
+                  }
+                >
+                  <option value="">{t("style.symbology.heatmapEqualWeight")}</option>
+                  {numericPropertyOptions.map((property) => (
+                    <option key={property} value={property}>
+                      {property}
+                    </option>
+                  ))}
+                </Select>
+              </div>
               <NumericStyleInput
                 id="heatmapRadius"
                 label={t("style.symbology.heatmapRadius")}

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -6955,6 +6955,8 @@
       "pointRendererClustered": "مجمَّع",
       "heatmapRadius": "نصف قطر الخريطة الحرارية",
       "heatmapIntensity": "شدة الخريطة الحرارية",
+      "heatmapWeightField": "حقل الوزن",
+      "heatmapEqualWeight": "لا شيء (وزن متساوٍ)",
       "clusterRadius": "نصف قطر التجميع (بكسل)",
       "clusterMaxZoom": "الحد الأقصى لتكبير التجميع",
       "strokeWidthUnit": "وحدة عرض الحد الخارجي",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "Geclustert",
       "heatmapRadius": "Heatmap-Radius",
       "heatmapIntensity": "Heatmap-Intensität",
+      "heatmapWeightField": "Gewichtungsfeld",
+      "heatmapEqualWeight": "Keines (gleiche Gewichtung)",
       "clusterRadius": "Cluster-Radius (px)",
       "clusterMaxZoom": "Cluster max. Zoom",
       "strokeWidthUnit": "Einheit der Strichstärke",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -6708,6 +6708,8 @@
       "pointRendererClustered": "Clustered",
       "heatmapRadius": "Heatmap radius",
       "heatmapIntensity": "Heatmap intensity",
+      "heatmapWeightField": "Weight field",
+      "heatmapEqualWeight": "None (equal weight)",
       "clusterRadius": "Cluster radius (px)",
       "clusterMaxZoom": "Cluster max zoom",
       "strokeWidthUnit": "Stroke width unit",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "Agrupado",
       "heatmapRadius": "Radio de Heatmap",
       "heatmapIntensity": "Intensidad de Heatmap",
+      "heatmapWeightField": "Campo de ponderación",
+      "heatmapEqualWeight": "Ninguno (ponderación igual)",
       "clusterRadius": "Radio de clúster (px)",
       "clusterMaxZoom": "Zoom máximo de clúster",
       "strokeWidthUnit": "Unidad de ancho de trazo",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "خوشه‌بندی‌شده",
       "heatmapRadius": "شعاع نقشهٔ حرارتی",
       "heatmapIntensity": "شدت نقشهٔ حرارتی",
+      "heatmapWeightField": "فیلد وزن",
+      "heatmapEqualWeight": "هیچ‌کدام (وزن برابر)",
       "clusterRadius": "شعاع خوشه (پیکسل)",
       "clusterMaxZoom": "بیشینهٔ بزرگ‌نمایی خوشه",
       "strokeWidthUnit": "یکای ضخامت خط",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "Regroupé",
       "heatmapRadius": "Rayon de la Heatmap",
       "heatmapIntensity": "Intensité de la Heatmap",
+      "heatmapWeightField": "Champ de pondération",
+      "heatmapEqualWeight": "Aucun (poids égal)",
       "clusterRadius": "Rayon de cluster (px)",
       "clusterMaxZoom": "Zoom max du cluster",
       "strokeWidthUnit": "Unité d'épaisseur du trait",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "क्लस्टर्ड",
       "heatmapRadius": "हीटमैप त्रिज्या",
       "heatmapIntensity": "हीटमैप तीव्रता",
+      "heatmapWeightField": "भार फ़ील्ड",
+      "heatmapEqualWeight": "कोई नहीं (समान भार)",
       "clusterRadius": "क्लस्टर त्रिज्या (px)",
       "clusterMaxZoom": "क्लस्टर अधिकतम ज़ूम",
       "strokeWidthUnit": "स्ट्रोक चौड़ाई इकाई",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -6566,6 +6566,8 @@
       "pointRendererClustered": "Berkluster",
       "heatmapRadius": "Radius peta panas",
       "heatmapIntensity": "Intensitas peta panas",
+      "heatmapWeightField": "Bidang bobot",
+      "heatmapEqualWeight": "Tidak ada (bobot sama)",
       "clusterRadius": "Radius kluster (px)",
       "clusterMaxZoom": "Zoom maksimum kluster",
       "strokeWidthUnit": "Satuan lebar garis tepi",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "Raggruppato",
       "heatmapRadius": "Raggio mappa di calore",
       "heatmapIntensity": "Intensità mappa di calore",
+      "heatmapWeightField": "Campo di ponderazione",
+      "heatmapEqualWeight": "Nessuno (peso uguale)",
       "clusterRadius": "Raggio cluster (px)",
       "clusterMaxZoom": "Zoom massimo cluster",
       "strokeWidthUnit": "Unità di spessore del tratto",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -6566,6 +6566,8 @@
       "pointRendererClustered": "クラスタリング",
       "heatmapRadius": "ヒートマップの半径",
       "heatmapIntensity": "ヒートマップの強度",
+      "heatmapWeightField": "重みフィールド",
+      "heatmapEqualWeight": "なし（均等な重み）",
       "clusterRadius": "クラスタ半径 (px)",
       "clusterMaxZoom": "クラスタの最大ズーム",
       "strokeWidthUnit": "線幅の単位",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "დაჯგუფებული",
       "heatmapRadius": "სითბური რუკის რადიუსი",
       "heatmapIntensity": "სითბური რუკის ინტენსივობა",
+      "heatmapWeightField": "წონის ველი",
+      "heatmapEqualWeight": "არცერთი (თანაბარი წონა)",
       "clusterRadius": "კლასტერის რადიუსი (px)",
       "clusterMaxZoom": "კლასტერის მაქს. zoom",
       "strokeWidthUnit": "ხაზის სისქის ერთეული",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -6566,6 +6566,8 @@
       "pointRendererClustered": "클러스터링",
       "heatmapRadius": "히트맵 반경",
       "heatmapIntensity": "히트맵 강도",
+      "heatmapWeightField": "가중치 필드",
+      "heatmapEqualWeight": "없음 (동일 가중치)",
       "clusterRadius": "클러스터 반경(px)",
       "clusterMaxZoom": "클러스터 최대 줌",
       "strokeWidthUnit": "선 너비 단위",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "Geclusterd",
       "heatmapRadius": "Heatmap-straal",
       "heatmapIntensity": "Heatmap-intensiteit",
+      "heatmapWeightField": "Wegingsveld",
+      "heatmapEqualWeight": "Geen (gelijke weging)",
       "clusterRadius": "Clusterstraal (px)",
       "clusterMaxZoom": "Max. zoom cluster",
       "strokeWidthUnit": "Eenheid van lijndikte",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "Agrupado",
       "heatmapRadius": "Raio do mapa de calor",
       "heatmapIntensity": "Intensidade do mapa de calor",
+      "heatmapWeightField": "Campo de ponderação",
+      "heatmapEqualWeight": "Nenhum (peso igual)",
       "clusterRadius": "Raio do agrupamento (px)",
       "clusterMaxZoom": "Zoom máximo do agrupamento",
       "strokeWidthUnit": "Unidade da espessura do traço",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -6800,6 +6800,8 @@
       "pointRendererClustered": "Кластеризация",
       "heatmapRadius": "Радиус тепловой карты",
       "heatmapIntensity": "Интенсивность тепловой карты",
+      "heatmapWeightField": "Поле веса",
+      "heatmapEqualWeight": "Нет (равный вес)",
       "clusterRadius": "Радиус кластера (px)",
       "clusterMaxZoom": "Макс. масштаб кластеризации",
       "strokeWidthUnit": "Единица толщины обводки",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -6566,6 +6566,8 @@
       "pointRendererClustered": "จัดกลุ่ม",
       "heatmapRadius": "รัศมีของแผนที่ความร้อน",
       "heatmapIntensity": "ความเข้มของแผนที่ความร้อน",
+      "heatmapWeightField": "ฟิลด์น้ำหนัก",
+      "heatmapEqualWeight": "ไม่มี (น้ำหนักเท่ากัน)",
       "clusterRadius": "รัศมีของกลุ่ม (พิกเซล)",
       "clusterMaxZoom": "ระดับซูมสูงสุดที่ยังจัดกลุ่ม",
       "strokeWidthUnit": "หน่วยความหนาเส้น",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -6644,6 +6644,8 @@
       "pointRendererClustered": "Kümelenmiş",
       "heatmapRadius": "Isı haritası yarıçapı",
       "heatmapIntensity": "Isı haritası yoğunluğu",
+      "heatmapWeightField": "Ağırlık alanı",
+      "heatmapEqualWeight": "Yok (eşit ağırlık)",
       "clusterRadius": "Küme yarıçapı (px)",
       "clusterMaxZoom": "Maksimum küme yakınlaştırması",
       "strokeWidthUnit": "Kenarlık kalınlığı birimi",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -6557,6 +6557,8 @@
       "pointRendererClustered": "Được nhóm lại",
       "heatmapRadius": "Bán kính bản đồ nhiệt",
       "heatmapIntensity": "Cường độ bản đồ nhiệt",
+      "heatmapWeightField": "Trường trọng số",
+      "heatmapEqualWeight": "Không có (trọng số bằng nhau)",
       "fillPatterns": {
         "none": "Không có (điền đặc)",
         "hatch": "nở",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -6566,6 +6566,8 @@
       "pointRendererClustered": "聚类",
       "heatmapRadius": "热力图半径",
       "heatmapIntensity": "热力图强度",
+      "heatmapWeightField": "权重字段",
+      "heatmapEqualWeight": "无（等权重）",
       "clusterRadius": "聚类半径 (px)",
       "clusterMaxZoom": "聚类最大缩放级别",
       "strokeWidthUnit": "描边宽度单位",

--- a/apps/geolibre-desktop/src/lib/auto-legend.ts
+++ b/apps/geolibre-desktop/src/lib/auto-legend.ts
@@ -15,7 +15,7 @@
  */
 import {
   effectiveVectorRules,
-  getVectorColorRamp,
+  heatmapRampColors,
   isHexColor,
   proportionalSizeRange,
   styleValue,
@@ -679,7 +679,7 @@ function vectorParts(
 
   // A density heatmap renders no per-feature symbols: the entry is the ramp.
   if (shape === "circle" && styleValue(style, "pointRenderer") === "heatmap") {
-    const colors = getVectorColorRamp(styleValue(style, "heatmapColorRamp")).colors;
+    const colors = heatmapRampColors(style);
     return {
       rows: [...diagrams, ...generatorRows],
       gradient: { colors: ["rgba(0,0,0,0)", ...colors], minLabel: null, maxLabel: null },

--- a/apps/geolibre-desktop/src/lib/auto-legend.ts
+++ b/apps/geolibre-desktop/src/lib/auto-legend.ts
@@ -15,6 +15,7 @@
  */
 import {
   effectiveVectorRules,
+  getVectorColorRamp,
   isHexColor,
   proportionalSizeRange,
   styleValue,
@@ -56,14 +57,6 @@ const GRADIENT_SAMPLES = 6;
  * `@geolibre/map`'s style-mapper, minus the fully-transparent zero stop so the
  * bar starts visible).
  */
-export const HEATMAP_RAMP_COLORS: readonly string[] = [
-  "rgb(103,169,207)",
-  "rgb(209,229,240)",
-  "rgb(253,219,199)",
-  "rgb(239,138,98)",
-  "rgb(178,24,43)",
-];
-
 /** One row (class / rule / size step / custom item) under a legend entry. */
 export interface AutoLegendRow {
   /** Stable override key (`<entryId>::p:<index>` in the panel namespace). */
@@ -691,9 +684,10 @@ function vectorParts(
 
   // A density heatmap renders no per-feature symbols: the entry is the ramp.
   if (shape === "circle" && styleValue(style, "pointRenderer") === "heatmap") {
+    const colors = getVectorColorRamp(styleValue(style, "heatmapColorRamp")).colors;
     return {
       rows: [...diagrams, ...generatorRows],
-      gradient: { colors: [...HEATMAP_RAMP_COLORS], minLabel: null, maxLabel: null },
+      gradient: { colors: [...colors], minLabel: null, maxLabel: null },
       headerSwatch: null,
     };
   }

--- a/apps/geolibre-desktop/src/lib/auto-legend.ts
+++ b/apps/geolibre-desktop/src/lib/auto-legend.ts
@@ -52,11 +52,6 @@ export const MAX_LEGEND_ROWS = 100;
 /** Colors sampled per gradient bar. */
 const GRADIENT_SAMPLES = 6;
 
-/**
- * The map's heatmap ramp colors (mirrors `HEATMAP_COLOR_RAMP` in
- * `@geolibre/map`'s style-mapper, minus the fully-transparent zero stop so the
- * bar starts visible).
- */
 /** One row (class / rule / size step / custom item) under a legend entry. */
 export interface AutoLegendRow {
   /** Stable override key (`<entryId>::p:<index>` in the panel namespace). */
@@ -687,7 +682,7 @@ function vectorParts(
     const colors = getVectorColorRamp(styleValue(style, "heatmapColorRamp")).colors;
     return {
       rows: [...diagrams, ...generatorRows],
-      gradient: { colors: [...colors], minLabel: null, maxLabel: null },
+      gradient: { colors: ["rgba(0,0,0,0)", ...colors], minLabel: null, maxLabel: null },
       headerSwatch: null,
     };
   }

--- a/docs/python.md
+++ b/docs/python.md
@@ -276,7 +276,7 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | `add_markers(points, name=, **style)` | Add point markers from `(lng, lat)` pairs, `{lng/lon/x, lat/y, …}` dicts, GeoJSON, or a GeoDataFrame. |
 | `add_circle_markers(points, name=, radius=, **style)` | Add circle markers with an explicit `radius`. |
 | `add_marker_cluster(points, name=, cluster_radius=, cluster_max_zoom=, **style)` | Add clustered point markers. |
-| `add_heatmap(points, name=, radius=, intensity=, **style)` | Add point data using the density heatmap renderer. |
+| `add_heatmap(points, name=, radius=, intensity=, color_ramp=, weight_field=, **style)` | Add point data using the density heatmap renderer, optionally weighted by a numeric field. |
 | `add_choropleth(data, column, name=, class_count=, colormap=, scheme=, **style)` | Add a GeoJSON layer with graduated symbology computed from a numeric `column`. |
 | `add_data(data, column=None, name=, **kwargs)` | Add data; a choropleth when `column` is given, else a plain GeoJSON layer (leafmap parity). |
 | `add_vector(data, name=, render_mode=, data_format=, source_layer=, **style)` | Add a vector dataset from a URL (GeoParquet, FlatGeobuf, zipped Shapefile, GeoJSON, …) or a local file (read via GeoPandas and inlined). |

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -536,6 +536,10 @@ export interface LayerStyle {
   pointRenderer: PointRenderer;
   heatmapRadius: number;
   heatmapIntensity: number;
+  /** Built-in color ramp used by the heatmap density renderer. */
+  heatmapColorRamp: string;
+  /** Numeric feature property used as heatmap weight; blank gives every point equal weight. */
+  heatmapWeightProperty: string;
   clusterRadius: number;
   clusterMaxZoom: number;
   /**
@@ -707,6 +711,8 @@ export const DEFAULT_LAYER_STYLE: LayerStyle = {
   pointRenderer: "single",
   heatmapRadius: 30,
   heatmapIntensity: 1,
+  heatmapColorRamp: "turbo",
+  heatmapWeightProperty: "",
   clusterRadius: 50,
   clusterMaxZoom: 14,
   invertedFillEnabled: false,

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -1,4 +1,5 @@
-import { styleValue, type LayerStyle, type VectorRule } from "./types";
+import { DEFAULT_LAYER_STYLE, styleValue, type LayerStyle, type VectorRule } from "./types";
+import { getVectorColorRamp } from "./color-ramp";
 import { getActiveSemiMajorAxisMeters } from "./ellipsoids";
 import { removeTrailingJsonCommas } from "./expressions";
 
@@ -701,6 +702,25 @@ export function vectorFillOpacityValue(
   fallback: number | unknown[],
 ): number | unknown[] {
   return ruleOverrideValue(style, "fillOpacity", fallback) as number | unknown[];
+}
+
+/**
+ * The color-ramp colors a density heatmap paints with.
+ *
+ * {@link getVectorColorRamp} falls back to the *first* ramp ("viridis") for an
+ * unknown name, which is not the heatmap default ("turbo"). Both the map paint
+ * (`heatmapPaint` in `@geolibre/map`) and the auto-legend gradient resolve the
+ * ramp here so a stale or hand-edited `heatmapColorRamp` cannot make the legend
+ * and the rendered heatmap disagree about which ramp is in use.
+ *
+ * @param style - The layer style.
+ * @returns The ramp's colors, or the default ramp's colors for an unknown name.
+ */
+export function heatmapRampColors(style: LayerStyle): readonly string[] {
+  const value = styleValue(style, "heatmapColorRamp");
+  const ramp = getVectorColorRamp(value);
+  return (ramp.value === value ? ramp : getVectorColorRamp(DEFAULT_LAYER_STYLE.heatmapColorRamp))
+    .colors;
 }
 
 /** The validated proportional (graduated) size configuration of a layer. */

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -28,6 +28,7 @@ function heatmapWeightProperty(value: unknown): string | null {
   if (expression.length === 3 && expression[0] === "max" && expression[1] === 0) {
     expression = expression[2];
   }
+  if (!Array.isArray(expression)) return null;
   if (
     expression.length === 3 &&
     expression[0] === "to-number" &&

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_LAYER_STYLE,
+  VECTOR_COLOR_RAMPS,
   mercatorMetersPerPixelAtZoom0,
   type LabelStyle,
   type LayerStyle,
@@ -8,6 +9,46 @@ import {
 
 const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
 const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
+
+function heatmapRampExpression(colors: readonly string[]): unknown[] {
+  const expression: unknown[] = [
+    "interpolate",
+    ["linear"],
+    ["heatmap-density"],
+    0,
+    "rgba(0,0,0,0)",
+  ];
+  colors.forEach((color, index) => expression.push((index + 1) / colors.length, color));
+  return expression;
+}
+
+function heatmapRampName(value: unknown): string | null {
+  const serialized = JSON.stringify(value);
+  return (
+    VECTOR_COLOR_RAMPS.find(
+      (ramp) => JSON.stringify(heatmapRampExpression(ramp.colors)) === serialized,
+    )?.value ?? null
+  );
+}
+
+function heatmapWeightProperty(value: unknown): string | null {
+  if (value === undefined || value === 1) return "";
+  if (!Array.isArray(value) || value.length !== 3) return null;
+  const [operator, zero, conversion] = value;
+  if (operator !== "max" || zero !== 0 || !Array.isArray(conversion)) return null;
+  const [conversionOperator, getExpression, fallback] = conversion;
+  if (
+    conversionOperator !== "to-number" ||
+    fallback !== 0 ||
+    !Array.isArray(getExpression) ||
+    getExpression.length !== 2 ||
+    getExpression[0] !== "get" ||
+    typeof getExpression[1] !== "string"
+  ) {
+    return null;
+  }
+  return getExpression[1];
+}
 
 /** The `text-anchor` values GeoLibre's {@link LabelStyle.anchor} accepts. */
 const VALID_LABEL_ANCHORS = new Set<string>([
@@ -920,6 +961,16 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     const intensity = asFiniteNumber(paint["heatmap-intensity"]);
     if (intensity !== null) patch.heatmapIntensity = intensity;
     else warnUnreadableNumber(paint["heatmap-intensity"], "heatmap intensity", warnings);
+    const colorRamp = heatmapRampName(paint["heatmap-color"]);
+    if (colorRamp !== null) patch.heatmapColorRamp = colorRamp;
+    else if (paint["heatmap-color"] !== undefined) {
+      warnings.push("The heatmap color expression is not a built-in GeoLibre color ramp.");
+    }
+    const weightProperty = heatmapWeightProperty(paint["heatmap-weight"]);
+    if (weightProperty !== null) patch.heatmapWeightProperty = weightProperty;
+    else {
+      warnings.push("The heatmap weight expression is not a single GeoLibre attribute field.");
+    }
     applyZoomRange(heatmap, patch);
   }
 

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -22,21 +22,23 @@ function heatmapRampName(value: unknown): string | null {
 
 function heatmapWeightProperty(value: unknown): string | null {
   if (value === undefined || value === 1) return "";
-  if (!Array.isArray(value) || value.length !== 3) return null;
-  const [operator, zero, conversion] = value;
-  if (operator !== "max" || zero !== 0 || !Array.isArray(conversion)) return null;
-  const [conversionOperator, getExpression, fallback] = conversion;
-  if (
-    conversionOperator !== "to-number" ||
-    fallback !== 0 ||
-    !Array.isArray(getExpression) ||
-    getExpression.length !== 2 ||
-    getExpression[0] !== "get" ||
-    typeof getExpression[1] !== "string"
-  ) {
-    return null;
+  if (!Array.isArray(value)) return null;
+
+  let expression = value;
+  if (expression.length === 3 && expression[0] === "max" && expression[1] === 0) {
+    expression = expression[2];
   }
-  return getExpression[1];
+  if (
+    expression.length === 3 &&
+    expression[0] === "to-number" &&
+    expression[2] === 0 &&
+    Array.isArray(expression[1])
+  ) {
+    expression = expression[1];
+  }
+  return expression.length === 2 && expression[0] === "get" && typeof expression[1] === "string"
+    ? expression[1]
+    : null;
 }
 
 /** The `text-anchor` values GeoLibre's {@link LabelStyle.anchor} accepts. */

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -6,27 +6,16 @@ import {
   type LayerStyle,
   type VectorStyleStop,
 } from "@geolibre/core";
+import { heatmapColorRampExpression } from "./style-mapper";
 
 const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
 const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
-
-function heatmapRampExpression(colors: readonly string[]): unknown[] {
-  const expression: unknown[] = [
-    "interpolate",
-    ["linear"],
-    ["heatmap-density"],
-    0,
-    "rgba(0,0,0,0)",
-  ];
-  colors.forEach((color, index) => expression.push((index + 1) / colors.length, color));
-  return expression;
-}
 
 function heatmapRampName(value: unknown): string | null {
   const serialized = JSON.stringify(value);
   return (
     VECTOR_COLOR_RAMPS.find(
-      (ramp) => JSON.stringify(heatmapRampExpression(ramp.colors)) === serialized,
+      (ramp) => JSON.stringify(heatmapColorRampExpression(ramp.colors)) === serialized,
     )?.value ?? null
   );
 }

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -3,7 +3,7 @@ import {
   circleRadiusValue,
   extrusionColorValue,
   extrusionHeightValue,
-  getVectorColorRamp,
+  heatmapRampColors,
   lineWidthValue,
   mapZoomStepOutputs,
   simpleStyleNumberValue,
@@ -142,13 +142,6 @@ export function heatmapColorRampExpression(colors: readonly string[]): Expressio
   return expression as ExpressionSpecification;
 }
 
-function heatmapColorRamp(style: LayerStyle): ExpressionSpecification {
-  const value = styleValue(style, "heatmapColorRamp");
-  const ramp = getVectorColorRamp(value);
-  const fallback = getVectorColorRamp(DEFAULT_LAYER_STYLE.heatmapColorRamp);
-  return heatmapColorRampExpression((ramp.value === value ? ramp : fallback).colors);
-}
-
 function heatmapWeight(style: LayerStyle): PropertyValueSpecification<number> {
   const property = styleValue(style, "heatmapWeightProperty").trim();
   return property === ""
@@ -162,7 +155,7 @@ export function heatmapPaint(style: LayerStyle, opacity: number) {
     "heatmap-intensity": styleValue(style, "heatmapIntensity"),
     "heatmap-weight": heatmapWeight(style),
     "heatmap-opacity": opacity,
-    "heatmap-color": heatmapColorRamp(style),
+    "heatmap-color": heatmapColorRampExpression(heatmapRampColors(style)),
   };
 }
 

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -143,9 +143,10 @@ export function heatmapColorRampExpression(colors: readonly string[]): Expressio
 }
 
 function heatmapColorRamp(style: LayerStyle): ExpressionSpecification {
-  return heatmapColorRampExpression(
-    getVectorColorRamp(styleValue(style, "heatmapColorRamp")).colors,
-  );
+  const value = styleValue(style, "heatmapColorRamp");
+  const ramp = getVectorColorRamp(value);
+  const fallback = getVectorColorRamp(DEFAULT_LAYER_STYLE.heatmapColorRamp);
+  return heatmapColorRampExpression((ramp.value === value ? ramp : fallback).colors);
 }
 
 function heatmapWeight(style: LayerStyle): PropertyValueSpecification<number> {

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -128,8 +128,7 @@ export function circlePaint(style: LayerStyle, opacity: number) {
   };
 }
 
-function heatmapColorRamp(style: LayerStyle): ExpressionSpecification {
-  const colors = getVectorColorRamp(styleValue(style, "heatmapColorRamp")).colors;
+export function heatmapColorRampExpression(colors: readonly string[]): ExpressionSpecification {
   const expression: unknown[] = [
     "interpolate",
     ["linear"],
@@ -141,6 +140,12 @@ function heatmapColorRamp(style: LayerStyle): ExpressionSpecification {
     expression.push((index + 1) / colors.length, color);
   });
   return expression as ExpressionSpecification;
+}
+
+function heatmapColorRamp(style: LayerStyle): ExpressionSpecification {
+  return heatmapColorRampExpression(
+    getVectorColorRamp(styleValue(style, "heatmapColorRamp")).colors,
+  );
 }
 
 function heatmapWeight(style: LayerStyle): PropertyValueSpecification<number> {

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -3,6 +3,7 @@ import {
   circleRadiusValue,
   extrusionColorValue,
   extrusionHeightValue,
+  getVectorColorRamp,
   lineWidthValue,
   mapZoomStepOutputs,
   simpleStyleNumberValue,
@@ -127,31 +128,35 @@ export function circlePaint(style: LayerStyle, opacity: number) {
   };
 }
 
-// A perceptually-ordered cold→hot ramp over MapLibre's heatmap-density (0..1).
-const HEATMAP_COLOR_RAMP: ExpressionSpecification = [
-  "interpolate",
-  ["linear"],
-  ["heatmap-density"],
-  0,
-  "rgba(33,102,172,0)",
-  0.2,
-  "rgb(103,169,207)",
-  0.4,
-  "rgb(209,229,240)",
-  0.6,
-  "rgb(253,219,199)",
-  0.8,
-  "rgb(239,138,98)",
-  1,
-  "rgb(178,24,43)",
-];
+function heatmapColorRamp(style: LayerStyle): ExpressionSpecification {
+  const colors = getVectorColorRamp(styleValue(style, "heatmapColorRamp")).colors;
+  const expression: unknown[] = [
+    "interpolate",
+    ["linear"],
+    ["heatmap-density"],
+    0,
+    "rgba(0,0,0,0)",
+  ];
+  colors.forEach((color, index) => {
+    expression.push((index + 1) / colors.length, color);
+  });
+  return expression as ExpressionSpecification;
+}
+
+function heatmapWeight(style: LayerStyle): PropertyValueSpecification<number> {
+  const property = styleValue(style, "heatmapWeightProperty").trim();
+  return property === ""
+    ? 1
+    : (["max", 0, ["to-number", ["get", property], 0]] as PropertyValueSpecification<number>);
+}
 
 export function heatmapPaint(style: LayerStyle, opacity: number) {
   return {
     "heatmap-radius": styleValue(style, "heatmapRadius"),
     "heatmap-intensity": styleValue(style, "heatmapIntensity"),
+    "heatmap-weight": heatmapWeight(style),
     "heatmap-opacity": opacity,
-    "heatmap-color": HEATMAP_COLOR_RAMP,
+    "heatmap-color": heatmapColorRamp(style),
   };
 }
 

--- a/python/README.md
+++ b/python/README.md
@@ -103,7 +103,7 @@ The click payload has the form `{"lngLat": {"lng": ..., "lat": ...},
 | `add_geojson(data, name=, **style)` | Add GeoJSON (dict, path, URL, JSON, or GeoDataFrame). |
 | `add_gdf(gdf, name=, column=None, **style)` | Add a GeoDataFrame, optionally as a choropleth. |
 | `add_csv` / `add_xy_data` `(data, x=, y=, name=, **style)` | Add points from CSV, a DataFrame, or row mappings. |
-| `add_heatmap(points, name=, radius=, intensity=, **style)` | Add a point density heatmap. |
+| `add_heatmap(points, name=, radius=, intensity=, color_ramp=, weight_field=, **style)` | Add a point density heatmap, optionally weighted by a numeric field. |
 | `add_vector(data, name=, render_mode=, data_format=, source_layer=, **style)` | Add a vector dataset from a URL (GeoParquet, FlatGeobuf, zipped Shapefile, GeoJSON) or a local file (read via GeoPandas, inlined). |
 | `add_geoparquet` / `add_flatgeobuf` / `add_shp` / `add_kml` / `add_gpkg` | Format-specific wrappers over `add_vector`. |
 | `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add vector tiles from a TileJSON endpoint. |

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1480,9 +1480,25 @@ class Map(anywidget.AnyWidget):
         *,
         radius: float = 30,
         intensity: float = 1,
+        color_ramp: str = "turbo",
+        weight_field: str = "",
         **style: Any,
     ) -> str:
-        """Add point data using GeoLibre's density heatmap renderer."""
+        """Add point data using GeoLibre's density heatmap renderer.
+
+        Args:
+            points: Points in any form accepted by :meth:`add_markers`.
+            name: Layer display name.
+            radius: Heatmap radius in pixels.
+            intensity: Heatmap intensity multiplier.
+            color_ramp: Name of the built-in heatmap color ramp.
+            weight_field: Numeric property used to weight each point, or an
+                empty string to give every point equal weight.
+            **style: Additional style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
         # NaN and infinity slip past the comparisons below, so check finiteness
         # first rather than storing an unusable renderer setting.
         if not math.isfinite(float(radius)) or float(radius) <= 0:
@@ -1492,6 +1508,8 @@ class Map(anywidget.AnyWidget):
         style.setdefault("pointRenderer", "heatmap")
         style.setdefault("heatmapRadius", float(radius))
         style.setdefault("heatmapIntensity", float(intensity))
+        style.setdefault("heatmapColorRamp", str(color_ramp))
+        style.setdefault("heatmapWeightProperty", str(weight_field))
         return self.add_markers(points, name=name, **style)
 
     @staticmethod

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -331,6 +331,8 @@ DEFAULT_LAYER_STYLE: dict[str, Any] = {
     "pointRenderer": "single",
     "heatmapRadius": 30,
     "heatmapIntensity": 1,
+    "heatmapColorRamp": "turbo",
+    "heatmapWeightProperty": "",
     "clusterRadius": 50,
     "clusterMaxZoom": 14,
     "rasterBrightnessMin": 0,

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -867,11 +867,19 @@ def test_add_circle_markers_sets_radius(m):
 
 
 def test_add_heatmap_sets_renderer(m):
-    m.add_heatmap([(0, 0), (1, 1)], radius=42, intensity=1.5)
+    m.add_heatmap(
+        [(0, 0), (1, 1)],
+        radius=42,
+        intensity=1.5,
+        color_ramp="viridis",
+        weight_field="nb_ruches",
+    )
     style = _last_layer(m)["style"]
     assert style["pointRenderer"] == "heatmap"
     assert style["heatmapRadius"] == 42
     assert style["heatmapIntensity"] == 1.5
+    assert style["heatmapColorRamp"] == "viridis"
+    assert style["heatmapWeightProperty"] == "nb_ruches"
 
 
 def test_add_heatmap_validates_parameters(m):

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -85,7 +85,7 @@ m.add_marker(-122.4, 37.8, properties={"name": "San Francisco"})
 m.add_markers(points)
 m.add_circle_markers(points)
 m.add_marker_cluster(points, cluster_radius=50, cluster_max_zoom=14)
-m.add_heatmap(points, radius=35, intensity=1)
+m.add_heatmap(points, radius=35, intensity=1, color_ramp="turbo", weight_field="value")
 m.add_polyline(...)
 ```
 

--- a/tests/auto-legend.test.ts
+++ b/tests/auto-legend.test.ts
@@ -342,6 +342,7 @@ describe("buildAutoLegend — vector layers", () => {
     assert.ok(entry.gradient);
     assert.equal(entry.gradient?.minLabel, null);
     assert.equal(entry.gradient?.maxLabel, null);
+    assert.equal(entry.gradient?.colors[0], "rgba(0,0,0,0)");
     assert.ok((entry.gradient?.colors.length ?? 0) >= 2);
   });
 

--- a/tests/auto-legend.test.ts
+++ b/tests/auto-legend.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   DEFAULT_LAYER_STYLE,
   DEFAULT_LEGEND_CONFIG,
+  getVectorColorRamp,
   type GeoLibreLayer,
   type LegendConfig,
 } from "../packages/core/src/index";
@@ -344,6 +345,31 @@ describe("buildAutoLegend — vector layers", () => {
     assert.equal(entry.gradient?.maxLabel, null);
     assert.equal(entry.gradient?.colors[0], "rgba(0,0,0,0)");
     assert.ok((entry.gradient?.colors.length ?? 0) >= 2);
+  });
+
+  it("falls back to the default heatmap ramp the map paints, not the first ramp", () => {
+    const entries = buildAutoLegend(
+      [
+        layer({
+          id: "heat",
+          metadata: { geometryType: "point" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            pointRenderer: "heatmap",
+            heatmapColorRamp: "not-a-ramp",
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+    // getVectorColorRamp alone would answer "viridis" here, which is not what
+    // heatmapPaint renders: both go through heatmapRampColors, so an unknown
+    // ramp name resolves to the default ("turbo") in the legend too.
+    assert.deepEqual(entries[0].gradient?.colors, [
+      "rgba(0,0,0,0)",
+      ...getVectorColorRamp(DEFAULT_LAYER_STYLE.heatmapColorRamp).colors,
+    ]);
   });
 
   it("adds proportional-symbol size rows for a point layer", () => {

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -359,12 +359,26 @@ describe("parseMapboxStyle round-trips exported symbology", () => {
       heatmapColorRamp: "viridis",
       heatmapWeightProperty: "nb_ruches",
     });
-    const { style: result } = roundTrip(original, points());
+    const { style: result, warnings } = roundTrip(original, points());
+    assert.deepEqual(warnings, []);
     assert.equal(result.pointRenderer, "heatmap");
     assert.equal(result.heatmapRadius, 42);
     assert.equal(result.heatmapIntensity, 2);
     assert.equal(result.heatmapColorRamp, "viridis");
     assert.equal(result.heatmapWeightProperty, "nb_ruches");
+  });
+
+  it("recovers direct heatmap weight property expressions", () => {
+    for (const weight of [
+      ["get", "nb_ruches"],
+      ["to-number", ["get", "nb_ruches"], 0],
+    ]) {
+      const result = parseMapboxStyle({
+        layers: [{ id: "heat", type: "heatmap", paint: { "heatmap-weight": weight } }],
+      });
+      assert.equal(result.style.heatmapWeightProperty, "nb_ruches");
+      assert.deepEqual(result.warnings, []);
+    }
   });
 
   it("recovers 3D extrusion including height, scale, and base", () => {

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -356,11 +356,15 @@ describe("parseMapboxStyle round-trips exported symbology", () => {
       pointRenderer: "heatmap",
       heatmapRadius: 42,
       heatmapIntensity: 2,
+      heatmapColorRamp: "viridis",
+      heatmapWeightProperty: "nb_ruches",
     });
     const { style: result } = roundTrip(original, points());
     assert.equal(result.pointRenderer, "heatmap");
     assert.equal(result.heatmapRadius, 42);
     assert.equal(result.heatmapIntensity, 2);
+    assert.equal(result.heatmapColorRamp, "viridis");
+    assert.equal(result.heatmapWeightProperty, "nb_ruches");
   });
 
   it("recovers 3D extrusion including height, scale, and base", () => {

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -381,6 +381,14 @@ describe("parseMapboxStyle round-trips exported symbology", () => {
     }
   });
 
+  it("warns instead of throwing for a malformed clamped heatmap weight", () => {
+    const result = parseMapboxStyle({
+      layers: [{ id: "heat", type: "heatmap", paint: { "heatmap-weight": ["max", 0, null] } }],
+    });
+    assert.equal(result.style.heatmapWeightProperty, undefined);
+    assert.ok(result.warnings.some((warning) => /heatmap weight expression/.test(warning)));
+  });
+
   it("recovers 3D extrusion including height, scale, and base", () => {
     const original = style({
       extrusionEnabled: true,

--- a/tests/point-renderer-sync.test.ts
+++ b/tests/point-renderer-sync.test.ts
@@ -100,6 +100,36 @@ describe("point renderer sync", () => {
     assert.ok(!layers.has("layer-pts-circle"));
   });
 
+  it("applies the selected heatmap ramp and numeric weight field", () => {
+    const { map, layers } = makeMap();
+    syncLayer(
+      map as never,
+      pointLayer({
+        pointRenderer: "heatmap",
+        heatmapColorRamp: "viridis",
+        heatmapWeightProperty: "nb_ruches",
+      }),
+    );
+
+    const paint = layers.get("layer-pts-heatmap")?.paint as Record<string, unknown>;
+    assert.deepEqual(paint["heatmap-weight"], ["max", 0, ["to-number", ["get", "nb_ruches"], 0]]);
+    assert.deepEqual(paint["heatmap-color"], [
+      "interpolate",
+      ["linear"],
+      ["heatmap-density"],
+      0,
+      "rgba(0,0,0,0)",
+      0.25,
+      "#440154",
+      0.5,
+      "#31688e",
+      0.75,
+      "#35b779",
+      1,
+      "#fde725",
+    ]);
+  });
+
   it("clusters: a clustered source plus cluster, count, and unclustered layers", () => {
     const { map, layers, sources } = makeMap();
     syncLayer(


### PR DESCRIPTION
## Summary
- add a color-ramp picker to the point heatmap renderer
- add optional numeric attribute weighting, including the reported `nb_ruches` workflow
- keep exported styles, automatic legends, saved layer styles, and all locale catalogs aligned

Addresses https://github.com/opengeos/GeoLibre/discussions/2229

## Test plan
- [x] Import `ruchers_018.csv` as semicolon-delimited point data
- [x] Select Heatmap, Viridis, and `nb_ruches` in light mode
- [x] Verify the controls and selected values in dark mode
- [x] Run the full frontend test suite
- [x] Run the production build and pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Customize heatmap colors with selectable color ramps.
  - Weight heatmap intensity using a numeric data field or equal weighting.
  - Configure color ramps and weight fields through the Python API.
  - Import supported heatmap color ramps and weight fields from map styles.

- **Bug Fixes**
  - Heatmap legends now reflect the selected color ramp and styling.

- **Documentation**
  - Updated localized labels and heatmap API examples for weighting controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->