### PR TITLE
fix(stac): sign Planetary Computer assets

### DIFF
--- a/e2e/stac-api-panel.spec.ts
+++ b/e2e/stac-api-panel.spec.ts
@@ -147,16 +147,17 @@ test("asset options identify their format and whether they can be added", async 
 
 test("Planetary Computer COG assets are signed before raster reads", async ({ page }) => {
   const assetRequests: string[] = [];
-  let tokenRequests = 0;
+  let signingRequests = 0;
   await page.route("https://planetarycomputer.microsoft.com/**", async (route) => {
     const url = new URL(route.request().url());
     const json = (body: unknown) =>
       route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
 
-    if (url.pathname.endsWith("/api/sas/v1/token/private-cog")) {
-      tokenRequests += 1;
+    if (url.pathname.endsWith("/api/sas/v1/sign")) {
+      signingRequests += 1;
+      expect(url.searchParams.get("href")).toBe(PRIVATE_PLANETARY_COMPUTER_COG);
       return json({
-        token: "sp=r&sig=signed-for-test",
+        href: `${PRIVATE_PLANETARY_COMPUTER_COG}?sp=r&sig=signed-for-test`,
         "msft:expiry": "2099-01-01T00:00:00Z",
       });
     }
@@ -203,7 +204,7 @@ test("Planetary Computer COG assets are signed before raster reads", async ({ pa
   await page.getByRole("button", { name: "Add", exact: true }).click();
 
   await expect.poll(() => assetRequests.length).toBeGreaterThan(0);
-  expect(tokenRequests).toBe(1);
+  expect(signingRequests).toBe(1);
   const requestedAsset = new URL(assetRequests[0]);
   expect(requestedAsset.searchParams.get("sp")).toBe("r");
   expect(requestedAsset.searchParams.get("sig")).toBe("signed-for-test");

--- a/e2e/stac-api-panel.spec.ts
+++ b/e2e/stac-api-panel.spec.ts
@@ -6,6 +6,9 @@ import { waitForMap } from "./helpers";
 // has no tree at all: it answers item search itself, and offering a tree of its hierarchy would
 // promise a way in that its endpoint does not honour.
 const API = "https://api.stac.test/v1";
+const PLANETARY_COMPUTER_API = "https://planetarycomputer.microsoft.com/api/stac/v1/";
+const PRIVATE_PLANETARY_COMPUTER_COG =
+  "https://ai4edataeuwest.blob.core.windows.net/private-cog/example.tif";
 
 const COLLECTIONS = [
   {
@@ -140,6 +143,70 @@ test("asset options identify their format and whether they can be added", async 
     "Dataset root — Parquet",
     "Metadata — Unknown format (not addable)",
   ]);
+});
+
+test("Planetary Computer COG assets are signed before raster reads", async ({ page }) => {
+  const assetRequests: string[] = [];
+  let tokenRequests = 0;
+  await page.route("https://planetarycomputer.microsoft.com/**", async (route) => {
+    const url = new URL(route.request().url());
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+
+    if (url.pathname.endsWith("/api/sas/v1/token/private-cog")) {
+      tokenRequests += 1;
+      return json({
+        token: "sp=r&sig=signed-for-test",
+        "msft:expiry": "2099-01-01T00:00:00Z",
+      });
+    }
+    if (url.pathname.endsWith("/collections")) {
+      return json({ collections: [{ id: "private-cog", title: "Private COG" }] });
+    }
+    if (url.pathname.endsWith("/search")) {
+      return json({
+        type: "FeatureCollection",
+        features: [
+          item("private-cog-1", "private-cog", {
+            data: { href: PRIVATE_PLANETARY_COMPUTER_COG, type: "image/tiff" },
+          }),
+        ],
+        numberMatched: 1,
+        links: [],
+      });
+    }
+    return json({
+      type: "Catalog",
+      id: "planetary-computer",
+      title: "Planetary Computer",
+      conformsTo: ["https://api.stacspec.org/v1.0.0/item-search"],
+      links: [
+        { rel: "data", href: `${PLANETARY_COMPUTER_API}collections` },
+        { rel: "search", href: `${PLANETARY_COMPUTER_API}search`, method: "POST" },
+      ],
+    });
+  });
+  await page.route(`${PRIVATE_PLANETARY_COMPUTER_COG}**`, async (route) => {
+    assetRequests.push(route.request().url());
+    await route.fulfill({ status: 404, body: "fixture only checks the signed request" });
+  });
+
+  await waitForMap(page);
+  await connect(page, PLANETARY_COMPUTER_API);
+  await page.getByLabel("Limit search to the current map extent").uncheck();
+  await page
+    .locator("select")
+    .filter({ has: page.locator('option[value="private-cog"]') })
+    .selectOption("private-cog");
+  await page.getByRole("button", { name: "Search items" }).click();
+  await expect(page.getByText(/Showing 1 of 1 items\./)).toBeVisible();
+  await page.getByRole("button", { name: "Add", exact: true }).click();
+
+  await expect.poll(() => assetRequests.length).toBeGreaterThan(0);
+  expect(tokenRequests).toBe(1);
+  const requestedAsset = new URL(assetRequests[0]);
+  expect(requestedAsset.searchParams.get("sp")).toBe("r");
+  expect(requestedAsset.searchParams.get("sig")).toBe("signed-for-test");
 });
 
 async function connect(page: Page, url: string): Promise<void> {

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -36,6 +36,7 @@ import {
 import { disposeAllPaletteLegends, disposePaletteLegend } from "./raster-palette";
 import { isNonTiledRasterError } from "./non-tiled-raster-error";
 import { convertTiffYCbCrToRgb } from "./tiff-ycbcr";
+import { readableStacLayerHref } from "./stac-signing";
 
 const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const RASTER_PANEL_CLASS = "geolibre-raster-panel";
@@ -628,6 +629,22 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     // early, and the next control event would then prune the not-yet-replayed
     // layers out of the store.
     const localFiles = await readLocalRasterFiles(control);
+    const remoteSources = new Map(
+      await Promise.all(
+        useAppStore
+          .getState()
+          .layers.filter(isRasterControlStoreLayer)
+          .flatMap((layer) => {
+            const url =
+              typeof layer.source.url === "string" && layer.source.url
+                ? layer.source.url
+                : undefined;
+            return url
+              ? [readableStacLayerHref(layer, url).then((href) => [layer.id, href] as const)]
+              : [];
+          }),
+      ),
+    );
 
     // Re-read the store after the await: the project may have changed while
     // the control class was loading.
@@ -668,8 +685,9 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
         if (!isRasterControlStoreLayer(layer)) continue;
         if (control.getRaster(layer.id)) continue;
 
-        const url =
+        const storedUrl =
           typeof layer.source.url === "string" && layer.source.url ? layer.source.url : undefined;
+        const url = remoteSources.get(layer.id) ?? storedUrl;
         // A local file that was re-read above replays from its bytes; the
         // control re-derives its own blob URL from the File, as on a fresh add.
         const source = url ?? localFiles.get(layer.id);

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -640,7 +640,11 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
                 ? layer.source.url
                 : undefined;
             return url
-              ? [readableStacLayerHref(layer, url).then((href) => [layer.id, href] as const)]
+              ? [
+                  readableStacLayerHref(layer, url).then(
+                    (href) => [layer.id, { sourceUrl: url, href }] as const,
+                  ),
+                ]
               : [];
           }),
       ),
@@ -687,7 +691,11 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
 
         const storedUrl =
           typeof layer.source.url === "string" && layer.source.url ? layer.source.url : undefined;
-        const url = remoteSources.get(layer.id) ?? storedUrl;
+        const resolvedSource = remoteSources.get(layer.id);
+        const url =
+          resolvedSource && resolvedSource.sourceUrl === storedUrl
+            ? resolvedSource.href
+            : storedUrl;
         // A local file that was re-read above replays from its bytes; the
         // control re-derives its own blob URL from the File, as on a fresh add.
         const source = url ?? localFiles.get(layer.id);

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -17,7 +17,6 @@ import {
   connectStac,
   horizontalBbox,
   icechunkBranch,
-  isAzureBlobHref,
   isIcechunkAsset,
   isVisualizableAsset,
   requiresTarget,
@@ -53,6 +52,12 @@ import {
   repositoryOpenError,
   type ZarrKeyReader,
 } from "./stac-icechunk";
+import {
+  createStacAssetAccess,
+  readableStacAssetHref,
+  STAC_ASSET_ACCESS_METADATA_KEY,
+  type StacAssetAccess,
+} from "./stac-signing";
 
 export const STAC_PLUGIN_ID = "geolibre-stac-catalogs";
 export const PLANET_OPEN_DATA_PLUGIN_ID = "geolibre-planet-open-data";
@@ -664,45 +669,34 @@ function assetOptionLabel(item: StacItem, key: string, asset: StacAsset): string
   return `${assetLabel(key, asset)} — ${assetFormatLabel(asset)}${addability}`;
 }
 
-type SasSigner = { signUrl(url: string, collectionId: string): Promise<string> };
-let sasManager: Promise<SasSigner> | null = null;
-
-function planetaryComputerSigner(): Promise<SasSigner> {
-  sasManager ??= import("maplibre-gl-planetary-computer")
-    .then((module) => new module.SASTokenManager())
-    .catch((error) => {
-      // Don't let one failed import disable signing for the rest of the session.
-      sasManager = null;
-      throw error;
-    });
-  return sasManager;
-}
-
 /**
- * Planetary Computer serves several collections — most of the GeoParquet ones — from private
- * containers that answer 409 without a SAS token, while others (NAIP) read fine anonymously.
+ * Planetary Computer serves several collections from private containers that answer 409 without
+ * a SAS token, while others (NAIP) read fine anonymously.
  * Tokens are per-collection and expire within the hour, so they are minted when the asset is
  * added rather than when the item is parsed, and the upstream manager caches them. Anything
- * that is not an Azure blob, or that cannot be signed, is read unsigned.
- *
- * Only the GeoParquet path signs, because that is the one this branch made addable and it cannot
- * read a private container at all unsigned. PMTiles and COG read unsigned exactly as they did
- * before, rather than gaining a token they never had.
- *
- * Every one of these formats persists whatever URL it is handed: PMTiles and COG through the
- * store layer they create, and the vector control through `createVectorStoreLayer`, which records
- * the URL as both `source.url` and `sourcePath`. A project saved with a signed GeoParquet layer
- * therefore holds a token that `restoreVectorLayers` replays as-is and never re-signs, so the
- * layer stops reloading once the token lapses (about an hour). Fixing that properly means minting
- * the token per request, or re-signing on restore, rather than baking one in at add time.
+ * that is not an eligible Planetary Computer Azure blob, or that cannot be signed, is read
+ * unsigned. COG and GeoParquet layers retain the unsigned asset identity in metadata so project
+ * restore can mint a fresh token instead of replaying an expired one.
  */
-async function readableHref(item: StacItem, href: string): Promise<string> {
-  if (!isAzureBlobHref(href) || !item.collection) return href;
-  try {
-    return await (await planetaryComputerSigner()).signUrl(href, item.collection);
-  } catch {
-    return href;
-  }
+function assetAccess(
+  connection: StacConnection,
+  item: StacItem,
+  href: string,
+): StacAssetAccess | null {
+  return createStacAssetAccess(connection.url, item.collection, href);
+}
+
+function rememberAssetAccess(layerId: string, access: StacAssetAccess | null): void {
+  if (!access) return;
+  const layer = useAppStore.getState().layers.find((candidate) => candidate.id === layerId);
+  if (!layer) return;
+  useAppStore.getState().updateLayer(layerId, {
+    metadata: { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: access },
+  });
+}
+
+function readableHref(connection: StacConnection, item: StacItem, href: string): Promise<string> {
+  return readableStacAssetHref(assetAccess(connection, item, href), href);
 }
 
 /**
@@ -725,6 +719,7 @@ async function openIcechunkAsset(
 }
 
 async function visualizeAsset(
+  connection: StacConnection,
   item: StacItem,
   key: string,
   asset: StacAsset,
@@ -744,7 +739,7 @@ async function visualizeAsset(
     }
     case "geojson": {
       if (!appRef) throw new Error(labels.addFailed);
-      const response = await fetch(asset.href, {
+      const response = await fetch(await readableHref(connection, item, asset.href), {
         headers: { Accept: "application/geo+json, application/json" },
         signal,
       });
@@ -755,8 +750,16 @@ async function visualizeAsset(
     }
     case "parquet": {
       if (!appRef) throw new Error(labels.addFailed);
-      if (!(await addVectorLayerFromUrl(appRef, await readableHref(item, asset.href), { name }))) {
+      const access = assetAccess(connection, item, asset.href);
+      const href = await readableStacAssetHref(access, asset.href);
+      const previousIds = new Set(useAppStore.getState().layers.map((layer) => layer.id));
+      if (!(await addVectorLayerFromUrl(appRef, href, { name }))) {
         throw new Error(labels.addFailed);
+      }
+      for (const layer of useAppStore.getState().layers) {
+        if (!previousIds.has(layer.id) && layer.source.url === href) {
+          rememberAssetAccess(layer.id, access);
+        }
       }
       return;
     }
@@ -816,7 +819,10 @@ async function visualizeAsset(
     }
     case "cog": {
       if (!appRef?.addCogLayer) throw new Error(labels.cogUnsupported);
-      await appRef.addCogLayer(name, asset.href, cogOptions);
+      const access = assetAccess(connection, item, asset.href);
+      const href = await readableStacAssetHref(access, asset.href);
+      const layerId = await appRef.addCogLayer(name, href, cogOptions);
+      rememberAssetAccess(layerId, access);
       return;
     }
     case null:
@@ -1274,7 +1280,16 @@ function buildPanel(container: HTMLElement): () => void {
           syncAsset();
           setStatus(labels.adding(assetLabel(key, asset)));
           try {
-            await visualizeAsset(item, key, asset, cogOptions(), controller.signal, target);
+            if (!connection) throw new Error(labels.addFailed);
+            await visualizeAsset(
+              connection,
+              item,
+              key,
+              asset,
+              cogOptions(),
+              controller.signal,
+              target,
+            );
             setStatus(labels.added(assetLabel(key, asset)));
           } catch (error) {
             setStatus(error instanceof Error ? error.message : labels.addFailed, true);
@@ -1283,7 +1298,13 @@ function buildPanel(container: HTMLElement): () => void {
             syncAsset();
           }
         });
-        download.addEventListener("click", () => appRef?.openExternalUrl?.(selected()[1].href));
+        download.addEventListener("click", () => {
+          const asset = selected()[1];
+          if (!connection) return;
+          void readableHref(connection, item, asset.href).then((href) =>
+            appRef?.openExternalUrl?.(href),
+          );
+        });
         syncAsset();
         actions.append(assetSelect, targetSelect, add, download);
       }

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -43,7 +43,7 @@ import {
 } from "./stac-api";
 import { buildCatalogTree } from "./stac-catalog-tree";
 import { el, setDisabled } from "../panel-dom";
-import { addVectorLayerFromUrl } from "./maplibre-vector";
+import { addVectorLayersFromUrl } from "./maplibre-vector";
 import { addZarrRasterLayer } from "./maplibre-components";
 import {
   icechunkLayerUrl,
@@ -752,15 +752,11 @@ async function visualizeAsset(
       if (!appRef) throw new Error(labels.addFailed);
       const access = assetAccess(connection, item, asset.href);
       const href = await readableStacAssetHref(access, asset.href);
-      const previousIds = new Set(useAppStore.getState().layers.map((layer) => layer.id));
-      if (!(await addVectorLayerFromUrl(appRef, href, { name }))) {
+      const layerIds = await addVectorLayersFromUrl(appRef, href, { name });
+      if (!layerIds?.length) {
         throw new Error(labels.addFailed);
       }
-      for (const layer of useAppStore.getState().layers) {
-        if (!previousIds.has(layer.id) && layer.source.url === href) {
-          rememberAssetAccess(layer.id, access);
-        }
-      }
+      for (const layerId of layerIds) rememberAssetAccess(layerId, access);
       return;
     }
     case "zarr": {

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -672,8 +672,8 @@ function assetOptionLabel(item: StacItem, key: string, asset: StacAsset): string
 /**
  * Planetary Computer serves several collections from private containers that answer 409 without
  * a SAS token, while others (NAIP) read fine anonymously.
- * Tokens are per-collection and expire within the hour, so they are minted when the asset is
- * added rather than when the item is parsed, and the upstream manager caches them. Anything
+ * Signed URLs expire within the hour, so they are minted when the asset is added rather than when
+ * the item is parsed, and cached until shortly before expiry. Anything
  * that is not an eligible Planetary Computer Azure blob, or that cannot be signed, is read
  * unsigned. COG and GeoParquet layers retain the unsigned asset identity in metadata so project
  * restore can mint a fresh token instead of replaying an expired one.
@@ -692,6 +692,8 @@ function rememberAssetAccess(layerId: string, access: StacAssetAccess | null): v
   if (!layer) return;
   useAppStore.getState().updateLayer(layerId, {
     metadata: { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: access },
+    source: { ...layer.source, url: access.href },
+    sourcePath: access.href,
   });
 }
 

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -686,10 +686,22 @@ function assetAccess(
   return createStacAssetAccess(connection.url, item.collection, href);
 }
 
+/**
+ * Records how a layer's asset can be signed again, so a saved project restores
+ * a private asset instead of replaying an expired token.
+ *
+ * The layer has to be in the store already: every add path here resolves only
+ * after its control's store sync has written it (see the Zarr branch below).
+ * Should that ever stop holding, signed assets would quietly stop surviving a
+ * project save, so say so rather than dropping the record in silence.
+ */
 function rememberAssetAccess(layerId: string, access: StacAssetAccess | null): void {
   if (!access) return;
   const layer = useAppStore.getState().layers.find((candidate) => candidate.id === layerId);
-  if (!layer) return;
+  if (!layer) {
+    console.warn("[GeoLibre] STAC asset access could not be stored: no layer", layerId);
+    return;
+  }
   useAppStore.getState().updateLayer(layerId, {
     metadata: { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: access },
     source: { ...layer.source, url: access.href },
@@ -739,6 +751,9 @@ async function visualizeAsset(
   switch (format) {
     case "pmtiles": {
       // No appRef check: the layer goes to the store, not through the app API.
+      // Read unsigned, exactly as before: Planetary Computer serves no PMTiles
+      // from a private container, and a tile URL that outlives its token would
+      // break the layer an hour later rather than fix it.
       if (!(await addPMTilesAsset(asset.href, name, signal))) {
         throw new Error(labels.addNoSourceLayers);
       }

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -697,8 +697,13 @@ function rememberAssetAccess(layerId: string, access: StacAssetAccess | null): v
   });
 }
 
-function readableHref(connection: StacConnection, item: StacItem, href: string): Promise<string> {
-  return readableStacAssetHref(assetAccess(connection, item, href), href);
+function readableHref(
+  connection: StacConnection,
+  item: StacItem,
+  href: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  return readableStacAssetHref(assetAccess(connection, item, href), href, signal);
 }
 
 /**
@@ -741,7 +746,7 @@ async function visualizeAsset(
     }
     case "geojson": {
       if (!appRef) throw new Error(labels.addFailed);
-      const response = await fetch(await readableHref(connection, item, asset.href), {
+      const response = await fetch(await readableHref(connection, item, asset.href, signal), {
         headers: { Accept: "application/geo+json, application/json" },
         signal,
       });
@@ -753,7 +758,7 @@ async function visualizeAsset(
     case "parquet": {
       if (!appRef) throw new Error(labels.addFailed);
       const access = assetAccess(connection, item, asset.href);
-      const href = await readableStacAssetHref(access, asset.href);
+      const href = await readableStacAssetHref(access, asset.href, signal);
       const layerIds = await addVectorLayersFromUrl(appRef, href, { name });
       if (!layerIds?.length) {
         throw new Error(labels.addFailed);
@@ -818,7 +823,7 @@ async function visualizeAsset(
     case "cog": {
       if (!appRef?.addCogLayer) throw new Error(labels.cogUnsupported);
       const access = assetAccess(connection, item, asset.href);
-      const href = await readableStacAssetHref(access, asset.href);
+      const href = await readableStacAssetHref(access, asset.href, signal);
       const layerId = await appRef.addCogLayer(name, href, cogOptions);
       rememberAssetAccess(layerId, access);
       return;
@@ -1306,7 +1311,9 @@ function buildPanel(container: HTMLElement): () => void {
           signingDownload = true;
           syncAsset();
           try {
-            appRef?.openExternalUrl?.(await readableHref(connection, item, asset.href));
+            appRef?.openExternalUrl?.(
+              await readableHref(connection, item, asset.href, controller.signal),
+            );
           } catch (error) {
             setStatus(error instanceof Error ? error.message : labels.addFailed, true);
           } finally {

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -1252,7 +1252,9 @@ function buildPanel(container: HTMLElement): () => void {
         targetSelect.style.cssText = `${style.input}flex:1 1 140px;width:auto;`;
         targetSelect.title = labels.chooseTarget;
         let adding = false;
-        let signingDownload = false;
+        // Which asset's download is being signed, so switching the dropdown to
+        // another asset does not find its own button disabled.
+        let signingDownloadKey: string | null = null;
 
         const syncAsset = (): void => {
           const [key, asset] = selected();
@@ -1274,7 +1276,7 @@ function buildPanel(container: HTMLElement): () => void {
           setDisabled(add, adding || !addable);
           // A private asset is signed before it opens, so the button says so
           // by going quiet rather than looking like a dead click.
-          setDisabled(download, signingDownload);
+          setDisabled(download, signingDownloadKey === key);
           add.title = addReason(item, key, asset);
         };
 
@@ -1306,9 +1308,9 @@ function buildPanel(container: HTMLElement): () => void {
           }
         });
         download.addEventListener("click", async () => {
-          const asset = selected()[1];
+          const [key, asset] = selected();
           if (!connection) return;
-          signingDownload = true;
+          signingDownloadKey = key;
           syncAsset();
           try {
             appRef?.openExternalUrl?.(
@@ -1317,7 +1319,9 @@ function buildPanel(container: HTMLElement): () => void {
           } catch (error) {
             setStatus(error instanceof Error ? error.message : labels.addFailed, true);
           } finally {
-            signingDownload = false;
+            // Only this asset's own sign clears the flag: the user may have
+            // moved on and started another one.
+            if (signingDownloadKey === key) signingDownloadKey = null;
             syncAsset();
           }
         });

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -1247,6 +1247,7 @@ function buildPanel(container: HTMLElement): () => void {
         targetSelect.style.cssText = `${style.input}flex:1 1 140px;width:auto;`;
         targetSelect.title = labels.chooseTarget;
         let adding = false;
+        let signingDownload = false;
 
         const syncAsset = (): void => {
           const [key, asset] = selected();
@@ -1266,6 +1267,9 @@ function buildPanel(container: HTMLElement): () => void {
           assetSelect.title = asset.href;
           download.title = asset.href;
           setDisabled(add, adding || !addable);
+          // A private asset is signed before it opens, so the button says so
+          // by going quiet rather than looking like a dead click.
+          setDisabled(download, signingDownload);
           add.title = addReason(item, key, asset);
         };
 
@@ -1296,12 +1300,19 @@ function buildPanel(container: HTMLElement): () => void {
             syncAsset();
           }
         });
-        download.addEventListener("click", () => {
+        download.addEventListener("click", async () => {
           const asset = selected()[1];
           if (!connection) return;
-          void readableHref(connection, item, asset.href).then((href) =>
-            appRef?.openExternalUrl?.(href),
-          );
+          signingDownload = true;
+          syncAsset();
+          try {
+            appRef?.openExternalUrl?.(await readableHref(connection, item, asset.href));
+          } catch (error) {
+            setStatus(error instanceof Error ? error.message : labels.addFailed, true);
+          } finally {
+            signingDownload = false;
+            syncAsset();
+          }
         });
         syncAsset();
         actions.append(assetSelect, targetSelect, add, download);

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -99,6 +99,11 @@ type VectorControlConstructor = typeof VectorControl;
 let vectorControlClassPromise: Promise<VectorControlConstructor> | null = null;
 let vectorControl: VectorControl | null = null;
 let vectorControlMounted = false;
+/**
+ * Serializes addVectorLayersFromUrl so overlapping remote adds cannot claim
+ * each other's layers -- see the comment in that function.
+ */
+let remoteVectorAddQueue: Promise<void> = Promise.resolve();
 let openPanelTimeout: number | null = null;
 let restorePanelExpandTimeout: number | null = null;
 /**
@@ -726,12 +731,47 @@ export async function addVectorLayersFromUrl(
 ): Promise<string[] | null> {
   const control = await ensureVectorControl(app);
   if (!control) return null;
-  const previousIds = new Set(control.getLayers().map((layer) => layer.id));
-  await control.addData(url, options);
-  return control
-    .getLayers()
-    .filter((layer) => !previousIds.has(layer.id))
-    .map((layer) => layer.id);
+  return addVectorLayersThroughControl(control, url, options);
+}
+
+/** The subset of VectorControl used to add a remote dataset (eases testing). */
+export type VectorUrlSink = Pick<VectorControl, "addData" | "getLayers">;
+
+/**
+ * Adds one remote dataset through a control and reports the layer ids it
+ * created.
+ *
+ * `addData` resolves with a single layer while a multi-layer container adds
+ * several, so the created ids are read as a before/after diff of
+ * `getLayers()`. Two overlapping adds would share a "before" snapshot and each
+ * claim the other's layers, so they run one at a time: a caller that tags what
+ * it added (the STAC panel writes an asset-access record onto every returned
+ * id) must never be handed a layer that came from a different dataset.
+ *
+ * @param control - The vector control (or anything with `addData`/`getLayers`).
+ * @param url - An http(s) URL to a vector dataset.
+ * @param options - Display name, fitBounds, explicit format, ...
+ * @returns The ids of the layers this call created.
+ */
+export function addVectorLayersThroughControl(
+  control: VectorUrlSink,
+  url: string,
+  options: VectorLayerOptions = {},
+): Promise<string[]> {
+  const added = remoteVectorAddQueue.then(async () => {
+    const previousIds = new Set(control.getLayers().map((layer) => layer.id));
+    await control.addData(url, options);
+    return control
+      .getLayers()
+      .filter((layer) => !previousIds.has(layer.id))
+      .map((layer) => layer.id);
+  });
+  // Errors belong to the caller; the queue only needs the turn to end.
+  remoteVectorAddQueue = added.then(
+    () => undefined,
+    () => undefined,
+  );
+  return added;
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -99,11 +99,6 @@ type VectorControlConstructor = typeof VectorControl;
 let vectorControlClassPromise: Promise<VectorControlConstructor> | null = null;
 let vectorControl: VectorControl | null = null;
 let vectorControlMounted = false;
-/**
- * Serializes addVectorLayersFromUrl so overlapping remote adds cannot claim
- * each other's layers -- see the comment in that function.
- */
-let remoteVectorAddQueue: Promise<void> = Promise.resolve();
 let openPanelTimeout: number | null = null;
 let restorePanelExpandTimeout: number | null = null;
 /**
@@ -743,35 +738,33 @@ export type VectorUrlSink = Pick<VectorControl, "addData" | "getLayers">;
  *
  * `addData` resolves with a single layer while a multi-layer container adds
  * several, so the created ids are read as a before/after diff of
- * `getLayers()`. Two overlapping adds would share a "before" snapshot and each
- * claim the other's layers, so they run one at a time: a caller that tags what
- * it added (the STAC panel writes an asset-access record onto every returned
- * id) must never be handed a layer that came from a different dataset.
+ * `getLayers()`. A load that overlaps another one -- two "Add" clicks in the
+ * STAC panel, a Hugging Face add while a large GeoParquet is still
+ * downloading -- would otherwise pick up the other load's layers as well, and
+ * a caller that tags what it added (the STAC panel writes an asset-access
+ * record onto every returned id) would stamp one dataset's identity onto
+ * another's layer. Only layers the control recorded against this url count as
+ * ours; the control echoes the url back on `source` verbatim.
  *
  * @param control - The vector control (or anything with `addData`/`getLayers`).
  * @param url - An http(s) URL to a vector dataset.
  * @param options - Display name, fitBounds, explicit format, ...
  * @returns The ids of the layers this call created.
  */
-export function addVectorLayersThroughControl(
+export async function addVectorLayersThroughControl(
   control: VectorUrlSink,
   url: string,
   options: VectorLayerOptions = {},
 ): Promise<string[]> {
-  const added = remoteVectorAddQueue.then(async () => {
-    const previousIds = new Set(control.getLayers().map((layer) => layer.id));
-    await control.addData(url, options);
-    return control
-      .getLayers()
-      .filter((layer) => !previousIds.has(layer.id))
-      .map((layer) => layer.id);
-  });
-  // Errors belong to the caller; the queue only needs the turn to end.
-  remoteVectorAddQueue = added.then(
-    () => undefined,
-    () => undefined,
-  );
-  return added;
+  const previousIds = new Set(control.getLayers().map((layer) => layer.id));
+  await control.addData(url, options);
+  return control
+    .getLayers()
+    .filter(
+      (layer) =>
+        !previousIds.has(layer.id) && layer.source.kind === "url" && layer.source.url === url,
+    )
+    .map((layer) => layer.id);
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -717,17 +717,37 @@ async function ensureVectorControl(app: GeoLibreAppAPI): Promise<VectorControl |
  * @param app - The GeoLibre app API.
  * @param url - An http(s) URL to a vector dataset.
  * @param options - Display name, fitBounds, explicit format, ...
- * @returns True when the layer was added.
+ * @returns The created layer ids, or null when the control is unavailable.
+ */
+export async function addVectorLayersFromUrl(
+  app: GeoLibreAppAPI,
+  url: string,
+  options: VectorLayerOptions = {},
+): Promise<string[] | null> {
+  const control = await ensureVectorControl(app);
+  if (!control) return null;
+  const previousIds = new Set(control.getLayers().map((layer) => layer.id));
+  await control.addData(url, options);
+  return control
+    .getLayers()
+    .filter((layer) => !previousIds.has(layer.id))
+    .map((layer) => layer.id);
+}
+
+/**
+ * Loads a remote vector dataset and reports whether the control was available.
+ *
+ * @param app - The GeoLibre app API.
+ * @param url - An http(s) URL to a vector dataset.
+ * @param options - Display name, fitBounds, explicit format, ...
+ * @returns True when the control accepted the layer.
  */
 export async function addVectorLayerFromUrl(
   app: GeoLibreAppAPI,
   url: string,
   options: VectorLayerOptions = {},
 ): Promise<boolean> {
-  const control = await ensureVectorControl(app);
-  if (!control) return false;
-  await control.addData(url, options);
-  return true;
+  return (await addVectorLayersFromUrl(app, url, options)) !== null;
 }
 
 function getVectorControlClass(): Promise<VectorControlConstructor> {

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -36,6 +36,7 @@ import {
   unwireVectorStoreSync,
   wireVectorStoreSync,
 } from "./vector-layer-sync";
+import { readableStacLayerHref } from "./stac-signing";
 import type { FeatureCollection } from "geojson";
 
 const vectorControlPosition: GeoLibreMapControlPosition = "top-left";
@@ -336,9 +337,11 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
           pending.push(
             trackReplay(
               layer.id,
-              replayVectorLayer(control, layer, url, restoredGroups, {
-                onError: () => failedLayerIds.add(layer.id),
-              }),
+              readableStacLayerHref(layer, url).then((href) =>
+                replayVectorLayer(control, layer, href, restoredGroups, {
+                  onError: () => failedLayerIds.add(layer.id),
+                }),
+              ),
             ),
           );
           continue;
@@ -573,7 +576,7 @@ export async function replayVectorControlLayerById(
   replayingLayerIds.add(id);
   suspendVectorStoreSync();
   try {
-    await replayVectorLayer(control, layer, url, groups);
+    await replayVectorLayer(control, layer, await readableStacLayerHref(layer, url), groups);
   } finally {
     resumeVectorStoreSync();
     replayingLayerIds.delete(id);

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -332,6 +332,13 @@ export function syncRasterLayersToStoreWithOptions(
       }
       const metadata =
         Object.keys(preserved).length > 0 ? { ...layer.metadata, ...preserved } : layer.metadata;
+      const stacAssetAccess = preserved[STAC_ASSET_ACCESS_METADATA_KEY] as
+        | ReturnType<typeof stacAssetAccessFromLayer>
+        | undefined;
+      const source = stacAssetAccess
+        ? { ...layer.source, url: stacAssetAccess.href }
+        : layer.source;
+      const sourcePath = stacAssetAccess ? stacAssetAccess.href : layer.sourcePath;
 
       // A control still reporting the value this module last knows it to hold
       // is echoing that value, not recording a user edit. Mirroring the echo
@@ -358,8 +365,8 @@ export function syncRasterLayersToStoreWithOptions(
       if (
         existing.visible !== visible ||
         existing.opacity !== opacity ||
-        existing.sourcePath !== layer.sourcePath ||
-        !recordsEqual(existing.source, layer.source) ||
+        existing.sourcePath !== sourcePath ||
+        !recordsEqual(existing.source, source) ||
         !recordsEqual(existing.metadata, metadata)
       ) {
         useAppStore.getState().updateLayer(layer.id, {
@@ -367,8 +374,8 @@ export function syncRasterLayersToStoreWithOptions(
           // survive a raster being swapped out under the same id.
           metadata,
           opacity,
-          source: layer.source,
-          sourcePath: layer.sourcePath,
+          source,
+          sourcePath,
           visible,
         });
       }

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -6,7 +6,7 @@ import {
   useAppStore,
 } from "@geolibre/core";
 import type { RasterLayerInfo, RasterLayerState, RenderEngine } from "maplibre-gl-raster";
-import { STAC_ASSET_ACCESS_METADATA_KEY } from "./stac-signing";
+import { stacAssetAccessFromLayer, STAC_ASSET_ACCESS_METADATA_KEY } from "./stac-signing";
 
 export const RASTER_SOURCE_KIND = "maplibre-gl-raster";
 
@@ -320,6 +320,12 @@ export function syncRasterLayersToStoreWithOptions(
       // wipe them.
       const preserved: Record<string, unknown> = {};
       for (const key of GEOLIBRE_OWNED_METADATA_KEYS) {
+        if (key === STAC_ASSET_ACCESS_METADATA_KEY) {
+          const sourceUrl = typeof layer.source.url === "string" ? layer.source.url : undefined;
+          const access = sourceUrl ? stacAssetAccessFromLayer(existing, sourceUrl) : null;
+          if (access) preserved[key] = access;
+          continue;
+        }
         if (existing.metadata[key] !== undefined) {
           preserved[key] = existing.metadata[key];
         }

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -6,6 +6,7 @@ import {
   useAppStore,
 } from "@geolibre/core";
 import type { RasterLayerInfo, RasterLayerState, RenderEngine } from "maplibre-gl-raster";
+import { STAC_ASSET_ACCESS_METADATA_KEY } from "./stac-signing";
 
 export const RASTER_SOURCE_KIND = "maplibre-gl-raster";
 
@@ -271,6 +272,7 @@ export const GEOLIBRE_OWNED_METADATA_KEYS = [
   "rasterSymbology",
   "rasterAttributeTable",
   "localBytesUrl",
+  STAC_ASSET_ACCESS_METADATA_KEY,
 ] as const;
 
 export function syncRasterLayersToStoreWithOptions(

--- a/packages/plugins/src/plugins/stac-signing.ts
+++ b/packages/plugins/src/plugins/stac-signing.ts
@@ -1,0 +1,94 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import { isAzureBlobHref } from "./stac-api";
+
+const PLANETARY_COMPUTER_HOST = "planetarycomputer.microsoft.com";
+
+/** Metadata key used to retain the unsigned STAC asset identity across project saves. */
+export const STAC_ASSET_ACCESS_METADATA_KEY = "stacAssetAccess";
+
+export interface StacAssetAccess {
+  catalogUrl: string;
+  collectionId: string;
+  href: string;
+}
+
+type SasSigner = { signUrl(url: string, collectionId: string): Promise<string> };
+let sasManager: Promise<SasSigner> | null = null;
+
+function planetaryComputerSigner(): Promise<SasSigner> {
+  sasManager ??= import("maplibre-gl-planetary-computer")
+    .then((module) => new module.SASTokenManager())
+    .catch((error) => {
+      // Do not let one failed import disable signing for the rest of the session.
+      sasManager = null;
+      throw error;
+    });
+  return sasManager;
+}
+
+function catalogHost(catalogUrl: string): string | null {
+  try {
+    return new URL(catalogUrl).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Builds the information needed to sign a Planetary Computer asset.
+ *
+ * Restricting the catalog host prevents a third-party STAC catalog that also
+ * uses Azure storage from sending its collection and asset details to
+ * Microsoft's token endpoint.
+ */
+export function createStacAssetAccess(
+  catalogUrl: string,
+  collectionId: string | undefined,
+  href: string,
+): StacAssetAccess | null {
+  if (
+    catalogHost(catalogUrl) !== PLANETARY_COMPUTER_HOST ||
+    !collectionId ||
+    !isAzureBlobHref(href)
+  ) {
+    return null;
+  }
+  return { catalogUrl, collectionId, href };
+}
+
+/** Reads and validates persisted STAC asset access metadata from a layer. */
+export function stacAssetAccessFromLayer(layer: GeoLibreLayer): StacAssetAccess | null {
+  const value = layer.metadata[STAC_ASSET_ACCESS_METADATA_KEY];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as Partial<StacAssetAccess>;
+  if (
+    typeof candidate.catalogUrl !== "string" ||
+    typeof candidate.collectionId !== "string" ||
+    typeof candidate.href !== "string"
+  ) {
+    return null;
+  }
+  return createStacAssetAccess(candidate.catalogUrl, candidate.collectionId, candidate.href);
+}
+
+/**
+ * Returns a fresh signed URL for a protected asset, or its unsigned URL when
+ * signing is unavailable. The upstream manager caches tokens until they near
+ * expiry, so calling this again during project restore is inexpensive.
+ */
+export async function readableStacAssetHref(
+  access: StacAssetAccess | null,
+  fallbackHref: string,
+): Promise<string> {
+  if (!access) return fallbackHref;
+  try {
+    return await (await planetaryComputerSigner()).signUrl(access.href, access.collectionId);
+  } catch {
+    return access.href;
+  }
+}
+
+/** Re-signs a saved STAC-backed layer from its retained unsigned asset URL. */
+export function readableStacLayerHref(layer: GeoLibreLayer, fallbackHref: string): Promise<string> {
+  return readableStacAssetHref(stacAssetAccessFromLayer(layer), fallbackHref);
+}

--- a/packages/plugins/src/plugins/stac-signing.ts
+++ b/packages/plugins/src/plugins/stac-signing.ts
@@ -2,6 +2,8 @@ import type { GeoLibreLayer } from "@geolibre/core";
 import { isAzureBlobHref } from "./stac-api";
 
 const PLANETARY_COMPUTER_HOST = "planetarycomputer.microsoft.com";
+const PLANETARY_COMPUTER_SIGN_URL = "https://planetarycomputer.microsoft.com/api/sas/v1/sign";
+const SIGNING_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
 /** Metadata key used to retain the unsigned STAC asset identity across project saves. */
 export const STAC_ASSET_ACCESS_METADATA_KEY = "stacAssetAccess";
@@ -12,19 +14,7 @@ export interface StacAssetAccess {
   href: string;
 }
 
-type SasSigner = { signUrl(url: string, collectionId: string): Promise<string> };
-let sasManager: Promise<SasSigner> | null = null;
-
-function planetaryComputerSigner(): Promise<SasSigner> {
-  sasManager ??= import("maplibre-gl-planetary-computer")
-    .then((module) => new module.SASTokenManager())
-    .catch((error) => {
-      // Do not let one failed import disable signing for the rest of the session.
-      sasManager = null;
-      throw error;
-    });
-  return sasManager;
-}
+const signedHrefCache = new Map<string, { href: string; expiresAt: number }>();
 
 function catalogHost(catalogUrl: string): string | null {
   try {
@@ -39,21 +29,55 @@ function catalogHost(catalogUrl: string): string | null {
  *
  * Restricting the catalog host prevents a third-party STAC catalog that also
  * uses Azure storage from sending its collection and asset details to
- * Microsoft's token endpoint.
+ * Microsoft's signing endpoint. That endpoint validates the storage account
+ * and container before returning a signed URL, so raw collection tokens never
+ * enter the browser.
  */
 export function createStacAssetAccess(
   catalogUrl: string,
   collectionId: string | undefined,
   href: string,
 ): StacAssetAccess | null {
+  let assetUrl: URL;
+  try {
+    assetUrl = new URL(href);
+  } catch {
+    return null;
+  }
   if (
     catalogHost(catalogUrl) !== PLANETARY_COMPUTER_HOST ||
     !collectionId ||
+    assetUrl.protocol !== "https:" ||
     !isAzureBlobHref(href)
   ) {
     return null;
   }
   return { catalogUrl, collectionId, href };
+}
+
+async function planetaryComputerSignedHref(href: string): Promise<string> {
+  const cached = signedHrefCache.get(href);
+  if (cached && cached.expiresAt - Date.now() > SIGNING_EXPIRY_BUFFER_MS) return cached.href;
+
+  const endpoint = new URL(PLANETARY_COMPUTER_SIGN_URL);
+  endpoint.searchParams.set("href", href);
+  const response = await fetch(endpoint);
+  if (!response.ok) throw new Error(`Planetary Computer signing failed: ${response.status}`);
+  const data = (await response.json()) as Record<string, unknown>;
+  if (typeof data.href !== "string" || typeof data["msft:expiry"] !== "string") {
+    throw new Error("Planetary Computer returned an invalid signed URL");
+  }
+  const expiresAt = Date.parse(data["msft:expiry"]);
+  const signedUrl = new URL(data.href);
+  if (
+    !Number.isFinite(expiresAt) ||
+    signedUrl.protocol !== "https:" ||
+    !sameAssetHref(data.href, href)
+  ) {
+    throw new Error("Planetary Computer returned a signed URL for a different asset");
+  }
+  signedHrefCache.set(href, { href: data.href, expiresAt });
+  return data.href;
 }
 
 /** Reads and validates persisted STAC asset access metadata from a layer. */
@@ -96,8 +120,8 @@ function sameAssetHref(left: string, right: string): boolean {
 
 /**
  * Returns a fresh signed URL for a protected asset, or its unsigned URL when
- * signing is unavailable. The upstream manager caches tokens until they near
- * expiry, so calling this again during project restore is inexpensive.
+ * signing is unavailable. Signed URLs are cached until they near expiry, so
+ * calling this again during project restore is inexpensive.
  */
 export async function readableStacAssetHref(
   access: StacAssetAccess | null,
@@ -105,7 +129,7 @@ export async function readableStacAssetHref(
 ): Promise<string> {
   if (!access) return fallbackHref;
   try {
-    return await (await planetaryComputerSigner()).signUrl(access.href, access.collectionId);
+    return await planetaryComputerSignedHref(access.href);
   } catch {
     return access.href;
   }

--- a/packages/plugins/src/plugins/stac-signing.ts
+++ b/packages/plugins/src/plugins/stac-signing.ts
@@ -15,6 +15,9 @@ export interface StacAssetAccess {
 }
 
 const signedHrefCache = new Map<string, { href: string; expiresAt: number }>();
+const pendingSignedHrefs = new Map<string, Promise<string>>();
+/** How many signed URLs are kept before the oldest ones are dropped. */
+const SIGNED_HREF_CACHE_LIMIT = 200;
 
 function catalogHost(catalogUrl: string): string | null {
   try {
@@ -55,10 +58,48 @@ export function createStacAssetAccess(
   return { catalogUrl, collectionId, href };
 }
 
-async function planetaryComputerSignedHref(href: string): Promise<string> {
+/**
+ * Signs one asset, sharing a request with any sign of the same asset that is
+ * already in flight. Restoring a project signs every STAC-backed layer at
+ * once, so layers that point at the same asset cost one round trip, not one
+ * each -- the settled cache below only dedupes once a request has returned.
+ */
+function planetaryComputerSignedHref(href: string): Promise<string> {
   const cached = signedHrefCache.get(href);
-  if (cached && cached.expiresAt - Date.now() > SIGNING_EXPIRY_BUFFER_MS) return cached.href;
+  if (cached && cached.expiresAt - Date.now() > SIGNING_EXPIRY_BUFFER_MS) {
+    return Promise.resolve(cached.href);
+  }
+  const inFlight = pendingSignedHrefs.get(href);
+  if (inFlight) return inFlight;
 
+  const request = requestSignedHref(href).finally(() => {
+    pendingSignedHrefs.delete(href);
+  });
+  pendingSignedHrefs.set(href, request);
+  return request;
+}
+
+/**
+ * Drops entries that can no longer be served before the cache is allowed to
+ * grow, so a long session that walks a whole catalog does not retain every
+ * signed URL it ever minted.
+ */
+function rememberSignedHref(href: string, signed: string, expiresAt: number): void {
+  if (signedHrefCache.size >= SIGNED_HREF_CACHE_LIMIT) {
+    const now = Date.now();
+    for (const [key, entry] of signedHrefCache) {
+      if (entry.expiresAt - now <= SIGNING_EXPIRY_BUFFER_MS) signedHrefCache.delete(key);
+    }
+    // Still full: Map iterates in insertion order, so this drops the oldest.
+    for (const key of signedHrefCache.keys()) {
+      if (signedHrefCache.size < SIGNED_HREF_CACHE_LIMIT) break;
+      signedHrefCache.delete(key);
+    }
+  }
+  signedHrefCache.set(href, { href: signed, expiresAt });
+}
+
+async function requestSignedHref(href: string): Promise<string> {
   const endpoint = new URL(PLANETARY_COMPUTER_SIGN_URL);
   endpoint.searchParams.set("href", href);
   const response = await fetch(endpoint);
@@ -76,7 +117,7 @@ async function planetaryComputerSignedHref(href: string): Promise<string> {
   ) {
     throw new Error("Planetary Computer returned a signed URL for a different asset");
   }
-  signedHrefCache.set(href, { href: data.href, expiresAt });
+  rememberSignedHref(href, data.href, expiresAt);
   return data.href;
 }
 

--- a/packages/plugins/src/plugins/stac-signing.ts
+++ b/packages/plugins/src/plugins/stac-signing.ts
@@ -57,7 +57,10 @@ export function createStacAssetAccess(
 }
 
 /** Reads and validates persisted STAC asset access metadata from a layer. */
-export function stacAssetAccessFromLayer(layer: GeoLibreLayer): StacAssetAccess | null {
+export function stacAssetAccessFromLayer(
+  layer: GeoLibreLayer,
+  currentHref?: string,
+): StacAssetAccess | null {
   const value = layer.metadata[STAC_ASSET_ACCESS_METADATA_KEY];
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const candidate = value as Partial<StacAssetAccess>;
@@ -68,7 +71,27 @@ export function stacAssetAccessFromLayer(layer: GeoLibreLayer): StacAssetAccess 
   ) {
     return null;
   }
-  return createStacAssetAccess(candidate.catalogUrl, candidate.collectionId, candidate.href);
+  const access = createStacAssetAccess(
+    candidate.catalogUrl,
+    candidate.collectionId,
+    candidate.href,
+  );
+  if (!access || (currentHref && !sameAssetHref(currentHref, access.href))) return null;
+  return access;
+}
+
+function sameAssetHref(left: string, right: string): boolean {
+  try {
+    const leftUrl = new URL(left);
+    const rightUrl = new URL(right);
+    return (
+      leftUrl.protocol === rightUrl.protocol &&
+      leftUrl.host.toLowerCase() === rightUrl.host.toLowerCase() &&
+      leftUrl.pathname === rightUrl.pathname
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -90,5 +113,5 @@ export async function readableStacAssetHref(
 
 /** Re-signs a saved STAC-backed layer from its retained unsigned asset URL. */
 export function readableStacLayerHref(layer: GeoLibreLayer, fallbackHref: string): Promise<string> {
-  return readableStacAssetHref(stacAssetAccessFromLayer(layer), fallbackHref);
+  return readableStacAssetHref(stacAssetAccessFromLayer(layer, fallbackHref), fallbackHref);
 }

--- a/packages/plugins/src/plugins/stac-signing.ts
+++ b/packages/plugins/src/plugins/stac-signing.ts
@@ -160,23 +160,56 @@ function sameAssetHref(left: string, right: string): boolean {
 }
 
 /**
+ * Stops waiting for a signing request as soon as the caller's own signal
+ * aborts.
+ *
+ * The request itself is left running: it is shared with every other caller
+ * waiting on the same asset, and it fills the cache for the next one. Only
+ * this caller walks away.
+ */
+function untilAborted(request: Promise<string>, signal: AbortSignal): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const abort = (): void =>
+      reject(signal.reason ?? new DOMException("Signing was cancelled", "AbortError"));
+    if (signal.aborted) {
+      // The request still settles for the callers that are waiting on it.
+      void request.catch(() => {});
+      abort();
+      return;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+    request.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+  });
+}
+
+/**
  * Returns a fresh signed URL for a protected asset, or its unsigned URL when
  * signing is unavailable. Signed URLs are cached until they near expiry, so
  * calling this again during project restore is inexpensive.
+ *
+ * An aborted `signal` rejects rather than falling back: a cancelled add must
+ * not carry on with a URL that cannot be read.
  */
 export async function readableStacAssetHref(
   access: StacAssetAccess | null,
   fallbackHref: string,
+  signal?: AbortSignal,
 ): Promise<string> {
   if (!access) return fallbackHref;
+  const request = planetaryComputerSignedHref(access.href);
   try {
-    return await planetaryComputerSignedHref(access.href);
-  } catch {
+    return await (signal ? untilAborted(request, signal) : request);
+  } catch (error) {
+    if (signal?.aborted) throw error;
     return access.href;
   }
 }
 
 /** Re-signs a saved STAC-backed layer from its retained unsigned asset URL. */
-export function readableStacLayerHref(layer: GeoLibreLayer, fallbackHref: string): Promise<string> {
-  return readableStacAssetHref(stacAssetAccessFromLayer(layer, fallbackHref), fallbackHref);
+export function readableStacLayerHref(
+  layer: GeoLibreLayer,
+  fallbackHref: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  return readableStacAssetHref(stacAssetAccessFromLayer(layer, fallbackHref), fallbackHref, signal);
 }

--- a/packages/plugins/src/plugins/stac-signing.ts
+++ b/packages/plugins/src/plugins/stac-signing.ts
@@ -4,6 +4,8 @@ import { isAzureBlobHref } from "./stac-api";
 const PLANETARY_COMPUTER_HOST = "planetarycomputer.microsoft.com";
 const PLANETARY_COMPUTER_SIGN_URL = "https://planetarycomputer.microsoft.com/api/sas/v1/sign";
 const SIGNING_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+/** How long one signing request may hang before it is given up on. */
+const SIGNING_REQUEST_TIMEOUT_MS = 20 * 1000;
 
 /** Metadata key used to retain the unsigned STAC asset identity across project saves. */
 export const STAC_ASSET_ACCESS_METADATA_KEY = "stacAssetAccess";
@@ -102,23 +104,34 @@ function rememberSignedHref(href: string, signed: string, expiresAt: number): vo
 async function requestSignedHref(href: string): Promise<string> {
   const endpoint = new URL(PLANETARY_COMPUTER_SIGN_URL);
   endpoint.searchParams.set("href", href);
-  const response = await fetch(endpoint);
-  if (!response.ok) throw new Error(`Planetary Computer signing failed: ${response.status}`);
-  const data = (await response.json()) as Record<string, unknown>;
-  if (typeof data.href !== "string" || typeof data["msft:expiry"] !== "string") {
-    throw new Error("Planetary Computer returned an invalid signed URL");
+  // Everyone waiting on this asset shares this request, and the entry that
+  // makes that possible is only cleared once it settles, so it has to. A
+  // signer that hangs would otherwise leave the asset unsignable for the rest
+  // of the session. This timeout is the request's own: a caller cancelling its
+  // wait never abandons the request for the others.
+  const expiry = new AbortController();
+  const timer = setTimeout(() => expiry.abort(), SIGNING_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(endpoint, { signal: expiry.signal });
+    if (!response.ok) throw new Error(`Planetary Computer signing failed: ${response.status}`);
+    const data = (await response.json()) as Record<string, unknown>;
+    if (typeof data.href !== "string" || typeof data["msft:expiry"] !== "string") {
+      throw new Error("Planetary Computer returned an invalid signed URL");
+    }
+    const expiresAt = Date.parse(data["msft:expiry"]);
+    const signedUrl = new URL(data.href);
+    if (
+      !Number.isFinite(expiresAt) ||
+      signedUrl.protocol !== "https:" ||
+      !sameAssetHref(data.href, href)
+    ) {
+      throw new Error("Planetary Computer returned a signed URL for a different asset");
+    }
+    rememberSignedHref(href, data.href, expiresAt);
+    return data.href;
+  } finally {
+    clearTimeout(timer);
   }
-  const expiresAt = Date.parse(data["msft:expiry"]);
-  const signedUrl = new URL(data.href);
-  if (
-    !Number.isFinite(expiresAt) ||
-    signedUrl.protocol !== "https:" ||
-    !sameAssetHref(data.href, href)
-  ) {
-    throw new Error("Planetary Computer returned a signed URL for a different asset");
-  }
-  rememberSignedHref(href, data.href, expiresAt);
-  return data.href;
 }
 
 /** Reads and validates persisted STAC asset access metadata from a layer. */

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -268,13 +268,17 @@ export function syncVectorLayersToStore(
       const metadata = stacAssetAccess
         ? { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: stacAssetAccess }
         : layer.metadata;
+      const source = stacAssetAccess
+        ? { ...layer.source, url: stacAssetAccess.href }
+        : layer.source;
+      const sourcePath = stacAssetAccess ? stacAssetAccess.href : layer.sourcePath;
 
       if (
         existing.type !== layer.type ||
         existing.visible !== visible ||
         existing.opacity !== opacity ||
-        existing.sourcePath !== layer.sourcePath ||
-        !recordsEqual(existing.source, layer.source) ||
+        existing.sourcePath !== sourcePath ||
+        !recordsEqual(existing.source, source) ||
         !recordsEqual(existing.metadata, metadata)
       ) {
         useAppStore.getState().updateLayer(layer.id, {
@@ -286,8 +290,8 @@ export function syncVectorLayersToStore(
           // control (getLayerGeoJSON), so it intentionally is not preserved.
           metadata,
           opacity,
-          source: layer.source,
-          sourcePath: layer.sourcePath,
+          source,
+          sourcePath,
           // A render-mode switch in the panel flips geojson <-> vector-tiles.
           type: layer.type,
           visible,

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -14,7 +14,7 @@ import {
 } from "@geolibre/core";
 import type { PropertyValueSpecification } from "maplibre-gl";
 import type { VectorLayerInfo, VectorLayerOptions, VectorLayerStyle } from "maplibre-gl-vector";
-import { STAC_ASSET_ACCESS_METADATA_KEY } from "./stac-signing";
+import { stacAssetAccessFromLayer, STAC_ASSET_ACCESS_METADATA_KEY } from "./stac-signing";
 
 export const VECTOR_SOURCE_KIND = "maplibre-gl-vector";
 
@@ -263,11 +263,11 @@ export function syncVectorLayersToStore(
         known?.opacity !== undefined && numbersEqual(layer.opacity, known.opacity);
       const visible = visibleIsEcho ? existing.visible : layer.visible;
       const opacity = opacityIsEcho ? existing.opacity : layer.opacity;
-      const stacAssetAccess = existing.metadata[STAC_ASSET_ACCESS_METADATA_KEY];
-      const metadata =
-        stacAssetAccess === undefined
-          ? layer.metadata
-          : { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: stacAssetAccess };
+      const sourceUrl = typeof layer.source.url === "string" ? layer.source.url : undefined;
+      const stacAssetAccess = sourceUrl ? stacAssetAccessFromLayer(existing, sourceUrl) : null;
+      const metadata = stacAssetAccess
+        ? { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: stacAssetAccess }
+        : layer.metadata;
 
       if (
         existing.type !== layer.type ||

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -14,6 +14,7 @@ import {
 } from "@geolibre/core";
 import type { PropertyValueSpecification } from "maplibre-gl";
 import type { VectorLayerInfo, VectorLayerOptions, VectorLayerStyle } from "maplibre-gl-vector";
+import { STAC_ASSET_ACCESS_METADATA_KEY } from "./stac-signing";
 
 export const VECTOR_SOURCE_KIND = "maplibre-gl-vector";
 
@@ -262,6 +263,11 @@ export function syncVectorLayersToStore(
         known?.opacity !== undefined && numbersEqual(layer.opacity, known.opacity);
       const visible = visibleIsEcho ? existing.visible : layer.visible;
       const opacity = opacityIsEcho ? existing.opacity : layer.opacity;
+      const stacAssetAccess = existing.metadata[STAC_ASSET_ACCESS_METADATA_KEY];
+      const metadata =
+        stacAssetAccess === undefined
+          ? layer.metadata
+          : { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: stacAssetAccess };
 
       if (
         existing.type !== layer.type ||
@@ -269,16 +275,16 @@ export function syncVectorLayersToStore(
         existing.opacity !== opacity ||
         existing.sourcePath !== layer.sourcePath ||
         !recordsEqual(existing.source, layer.source) ||
-        !recordsEqual(existing.metadata, layer.metadata)
+        !recordsEqual(existing.metadata, metadata)
       ) {
         useAppStore.getState().updateLayer(layer.id, {
-          // Replace metadata wholesale so stale keys (bounds, featureCount,
-          // and any embeddedGeoJSON loaded from the project) cannot survive a
-          // layer being swapped out under the same id. embeddedGeoJSON is not
-          // kept live: the web Save flow re-materializes it fresh from the
-          // control (getLayerGeoJSON), so a reopened layer drops its loaded
-          // blob here and re-embeds current data on the next save.
-          metadata: layer.metadata,
+          // Replace control-derived metadata wholesale so stale keys (bounds,
+          // featureCount, and loaded embeddedGeoJSON) cannot survive a layer
+          // being swapped out under the same id. Only the STAC access record is
+          // host-owned and carried forward so a protected URL can be re-signed.
+          // The web Save flow re-materializes embeddedGeoJSON fresh from the
+          // control (getLayerGeoJSON), so it intentionally is not preserved.
+          metadata,
           opacity,
           source: layer.source,
           sourcePath: layer.sourcePath,

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -18,6 +18,7 @@ import {
   wireRasterStoreSync,
   type RasterSyncableControl,
 } from "../packages/plugins/src/plugins/raster-layer-sync";
+import { STAC_ASSET_ACCESS_METADATA_KEY } from "../packages/plugins/src/plugins/stac-signing";
 
 function rasterState(patch: Partial<RasterLayerState> = {}): RasterLayerState {
   return {
@@ -353,6 +354,28 @@ describe("syncRasterLayersToStore", () => {
     } finally {
       rememberLocalRasterPath("raster-1", undefined);
     }
+  });
+
+  it("keeps STAC access metadata across repeated syncs", () => {
+    syncRasterLayersToStore(fakeControl([rasterInfo()]).control);
+    const access = {
+      catalogUrl: "https://planetarycomputer.microsoft.com/api/stac/v1/",
+      collectionId: "private-cog",
+      href: "https://example.blob.core.windows.net/private-cog/data.tif",
+    };
+    const layer = useAppStore.getState().layers[0];
+    useAppStore.getState().updateLayer(layer.id, {
+      metadata: { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: access },
+    });
+
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ opacity: 0.4 }) })]).control,
+    );
+
+    assert.deepEqual(
+      useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
+      access,
+    );
   });
 
   it("removes store layers whose rasters are gone", () => {

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -381,6 +381,8 @@ describe("syncRasterLayersToStore", () => {
       useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
       access,
     );
+    assert.equal(useAppStore.getState().layers[0].source.url, access.href);
+    assert.equal(useAppStore.getState().layers[0].sourcePath, access.href);
 
     syncRasterLayersToStore(
       fakeControl([

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -357,24 +357,44 @@ describe("syncRasterLayersToStore", () => {
   });
 
   it("keeps STAC access metadata across repeated syncs", () => {
-    syncRasterLayersToStore(fakeControl([rasterInfo()]).control);
     const access = {
       catalogUrl: "https://planetarycomputer.microsoft.com/api/stac/v1/",
       collectionId: "private-cog",
       href: "https://example.blob.core.windows.net/private-cog/data.tif",
     };
+    const signedSource = {
+      kind: "url" as const,
+      url: `${access.href}?sp=r&sig=old`,
+    };
+    syncRasterLayersToStore(fakeControl([rasterInfo({ source: signedSource })]).control);
     const layer = useAppStore.getState().layers[0];
     useAppStore.getState().updateLayer(layer.id, {
       metadata: { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: access },
     });
 
     syncRasterLayersToStore(
-      fakeControl([rasterInfo({ state: rasterState({ opacity: 0.4 }) })]).control,
+      fakeControl([rasterInfo({ source: signedSource, state: rasterState({ opacity: 0.4 }) })])
+        .control,
     );
 
     assert.deepEqual(
       useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
       access,
+    );
+
+    syncRasterLayersToStore(
+      fakeControl([
+        rasterInfo({
+          source: {
+            kind: "url",
+            url: "https://example.blob.core.windows.net/private-cog/different.tif",
+          },
+        }),
+      ]).control,
+    );
+    assert.equal(
+      useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
+      undefined,
     );
   });
 

--- a/tests/stac-signing.test.ts
+++ b/tests/stac-signing.test.ts
@@ -87,3 +87,40 @@ test("a saved STAC layer receives a fresh token when it is restored", async () =
     globalThis.fetch = originalFetch;
   }
 });
+
+test("layers pointing at one asset share a single signing request", async () => {
+  const asset = "https://ai4edataeuwest.blob.core.windows.net/io-lulc/shared.tif";
+  const access = createStacAssetAccess(CATALOG, "io-lulc-annual-v02", asset);
+  assert.ok(access);
+  const originalFetch = globalThis.fetch;
+  let requests = 0;
+  let release = (): void => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  globalThis.fetch = (async () => {
+    requests += 1;
+    await gate;
+    return new Response(
+      JSON.stringify({
+        href: `${asset}?sp=rl&sig=fresh-token`,
+        "msft:expiry": "2099-01-01T00:00:00Z",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as typeof fetch;
+  try {
+    // Project restore signs every STAC-backed layer at once, before any of
+    // them can populate the settled cache.
+    const hrefs = Promise.all([
+      readableStacLayerHref(layerWithAccess(access), `${asset}?sig=expired`),
+      readableStacLayerHref(layerWithAccess(access), `${asset}?sig=expired`),
+      readableStacLayerHref(layerWithAccess(access), `${asset}?sig=expired`),
+    ]);
+    release();
+    assert.deepEqual(await hrefs, Array(3).fill(`${asset}?sp=rl&sig=fresh-token`));
+    assert.equal(requests, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/stac-signing.test.ts
+++ b/tests/stac-signing.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
 import {
   createStacAssetAccess,
+  readableStacAssetHref,
   readableStacLayerHref,
   STAC_ASSET_ACCESS_METADATA_KEY,
   stacAssetAccessFromLayer,
@@ -120,6 +121,43 @@ test("layers pointing at one asset share a single signing request", async () => 
     release();
     assert.deepEqual(await hrefs, Array(3).fill(`${asset}?sp=rl&sig=fresh-token`));
     assert.equal(requests, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a cancelled add stops waiting for its signing request", async () => {
+  const asset = "https://ai4edataeuwest.blob.core.windows.net/io-lulc/cancelled.tif";
+  const access = createStacAssetAccess(CATALOG, "io-lulc-annual-v02", asset);
+  assert.ok(access);
+  const originalFetch = globalThis.fetch;
+  let release = (): void => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  globalThis.fetch = (async () => {
+    await gate;
+    return new Response(
+      JSON.stringify({
+        href: `${asset}?sp=rl&sig=fresh-token`,
+        "msft:expiry": "2099-01-01T00:00:00Z",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as typeof fetch;
+  const controller = new AbortController();
+  try {
+    // Closing the panel must not leave the add handler pending on a stalled
+    // signer, and it must not fall back to the unreadable unsigned URL either.
+    const pending = readableStacAssetHref(access, `${asset}?sig=expired`, controller.signal);
+    controller.abort();
+    await assert.rejects(pending, (error: Error) => error.name === "AbortError");
+    // The request itself lives on for whoever is still waiting on it.
+    release();
+    assert.equal(
+      await readableStacAssetHref(access, `${asset}?sig=expired`),
+      `${asset}?sp=rl&sig=fresh-token`,
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/stac-signing.test.ts
+++ b/tests/stac-signing.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import {
+  createStacAssetAccess,
+  readableStacLayerHref,
+  STAC_ASSET_ACCESS_METADATA_KEY,
+  stacAssetAccessFromLayer,
+} from "../packages/plugins/src/plugins/stac-signing";
+
+const CATALOG = "https://planetarycomputer.microsoft.com/api/stac/v1/";
+const ASSET = "https://ai4edataeuwest.blob.core.windows.net/io-lulc/example.tif";
+
+function layerWithAccess(access: unknown): GeoLibreLayer {
+  return {
+    id: "raster-1",
+    name: "Private raster",
+    type: "cog",
+    source: { type: "raster", url: `${ASSET}?sig=expired` },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: { [STAC_ASSET_ACCESS_METADATA_KEY]: access },
+  };
+}
+
+test("Planetary Computer Azure assets retain the information needed for re-signing", () => {
+  const access = createStacAssetAccess(CATALOG, "io-lulc-annual-v02", ASSET);
+  assert.deepEqual(access, {
+    catalogUrl: CATALOG,
+    collectionId: "io-lulc-annual-v02",
+    href: ASSET,
+  });
+  assert.deepEqual(stacAssetAccessFromLayer(layerWithAccess(access)), access);
+});
+
+test("third-party catalogs cannot send Azure asset details to the MPC signer", () => {
+  assert.equal(createStacAssetAccess("https://third-party.example/stac/", "private", ASSET), null);
+  assert.equal(createStacAssetAccess(CATALOG, "private", "https://example.com/data.tif"), null);
+  assert.equal(stacAssetAccessFromLayer(layerWithAccess({ collectionId: "private" })), null);
+});
+
+test("a saved STAC layer receives a fresh token when it is restored", async () => {
+  const access = createStacAssetAccess(CATALOG, "io-lulc-annual-v02", ASSET);
+  assert.ok(access);
+  const originalFetch = globalThis.fetch;
+  let tokenUrl = "";
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    tokenUrl = String(input);
+    return new Response(
+      JSON.stringify({
+        token: "sp=rl&sig=fresh-token",
+        "msft:expiry": "2099-01-01T00:00:00Z",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as typeof fetch;
+  try {
+    const href = await readableStacLayerHref(layerWithAccess(access), `${ASSET}?sig=expired`);
+    assert.equal(
+      tokenUrl,
+      "https://planetarycomputer.microsoft.com/api/sas/v1/token/io-lulc-annual-v02",
+    );
+    assert.equal(href, `${ASSET}?sp=rl&sig=fresh-token`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/stac-signing.test.ts
+++ b/tests/stac-signing.test.ts
@@ -37,6 +37,14 @@ test("Planetary Computer Azure assets retain the information needed for re-signi
 test("third-party catalogs cannot send Azure asset details to the MPC signer", () => {
   assert.equal(createStacAssetAccess("https://third-party.example/stac/", "private", ASSET), null);
   assert.equal(createStacAssetAccess(CATALOG, "private", "https://example.com/data.tif"), null);
+  assert.equal(
+    createStacAssetAccess(
+      CATALOG,
+      "private",
+      "http://ai4edataeuwest.blob.core.windows.net/io-lulc/data.tif",
+    ),
+    null,
+  );
   assert.equal(stacAssetAccessFromLayer(layerWithAccess({ collectionId: "private" })), null);
 });
 
@@ -62,7 +70,7 @@ test("a saved STAC layer receives a fresh token when it is restored", async () =
     tokenUrl = String(input);
     return new Response(
       JSON.stringify({
-        token: "sp=rl&sig=fresh-token",
+        href: `${ASSET}?sp=rl&sig=fresh-token`,
         "msft:expiry": "2099-01-01T00:00:00Z",
       }),
       { status: 200, headers: { "Content-Type": "application/json" } },
@@ -72,7 +80,7 @@ test("a saved STAC layer receives a fresh token when it is restored", async () =
     const href = await readableStacLayerHref(layerWithAccess(access), `${ASSET}?sig=expired`);
     assert.equal(
       tokenUrl,
-      "https://planetarycomputer.microsoft.com/api/sas/v1/token/io-lulc-annual-v02",
+      `https://planetarycomputer.microsoft.com/api/sas/v1/sign?href=${encodeURIComponent(ASSET)}`,
     );
     assert.equal(href, `${ASSET}?sp=rl&sig=fresh-token`);
   } finally {

--- a/tests/stac-signing.test.ts
+++ b/tests/stac-signing.test.ts
@@ -162,3 +162,34 @@ test("a cancelled add stops waiting for its signing request", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("a failed signing request does not block a later retry of the same asset", async () => {
+  const asset = "https://ai4edataeuwest.blob.core.windows.net/io-lulc/retried.tif";
+  const access = createStacAssetAccess(CATALOG, "io-lulc-annual-v02", asset);
+  assert.ok(access);
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = (async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("network down");
+    return new Response(
+      JSON.stringify({
+        href: `${asset}?sp=rl&sig=fresh-token`,
+        "msft:expiry": "2099-01-01T00:00:00Z",
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as typeof fetch;
+  try {
+    // The first attempt falls back to the unsigned URL; the shared request it
+    // registered has to be gone by then, or the asset stays unsignable.
+    assert.equal(await readableStacAssetHref(access, `${asset}?sig=expired`), asset);
+    assert.equal(
+      await readableStacAssetHref(access, `${asset}?sig=expired`),
+      `${asset}?sp=rl&sig=fresh-token`,
+    );
+    assert.equal(attempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/stac-signing.test.ts
+++ b/tests/stac-signing.test.ts
@@ -40,6 +40,19 @@ test("third-party catalogs cannot send Azure asset details to the MPC signer", (
   assert.equal(stacAssetAccessFromLayer(layerWithAccess({ collectionId: "private" })), null);
 });
 
+test("access metadata is rejected when a layer points at a different asset", () => {
+  const access = createStacAssetAccess(CATALOG, "io-lulc-annual-v02", ASSET);
+  assert.ok(access);
+  assert.equal(
+    stacAssetAccessFromLayer(
+      layerWithAccess(access),
+      "https://ai4edataeuwest.blob.core.windows.net/io-lulc/different.tif?sig=old",
+    ),
+    null,
+  );
+  assert.deepEqual(stacAssetAccessFromLayer(layerWithAccess(access), `${ASSET}?sig=old`), access);
+});
+
 test("a saved STAC layer receives a fresh token when it is restored", async () => {
   const access = createStacAssetAccess(CATALOG, "io-lulc-annual-v02", ASSET);
   assert.ok(access);

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -463,6 +463,8 @@ describe("syncVectorLayersToStore", () => {
       useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
       access,
     );
+    assert.equal(useAppStore.getState().layers[0].source.url, access.href);
+    assert.equal(useAppStore.getState().layers[0].sourcePath, access.href);
 
     syncVectorLayersToStore(
       fakeControl([

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -8,6 +8,7 @@ import type {
   VectorLayerStyle,
 } from "maplibre-gl-vector";
 import { replayVectorLayer } from "../packages/plugins/src/plugins/maplibre-vector";
+import { STAC_ASSET_ACCESS_METADATA_KEY } from "../packages/plugins/src/plugins/stac-signing";
 import {
   createVectorStoreLayer,
   isEmbeddableLocalVectorLayer,
@@ -436,6 +437,26 @@ describe("syncVectorLayersToStore", () => {
     assert.deepEqual(layer.metadata.bounds, [0, 0, 1, 1]);
     assert.equal(layer.source.type, "vector");
     assert.equal(layer.type, "vector-tiles");
+  });
+
+  it("keeps STAC access metadata across repeated syncs", () => {
+    syncVectorLayersToStore(fakeControl([vectorInfo()]).control);
+    const access = {
+      catalogUrl: "https://planetarycomputer.microsoft.com/api/stac/v1/",
+      collectionId: "private-parquet",
+      href: "https://example.blob.core.windows.net/private-parquet/data.parquet",
+    };
+    const layer = useAppStore.getState().layers[0];
+    useAppStore.getState().updateLayer(layer.id, {
+      metadata: { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: access },
+    });
+
+    syncVectorLayersToStore(fakeControl([vectorInfo({ opacity: 0.4 })]).control);
+
+    assert.deepEqual(
+      useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
+      access,
+    );
   });
 
   it("refreshes the saved panel collapsed state", () => {

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -440,22 +440,43 @@ describe("syncVectorLayersToStore", () => {
   });
 
   it("keeps STAC access metadata across repeated syncs", () => {
-    syncVectorLayersToStore(fakeControl([vectorInfo()]).control);
     const access = {
       catalogUrl: "https://planetarycomputer.microsoft.com/api/stac/v1/",
       collectionId: "private-parquet",
       href: "https://example.blob.core.windows.net/private-parquet/data.parquet",
     };
+    const signedSource = {
+      kind: "url" as const,
+      url: `${access.href}?sp=r&sig=old`,
+    };
+    syncVectorLayersToStore(fakeControl([vectorInfo({ source: signedSource })]).control);
     const layer = useAppStore.getState().layers[0];
     useAppStore.getState().updateLayer(layer.id, {
       metadata: { ...layer.metadata, [STAC_ASSET_ACCESS_METADATA_KEY]: access },
     });
 
-    syncVectorLayersToStore(fakeControl([vectorInfo({ opacity: 0.4 })]).control);
+    syncVectorLayersToStore(
+      fakeControl([vectorInfo({ source: signedSource, opacity: 0.4 })]).control,
+    );
 
     assert.deepEqual(
       useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
       access,
+    );
+
+    syncVectorLayersToStore(
+      fakeControl([
+        vectorInfo({
+          source: {
+            kind: "url",
+            url: "https://example.blob.core.windows.net/private-parquet/different.parquet",
+          },
+        }),
+      ]).control,
+    );
+    assert.equal(
+      useAppStore.getState().layers[0].metadata[STAC_ASSET_ACCESS_METADATA_KEY],
+      undefined,
     );
   });
 

--- a/tests/vector-url-add.test.ts
+++ b/tests/vector-url-add.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  addVectorLayersThroughControl,
+  type VectorUrlSink,
+} from "../packages/plugins/src/plugins/maplibre-vector";
+
+/**
+ * A control whose `addData` takes as long as the caller says before it
+ * registers the layers that load created, so two loads can be put in flight at
+ * once the way two "Add" clicks in the STAC panel would.
+ */
+function createSlowControl(loads: Record<string, { ids: string[]; delayMs: number }>) {
+  const layers: { id: string }[] = [];
+  const control = {
+    addData: async (url: string) => {
+      const load = loads[String(url)];
+      await new Promise((resolve) => setTimeout(resolve, load.delayMs));
+      layers.push(...load.ids.map((id) => ({ id })));
+      return {} as never;
+    },
+    getLayers: () => layers.slice(),
+  } as unknown as VectorUrlSink;
+  return { control, layers };
+}
+
+describe("addVectorLayersThroughControl", () => {
+  it("reports every layer a multi-layer container created", async () => {
+    const { control } = createSlowControl({
+      "https://example.com/tables.gpkg": { ids: ["roads", "rivers"], delayMs: 0 },
+    });
+
+    assert.deepEqual(
+      await addVectorLayersThroughControl(control, "https://example.com/tables.gpkg"),
+      ["roads", "rivers"],
+    );
+  });
+
+  it("keeps overlapping loads from claiming each other's layers", async () => {
+    // The slow load starts first and finishes last: with a shared "before"
+    // snapshot it would report the fast load's layer as its own, and the STAC
+    // panel would then stamp one asset's access record onto the other's layer.
+    const { control } = createSlowControl({
+      "https://example.com/slow.parquet": { ids: ["slow-1"], delayMs: 20 },
+      "https://example.com/fast.parquet": { ids: ["fast-1"], delayMs: 0 },
+    });
+
+    const [slow, fast] = await Promise.all([
+      addVectorLayersThroughControl(control, "https://example.com/slow.parquet"),
+      addVectorLayersThroughControl(control, "https://example.com/fast.parquet"),
+    ]);
+
+    assert.deepEqual(slow, ["slow-1"]);
+    assert.deepEqual(fast, ["fast-1"]);
+  });
+
+  it("lets a queued load run after the one before it failed", async () => {
+    const layers: { id: string }[] = [];
+    const control = {
+      addData: async (url: string) => {
+        if (String(url).includes("broken")) throw new Error("load failed");
+        layers.push({ id: "later" });
+        return {} as never;
+      },
+      getLayers: () => layers.slice(),
+    } as unknown as VectorUrlSink;
+
+    await assert.rejects(
+      addVectorLayersThroughControl(control, "https://example.com/broken.parquet"),
+      /load failed/,
+    );
+    assert.deepEqual(
+      await addVectorLayersThroughControl(control, "https://example.com/ok.parquet"),
+      ["later"],
+    );
+  });
+});

--- a/tests/vector-url-add.test.ts
+++ b/tests/vector-url-add.test.ts
@@ -11,12 +11,17 @@ import {
  * once the way two "Add" clicks in the STAC panel would.
  */
 function createSlowControl(loads: Record<string, { ids: string[]; delayMs: number }>) {
-  const layers: { id: string }[] = [];
+  const layers: { id: string; source: { kind: "url"; url: string } }[] = [];
   const control = {
     addData: async (url: string) => {
       const load = loads[String(url)];
       await new Promise((resolve) => setTimeout(resolve, load.delayMs));
-      layers.push(...load.ids.map((id) => ({ id })));
+      layers.push(
+        ...load.ids.map((id) => ({
+          id: layers.some((layer) => layer.id === id) ? `${id}-again` : id,
+          source: { kind: "url" as const, url },
+        })),
+      );
       return {} as never;
     },
     getLayers: () => layers.slice(),
@@ -37,8 +42,8 @@ describe("addVectorLayersThroughControl", () => {
   });
 
   it("keeps overlapping loads from claiming each other's layers", async () => {
-    // The slow load starts first and finishes last: with a shared "before"
-    // snapshot it would report the fast load's layer as its own, and the STAC
+    // The slow load starts first and finishes last: on a bare before/after
+    // diff it would report the fast load's layer as its own, and the STAC
     // panel would then stamp one asset's access record onto the other's layer.
     const { control } = createSlowControl({
       "https://example.com/slow.parquet": { ids: ["slow-1"], delayMs: 20 },
@@ -54,24 +59,18 @@ describe("addVectorLayersThroughControl", () => {
     assert.deepEqual(fast, ["fast-1"]);
   });
 
-  it("lets a queued load run after the one before it failed", async () => {
-    const layers: { id: string }[] = [];
-    const control = {
-      addData: async (url: string) => {
-        if (String(url).includes("broken")) throw new Error("load failed");
-        layers.push({ id: "later" });
-        return {} as never;
-      },
-      getLayers: () => layers.slice(),
-    } as unknown as VectorUrlSink;
+  it("ignores layers the control already held for the same url", async () => {
+    const { control } = createSlowControl({
+      "https://example.com/places.parquet": { ids: ["places-1"], delayMs: 0 },
+    });
 
-    await assert.rejects(
-      addVectorLayersThroughControl(control, "https://example.com/broken.parquet"),
-      /load failed/,
-    );
+    await addVectorLayersThroughControl(control, "https://example.com/places.parquet");
+
+    // The first load's layer is still there and still matches the url, so only
+    // the "before" snapshot tells the second load's layer apart from it.
     assert.deepEqual(
-      await addVectorLayersThroughControl(control, "https://example.com/ok.parquet"),
-      ["later"],
+      await addVectorLayersThroughControl(control, "https://example.com/places.parquet"),
+      ["places-1-again"],
     );
   });
 });


### PR DESCRIPTION
## Summary

- sign protected Azure Blob assets discovered through the official Microsoft Planetary Computer STAC catalog
- preserve the unsigned asset identity and mint a fresh SAS token when saved COG and GeoParquet layers are restored
- sign direct asset downloads while preventing third-party STAC catalogs from using the Microsoft signer
- add unit and browser coverage for signing and metadata persistence

## Testing

- `npm run test:frontend`
- `npx playwright test e2e/stac-api-panel.spec.ts -g "Planetary Computer COG assets"`
- `npm run build`
- `pre-commit run --all-files`
- manually loaded the 10m Annual Land Use Land Cover V2 COG from Planetary Computer in light and dark themes

Addresses https://github.com/opengeos/GeoLibre/discussions/2245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic signing and refreshing of Planetary Computer STAC asset URLs for raster, vector, COG, GeoJSON, and GeoParquet layers.
  - Preserved STAC access information when layers are restored, refreshed, downloaded, or synchronized.
  - Added fallback behavior when signed URLs are unavailable.
  - Added support for loading multiple vector layers from remote datasets.

- **Bug Fixes**
  - Fixed restored STAC-based layers using expired or unsigned asset URLs.

- **Tests**
  - Added coverage for URL signing, metadata preservation, concurrent loading, and private COG access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->