### PR TITLE
feat(raster): add per-class color and opacity controls

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -1133,7 +1133,7 @@ function ClassOpacityInput({
         max={100}
         step={1}
         className="h-7 pe-6 text-xs"
-        aria-label={`${t("rasterSymbology.classes")} ${index + 1} ${t("layers.opacity")}`}
+        aria-label={t("style.symbology.classOpacity", { index: index + 1 })}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         onBlur={commitDraft}

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -974,7 +974,7 @@ function ClassificationControls({
   onClassColor: (index: number, color: string) => void;
   onClassOpacity: (index: number, opacity: number) => void;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const min = symbology.breaks[0];
   const max = symbology.breaks[symbology.breaks.length - 1];
   return (
@@ -1076,8 +1076,8 @@ function ClassificationControls({
                 onChange={(color) => onClassColor(index, color)}
               />
               <span className="truncate text-[10px] text-muted-foreground">
-                {formatLegendNumber(symbology.breaks[index])} -{" "}
-                {formatLegendNumber(symbology.breaks[index + 1])}
+                {formatLegendNumber(symbology.breaks[index], i18n.language)} -{" "}
+                {formatLegendNumber(symbology.breaks[index + 1], i18n.language)}
               </span>
             </div>
             <ClassOpacityInput

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -1111,6 +1111,10 @@ function ClassOpacityInput({
   const [draft, setDraft] = useState(percent);
   useEffect(() => setDraft(percent), [percent]);
   const commitDraft = () => {
+    if (!draft.trim()) {
+      setDraft(percent);
+      return;
+    }
     const parsed = Number(draft);
     if (!Number.isFinite(parsed)) {
       setDraft(percent);

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -14,6 +14,7 @@ import {
   type RasterSymbology,
   colormapColors,
   computeRasterBreaks,
+  customColorsForRasterClassEdit,
   getPaletteLegend,
   getRasterBandStats,
   normalizeRasterClassOpacities,
@@ -23,6 +24,7 @@ import {
 } from "@geolibre/plugins";
 import {
   Button,
+  ColorField,
   type ColorRampOption,
   ColorRampSelect,
   Input,
@@ -590,6 +592,17 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     commit({ symbology: next });
   }
 
+  /** Promotes the displayed class colors to a custom ramp and edits one class. */
+  function setClassColor(index: number, color: string): void {
+    if (!symbology?.classified) return;
+    commit({
+      symbology: {
+        ...symbology,
+        customColors: customColorsForRasterClassEdit(classColors, index, color, reversed),
+      },
+    });
+  }
+
   // Switch to / edit / clear a user-defined ramp. `next` is the parsed color
   // list (>= 2 colors) or undefined to drop back to the named ramp.
   function setCustomColors(next: string[] | undefined): void {
@@ -767,6 +780,7 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           }}
           onRange={(range) => recomputeSymbology({ ...symbology }, { range })}
           classColors={classColors}
+          onClassColor={setClassColor}
           onClassOpacity={setClassOpacity}
         />
       )}
@@ -947,6 +961,7 @@ function ClassificationControls({
   onManualBreaks,
   onRange,
   classColors,
+  onClassColor,
   onClassOpacity,
 }: {
   symbology: RasterSymbology;
@@ -956,6 +971,7 @@ function ClassificationControls({
   onManualBreaks: (breaks: number[]) => void;
   onRange: (range: [number, number]) => void;
   classColors: string[];
+  onClassColor: (index: number, color: string) => void;
   onClassOpacity: (index: number, opacity: number) => void;
 }) {
   const { t } = useTranslation();
@@ -1050,12 +1066,14 @@ function ClassificationControls({
         {Array.from({ length: symbology.classCount }, (_, index) => (
           <div key={index} className="grid grid-cols-[minmax(0,1fr)_5rem] items-center gap-2">
             <div className="flex min-w-0 items-center gap-2">
-              <span
-                className="h-4 w-4 shrink-0 rounded-sm border border-border"
-                style={{
-                  backgroundColor: classColors[index] ?? "#808080",
-                  opacity: symbology.classOpacities?.[index] ?? 1,
-                }}
+              <ColorField
+                fill={false}
+                className="h-7 w-8 p-0.5"
+                buttonClassName="h-7 w-7"
+                aria-label={t("style.symbology.classColor", { index: index + 1 })}
+                eyedropperLabel={t("style.symbology.classColorPick", { index: index + 1 })}
+                value={classColors[index] ?? "#808080"}
+                onChange={(color) => onClassColor(index, color)}
               />
               <span className="truncate text-[10px] text-muted-foreground">
                 {formatLegendNumber(symbology.breaks[index])} -{" "}

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -1,4 +1,9 @@
-import { type GeoLibreLayer, parseHexColorList, useAppStore } from "@geolibre/core";
+import {
+  type GeoLibreLayer,
+  interpolateColors,
+  parseHexColorList,
+  useAppStore,
+} from "@geolibre/core";
 import {
   RASTER_MAX_CLASSES,
   RASTER_MAX_STORED_CLASSES,
@@ -11,6 +16,7 @@ import {
   computeRasterBreaks,
   getPaletteLegend,
   getRasterBandStats,
+  normalizeRasterClassOpacities,
   type PaletteLegendEntry,
   savedRasterSymbology,
   warmColormapColors,
@@ -35,7 +41,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useColormapRamps } from "../../hooks/useColormapRamps";
-import { setLegendCustomEntry } from "../../lib/auto-legend";
+import { formatLegendNumber, setLegendCustomEntry } from "../../lib/auto-legend";
 import { savedRasterAttributeTable } from "../../lib/raster-attribute-table";
 
 type RasterStateRecord = {
@@ -339,6 +345,13 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
         );
     const custom =
       (next.customColors?.length ?? 0) >= MIN_CUSTOM_COLORS ? next.customColors : undefined;
+    const classOpacities = normalizeRasterClassOpacities(
+      Array.from(
+        { length: breaks.length - 1 },
+        (_, index) => symbology?.classOpacities?.[index] ?? 1,
+      ),
+      breaks.length - 1,
+    );
     commit({
       statePatch: { colormap: next.ramp, rescale: rangeFromBreaks(breaks) },
       symbology: {
@@ -352,6 +365,7 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
         classCount: breaks.length - 1,
         breaks,
         ...(custom ? { customColors: custom } : {}),
+        ...(classOpacities ? { classOpacities } : {}),
       },
     });
   }
@@ -562,6 +576,20 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     commit({ statePatch: { reversed: next } });
   }
 
+  /** Updates one classified value range without disturbing the other classes. */
+  function setClassOpacity(index: number, opacity: number): void {
+    if (!symbology?.classified) return;
+    const values = Array.from(
+      { length: symbology.classCount },
+      (_, classIndex) => symbology.classOpacities?.[classIndex] ?? 1,
+    );
+    values[index] = opacity;
+    const classOpacities = normalizeRasterClassOpacities(values, symbology.classCount);
+    const next = { ...symbology, classOpacities };
+    if (!classOpacities) delete next.classOpacities;
+    commit({ symbology: next });
+  }
+
   // Switch to / edit / clear a user-defined ramp. `next` is the parsed color
   // list (>= 2 colors) or undefined to drop back to the named ramp.
   function setCustomColors(next: string[] | undefined): void {
@@ -619,6 +647,11 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     // Preview the actual user-defined colors when a custom ramp is active.
     colors: isCustom ? (customColors as string[]) : [],
   });
+  const classColors = interpolateColors(
+    previewCustom ?? (rampPreview.length > 0 ? rampPreview : ["#808080"]),
+    classCount,
+  );
+  if (reversed) classColors.reverse();
 
   return (
     <div className="space-y-3">
@@ -733,6 +766,8 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
             });
           }}
           onRange={(range) => recomputeSymbology({ ...symbology }, { range })}
+          classColors={classColors}
+          onClassOpacity={setClassOpacity}
         />
       )}
 
@@ -911,6 +946,8 @@ function ClassificationControls({
   onClassCount,
   onManualBreaks,
   onRange,
+  classColors,
+  onClassOpacity,
 }: {
   symbology: RasterSymbology;
   stats: RasterBandStats | null;
@@ -918,6 +955,8 @@ function ClassificationControls({
   onClassCount: (count: number) => void;
   onManualBreaks: (breaks: number[]) => void;
   onRange: (range: [number, number]) => void;
+  classColors: string[];
+  onClassOpacity: (index: number, opacity: number) => void;
 }) {
   const { t } = useTranslation();
   const min = symbology.breaks[0];
@@ -1003,9 +1042,86 @@ function ClassificationControls({
         </div>
       )}
 
+      <div className="space-y-2">
+        <div className="grid grid-cols-[minmax(0,1fr)_5rem] gap-2 text-[10px] font-medium text-muted-foreground">
+          <span>{t("rasterSymbology.classes")}</span>
+          <span>{t("layers.opacity")}</span>
+        </div>
+        {Array.from({ length: symbology.classCount }, (_, index) => (
+          <div key={index} className="grid grid-cols-[minmax(0,1fr)_5rem] items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <span
+                className="h-4 w-4 shrink-0 rounded-sm border border-border"
+                style={{
+                  backgroundColor: classColors[index] ?? "#808080",
+                  opacity: symbology.classOpacities?.[index] ?? 1,
+                }}
+              />
+              <span className="truncate text-[10px] text-muted-foreground">
+                {formatLegendNumber(symbology.breaks[index])} -{" "}
+                {formatLegendNumber(symbology.breaks[index + 1])}
+              </span>
+            </div>
+            <ClassOpacityInput
+              index={index}
+              value={symbology.classOpacities?.[index] ?? 1}
+              onCommit={(opacity) => onClassOpacity(index, opacity)}
+            />
+          </div>
+        ))}
+      </div>
+
       {symbology.method !== "manual" && !stats && (
         <p className="text-[10px] text-muted-foreground">Computing data range…</p>
       )}
+    </div>
+  );
+}
+
+/** A compact percentage editor for one classified raster value range. */
+function ClassOpacityInput({
+  index,
+  value,
+  onCommit,
+}: {
+  index: number;
+  value: number;
+  onCommit: (value: number) => void;
+}) {
+  const { t } = useTranslation();
+  const percent = String(Math.round(value * 100));
+  const [draft, setDraft] = useState(percent);
+  useEffect(() => setDraft(percent), [percent]);
+  const commitDraft = () => {
+    const parsed = Number(draft);
+    if (!Number.isFinite(parsed)) {
+      setDraft(percent);
+      return;
+    }
+    const clamped = Math.min(100, Math.max(0, parsed));
+    setDraft(String(clamped));
+    onCommit(clamped / 100);
+  };
+  return (
+    <div className="relative">
+      <Input
+        type="number"
+        inputMode="decimal"
+        min={0}
+        max={100}
+        step={1}
+        className="h-7 pe-6 text-xs"
+        aria-label={`${t("rasterSymbology.classes")} ${index + 1} ${t("layers.opacity")}`}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commitDraft}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") event.currentTarget.blur();
+        }}
+      />
+      <span className="pointer-events-none absolute end-2 top-1/2 -translate-y-1/2 text-[10px] text-muted-foreground">
+        %
+      </span>
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -6946,6 +6946,7 @@
       "categories": "الأصناف",
       "classColor": "لون الفئة {{index}}",
       "classColorPick": "التقاط لون الفئة {{index}} من الشاشة",
+      "classOpacity": "عتامة الفئة {{index}}",
       "classValue": "قيمة الفئة {{index}}",
       "colorExpression": "تعبير اللون",
       "applyStyleType": "تطبيق نوع النمط",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -6635,6 +6635,7 @@
       "categories": "Kategorien",
       "classColor": "Farbe für Klasse {{index}}",
       "classColorPick": "Farbe für Klasse {{index}} vom Bildschirm auswählen",
+      "classOpacity": "Deckkraft für Klasse {{index}}",
       "classValue": "Wert für Klasse {{index}}",
       "colorExpression": "Farbausdruck",
       "applyStyleType": "Stiltyp anwenden",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -6699,6 +6699,7 @@
       "categories": "Categories",
       "classColor": "Class {{index}} color",
       "classColorPick": "Pick class {{index}} color from the screen",
+      "classOpacity": "Class {{index}} opacity",
       "classValue": "Class {{index}} value",
       "colorExpression": "Color expression",
       "applyStyleType": "Apply style type",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -6635,6 +6635,7 @@
       "categories": "Categorías",
       "classColor": "Color de la clase {{index}}",
       "classColorPick": "Elegir el color de la clase {{index}} de la pantalla",
+      "classOpacity": "Opacidad de la clase {{index}}",
       "classValue": "Valor de la clase {{index}}",
       "colorExpression": "Expresión de color",
       "applyStyleType": "Aplicar tipo de estilo",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -6635,6 +6635,7 @@
       "categories": "دسته‌ها",
       "classColor": "رنگ کلاس {{index}}",
       "classColorPick": "برگزیدن رنگ کلاس {{index}} از صفحه",
+      "classOpacity": "کدری کلاس {{index}}",
       "classValue": "مقدار کلاس {{index}}",
       "colorExpression": "عبارت رنگ",
       "applyStyleType": "اعمال نوع شیوهٔ نمایش",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -6635,6 +6635,7 @@
       "categories": "Catégories",
       "classColor": "Couleur de la classe {{index}}",
       "classColorPick": "Choisir la couleur de la classe {{index}} à l'écran",
+      "classOpacity": "Opacité de la classe {{index}}",
       "classValue": "Valeur de la classe {{index}}",
       "colorExpression": "Expression de couleur",
       "applyStyleType": "Appliquer le type de style",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -6635,6 +6635,7 @@
       "categories": "श्रेणियां",
       "classColor": "वर्ग {{index}} रंग",
       "classColorPick": "स्क्रीन से वर्ग {{index}} रंग चुनें",
+      "classOpacity": "वर्ग {{index}} अपारदर्शिता",
       "classValue": "वर्ग {{index}} मान",
       "colorExpression": "रंग एक्सप्रेशन",
       "applyStyleType": "शैली प्रकार लागू करें",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -6557,6 +6557,7 @@
       "categories": "Kategori",
       "classColor": "Warna kelas {{index}}",
       "classColorPick": "Pilih warna kelas {{index}} dari layar",
+      "classOpacity": "Opasitas kelas {{index}}",
       "classValue": "Nilai kelas {{index}}",
       "colorExpression": "Ekspresi warna",
       "applyStyleType": "Terapkan jenis gaya",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -6635,6 +6635,7 @@
       "categories": "Categorie",
       "classColor": "Colore classe {{index}}",
       "classColorPick": "Preleva il colore della classe {{index}} dallo schermo",
+      "classOpacity": "Opacità classe {{index}}",
       "classValue": "Valore classe {{index}}",
       "colorExpression": "Espressione colore",
       "applyStyleType": "Applica tipo di stile",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -6557,6 +6557,7 @@
       "categories": "カテゴリ",
       "classColor": "クラス{{index}}の色",
       "classColorPick": "画面からクラス{{index}}の色を選択",
+      "classOpacity": "クラス{{index}}の不透明度",
       "classValue": "クラス{{index}}の値",
       "colorExpression": "色の式",
       "applyStyleType": "スタイルタイプを適用",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -6635,6 +6635,7 @@
       "categories": "კატეგორიები",
       "classColor": "კლასი {{index}}-ის ფერი",
       "classColorPick": "კლასი {{index}}-ის ფერის აღება ეკრანიდან",
+      "classOpacity": "კლასი {{index}}-ის გამჭვირვალობა",
       "classValue": "კლასი {{index}}-ის მნიშვნელობა",
       "colorExpression": "ფერის გამოსახულება",
       "applyStyleType": "სტილის ტიპის გამოყენება",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -6557,6 +6557,7 @@
       "categories": "카테고리",
       "classColor": "클래스 {{index}} 색상",
       "classColorPick": "화면에서 클래스 {{index}} 색상 선택",
+      "classOpacity": "클래스 {{index}} 불투명도",
       "classValue": "클래스 {{index}} 값",
       "colorExpression": "색상 표현식",
       "applyStyleType": "스타일 유형 적용",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -6635,6 +6635,7 @@
       "categories": "Categorieën",
       "classColor": "Kleur klasse {{index}}",
       "classColorPick": "Kleur voor klasse {{index}} van het scherm oppikken",
+      "classOpacity": "Dekking klasse {{index}}",
       "classValue": "Waarde klasse {{index}}",
       "colorExpression": "Kleurexpressie",
       "applyStyleType": "Stijltype toepassen",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -6635,6 +6635,7 @@
       "categories": "Categorias",
       "classColor": "Cor da classe {{index}}",
       "classColorPick": "Escolher a cor da classe {{index}} da tela",
+      "classOpacity": "Opacidade da classe {{index}}",
       "classValue": "Valor da classe {{index}}",
       "colorExpression": "Expressão de cor",
       "applyStyleType": "Aplicar tipo de estilo",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -6791,6 +6791,7 @@
       "categories": "Категории",
       "classColor": "Цвет класса {{index}}",
       "classColorPick": "Выбрать цвет класса {{index}} с экрана",
+      "classOpacity": "Непрозрачность класса {{index}}",
       "classValue": "Значение класса {{index}}",
       "colorExpression": "Выражение цвета",
       "applyStyleType": "Применить тип стиля",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -6557,6 +6557,7 @@
       "categories": "หมวดหมู่",
       "classColor": "สีของชั้นข้อมูลที่ {{index}}",
       "classColorPick": "เลือกสีของชั้นข้อมูลที่ {{index}} จากหน้าจอ",
+      "classOpacity": "ความทึบของชั้นข้อมูลที่ {{index}}",
       "classValue": "ค่าของชั้นข้อมูลที่ {{index}}",
       "colorExpression": "นิพจน์สี",
       "applyStyleType": "ใช้ชนิดของสไตล์นี้",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -6635,6 +6635,7 @@
       "categories": "Kategoriler",
       "classColor": "Sınıf {{index}} rengi",
       "classColorPick": "Sınıf {{index}} rengini ekrandan seç",
+      "classOpacity": "Sınıf {{index}} opaklığı",
       "classValue": "Sınıf {{index}} değeri",
       "colorExpression": "Renk ifadesi",
       "applyStyleType": "Stil türünü uygula",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -6548,6 +6548,7 @@
       "schemeQuantile": "lượng tử",
       "schemeNaturalBreaks": "Nghỉ giải lao tự nhiên",
       "classColorPick": "Chọn màu cho hạng {{index}}",
+      "classOpacity": "Lớp {{index}} độ mờ",
       "classValue": "Giá trị hạng {{index}}",
       "colorExpression": "Biểu hiện màu sắc",
       "applyStyleType": "Áp dụng kiểu kiểu",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -6557,6 +6557,7 @@
       "categories": "类别",
       "classColor": "分类 {{index}} 颜色",
       "classColorPick": "从屏幕上拾取分类 {{index}} 的颜色",
+      "classOpacity": "分类 {{index}} 不透明度",
       "classValue": "分类 {{index}} 值",
       "colorExpression": "颜色表达式",
       "applyStyleType": "应用样式类型",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -266,6 +266,7 @@ export {
   type RasterSymbology,
   clampRasterClassCount,
   computeRasterBreaks,
+  customColorsForRasterClassEdit,
   defaultRasterSymbology,
   normalizeRasterClassOpacities,
   savedRasterSymbology,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -267,6 +267,7 @@ export {
   clampRasterClassCount,
   computeRasterBreaks,
   defaultRasterSymbology,
+  normalizeRasterClassOpacities,
   savedRasterSymbology,
 } from "./plugins/raster-symbology";
 export { RASTER_SOURCE_KIND, getRasterBandStats } from "./plugins/raster-symbology-texture";

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -55,7 +55,7 @@ type ClassificationEntry = {
   /** Whether the ramp is reversed (from `rasterState.reversed`); baked into
    * the injected texture. */
   reversed: boolean;
-  /** Cache key for the built texture (breaks + ramp + customColors + reversed). */
+  /** Cache key for the built texture (breaks + ramp + colors + opacity + reverse). */
   key: string;
   texture?: GpuTexture;
 };
@@ -111,6 +111,7 @@ function symbologyKey(symbology: RasterSymbology, reversed: boolean): string {
     symbology.breaks,
     symbology.ramp,
     symbology.customColors ?? null,
+    symbology.classOpacities ?? null,
     reversed,
   ]);
 }
@@ -197,7 +198,7 @@ function ensureTexture(manager: RasterLayerManager, entry: ClassificationEntry):
   if (entry.texture && entry.key === key) return entry.texture;
   entry.texture?.destroy?.();
   try {
-    const { classified, breaks, ramp, customColors } = entry.symbology;
+    const { classified, breaks, ramp, customColors, classOpacities } = entry.symbology;
     const reversed = entry.reversed;
     // Classified ramps step through the class breaks; a custom continuous ramp
     // is a smooth gradient of the user's colors. (A built-in continuous ramp
@@ -215,6 +216,7 @@ function ensureTexture(manager: RasterLayerManager, entry: ClassificationEntry):
           ramp,
           reversed,
           custom ?? colormapColors(ramp) ?? undefined,
+          classOpacities,
         )
       : buildContinuousColormapRgba(custom ?? ["#000000", "#ffffff"], reversed);
     // The DOM ImageData ctor types its buffer as ArrayBuffer (not the wider

--- a/packages/plugins/src/plugins/raster-symbology.ts
+++ b/packages/plugins/src/plugins/raster-symbology.ts
@@ -93,6 +93,29 @@ export function normalizeRasterClassOpacities(
   return normalized.some((value) => value < 1) ? normalized : undefined;
 }
 
+/**
+ * Converts a class color edit from value order into the stored ramp order.
+ * Raster reversal flips colors at render time, so an edit made while reversed
+ * must flip the displayed list back before persistence.
+ *
+ * @param classColors - Current colors from the lowest value class to the highest.
+ * @param index - The value-order class index being edited.
+ * @param color - The replacement color.
+ * @param reversed - Whether the raster ramp is currently reversed.
+ * @returns A full custom color list in stored ramp order.
+ */
+export function customColorsForRasterClassEdit(
+  classColors: readonly string[],
+  index: number,
+  color: string,
+  reversed = false,
+): string[] {
+  const next = [...classColors];
+  const normalized = normalizeHexColor(color);
+  if (normalized && index >= 0 && index < next.length) next[index] = normalized;
+  return reversed ? next.reverse() : next;
+}
+
 /** A single band's statistics, as produced by `computeAutoStats`. */
 export type RasterBandStats = {
   min: number;

--- a/packages/plugins/src/plugins/raster-symbology.ts
+++ b/packages/plugins/src/plugins/raster-symbology.ts
@@ -44,6 +44,11 @@ export type RasterSymbology = {
   classCount: number;
   /** Class edges, ascending, length `classCount + 1` (min..max inclusive). */
   breaks: number[];
+  /**
+   * Per-class opacity values in [0, 1], ordered from the lowest value class to
+   * the highest. Omitted when every class is fully opaque.
+   */
+  classOpacities?: number[];
 };
 
 /** Minimum and maximum class count for raster classification. */
@@ -64,6 +69,29 @@ export const COLORMAP_TEXTURE_WIDTH = 256;
 
 /** Minimum colors that make a usable custom ramp (fewer can't interpolate). */
 export const RASTER_MIN_CUSTOM_COLORS = 2;
+
+/**
+ * Validates and clamps a per-class opacity list. Fully opaque lists are
+ * represented by `undefined` so existing project files remain compact.
+ *
+ * @param values - Candidate opacity values.
+ * @param classCount - The number of raster classes the values must describe.
+ * @returns A normalized opacity list, or undefined when invalid or all opaque.
+ */
+export function normalizeRasterClassOpacities(
+  values: unknown,
+  classCount: number,
+): number[] | undefined {
+  if (
+    !Array.isArray(values) ||
+    values.length !== classCount ||
+    !values.every((value) => typeof value === "number" && Number.isFinite(value))
+  ) {
+    return undefined;
+  }
+  const normalized = (values as number[]).map((value) => Math.min(1, Math.max(0, value)));
+  return normalized.some((value) => value < 1) ? normalized : undefined;
+}
 
 /** A single band's statistics, as produced by `computeAutoStats`. */
 export type RasterBandStats = {
@@ -186,6 +214,7 @@ export function rampBaseColors(ramp: string, customColors?: readonly string[]): 
  * @param ramp - The color ramp name.
  * @param reversed - Whether to reverse the class colors.
  * @param customColors - Optional user-defined anchor colors overriding `ramp`.
+ * @param classOpacities - Optional per-class opacity values in [0, 1].
  * @returns A 256x1 RGBA buffer (length COLORMAP_TEXTURE_WIDTH * 4).
  */
 export function buildSteppedColormapRgba(
@@ -193,12 +222,14 @@ export function buildSteppedColormapRgba(
   ramp: string,
   reversed = false,
   customColors?: readonly string[],
+  classOpacities?: readonly number[],
 ): Uint8ClampedArray {
   const width = COLORMAP_TEXTURE_WIDTH;
   const rgba = new Uint8ClampedArray(width * 4);
   const classCount = Math.max(1, breaks.length - 1);
   const colors = interpolateColors(rampBaseColors(ramp, customColors), classCount);
   const orderedColors = reversed ? [...colors].reverse() : colors;
+  const opacities = normalizeRasterClassOpacities(classOpacities, classCount);
 
   const min = breaks[0];
   const max = breaks[breaks.length - 1];
@@ -223,7 +254,7 @@ export function buildSteppedColormapRgba(
     rgba[offset] = color.r;
     rgba[offset + 1] = color.g;
     rgba[offset + 2] = color.b;
-    rgba[offset + 3] = 255;
+    rgba[offset + 3] = Math.round((opacities?.[classIndex] ?? 1) * 255);
   }
   return rgba;
 }
@@ -309,6 +340,11 @@ export function savedRasterSymbology(layer: GeoLibreLayer): RasterSymbology | nu
   }
   const classCount = breaks.length - 1;
 
+  // Class opacity is optional for backward compatibility. A malformed list is
+  // ignored, while finite out-of-range values are clamped into the renderable
+  // range so a hand-edited project cannot create invalid texture data.
+  const classOpacities = normalizeRasterClassOpacities(candidate.classOpacities, classCount);
+
   // A custom ramp needs at least two valid colors; drop malformed entries so a
   // hand-edited project silently falls back to the named ramp rather than
   // rendering a broken texture.
@@ -328,6 +364,7 @@ export function savedRasterSymbology(layer: GeoLibreLayer): RasterSymbology | nu
     method: candidate.method,
     classCount,
     breaks,
+    ...(classOpacities ? { classOpacities } : {}),
   };
 }
 

--- a/tests/raster-symbology-texture.test.ts
+++ b/tests/raster-symbology-texture.test.ts
@@ -170,6 +170,46 @@ describe("raster symbology render injection", () => {
     assert.equal(created[0]?.opts.width, 256);
   });
 
+  it("rebuilds the classified texture when class opacity changes", () => {
+    const layer = rasterLayer("r1", {
+      rasterSymbology: {
+        classified: true,
+        ramp: "viridis",
+        customColors: ["#ff0000", "#0000ff"],
+        method: "equal-interval",
+        classCount: 2,
+        breaks: [0, 1, 2],
+      },
+    });
+    useAppStore.getState().addLayer(layer);
+    const control = fakeControl();
+    let created = 0;
+    let destroyed = 0;
+    control._layerManager._device = {
+      createTexture: () => {
+        created += 1;
+        return { destroy: () => (destroyed += 1) };
+      },
+    };
+    activateRasterClassification(control);
+    renderColormapProps(control, "r1");
+    assert.equal(created, 1);
+
+    useAppStore.getState().updateLayer("r1", {
+      metadata: {
+        ...layer.metadata,
+        rasterSymbology: {
+          ...(layer.metadata.rasterSymbology as Record<string, unknown>),
+          classOpacities: [0, 1],
+        },
+      },
+    });
+    renderColormapProps(control, "r1");
+
+    assert.equal(created, 2);
+    assert.equal(destroyed, 1);
+  });
+
   it("switches from the WASM renderer when discrete classes need the GPU pipeline", () => {
     useAppStore.getState().addLayer(
       rasterLayer("r1", {

--- a/tests/raster-symbology.test.ts
+++ b/tests/raster-symbology.test.ts
@@ -6,6 +6,7 @@ import {
   buildSteppedColormapRgba,
   clampRasterClassCount,
   computeRasterBreaks,
+  customColorsForRasterClassEdit,
   defaultRasterSymbology,
   normalizeRasterClassOpacities,
   percentileFromHistogram,
@@ -156,6 +157,29 @@ describe("normalizeRasterClassOpacities", () => {
   it("rejects malformed or incorrectly sized lists", () => {
     assert.equal(normalizeRasterClassOpacities([0.5], 2), undefined);
     assert.equal(normalizeRasterClassOpacities([0.5, Number.NaN], 2), undefined);
+  });
+});
+
+describe("customColorsForRasterClassEdit", () => {
+  it("updates a class directly when the ramp is not reversed", () => {
+    assert.deepEqual(customColorsForRasterClassEdit(["#ff0000", "#00ff00"], 0, "#0000FF"), [
+      "#0000ff",
+      "#00ff00",
+    ]);
+  });
+
+  it("converts a reversed value-order edit back to stored ramp order", () => {
+    assert.deepEqual(customColorsForRasterClassEdit(["#ff0000", "#00ff00"], 0, "#0000ff", true), [
+      "#00ff00",
+      "#0000ff",
+    ]);
+  });
+
+  it("ignores an invalid edit without corrupting the stored colors", () => {
+    assert.deepEqual(customColorsForRasterClassEdit(["#ff0000", "#00ff00"], 9, "invalid"), [
+      "#ff0000",
+      "#00ff00",
+    ]);
   });
 });
 

--- a/tests/raster-symbology.test.ts
+++ b/tests/raster-symbology.test.ts
@@ -7,6 +7,7 @@ import {
   clampRasterClassCount,
   computeRasterBreaks,
   defaultRasterSymbology,
+  normalizeRasterClassOpacities,
   percentileFromHistogram,
   savedRasterSymbology,
 } from "../packages/plugins/src/plugins/raster-symbology";
@@ -115,6 +116,47 @@ describe("buildSteppedColormapRgba", () => {
     assert.deepEqual([rgba[0], rgba[1], rgba[2]], [255, 0, 0]);
     assert.deepEqual([rgba[255 * 4], rgba[255 * 4 + 1], rgba[255 * 4 + 2]], [0, 0, 255]);
   });
+
+  it("writes per-class opacity into the texture alpha channel", () => {
+    const rgba = buildSteppedColormapRgba(
+      [0, 1, 2],
+      "viridis",
+      false,
+      ["#ff0000", "#0000ff"],
+      [0, 0.5],
+    );
+    assert.equal(rgba[3], 0);
+    assert.equal(rgba[127 * 4 + 3], 0);
+    assert.equal(rgba[128 * 4 + 3], 128);
+    assert.equal(rgba[255 * 4 + 3], 128);
+  });
+
+  it("keeps opacity attached to value classes when the ramp is reversed", () => {
+    const rgba = buildSteppedColormapRgba(
+      [0, 1, 2],
+      "viridis",
+      true,
+      ["#ff0000", "#0000ff"],
+      [0.25, 0.75],
+    );
+    assert.deepEqual([rgba[0], rgba[1], rgba[2], rgba[3]], [0, 0, 255, 64]);
+    assert.deepEqual(
+      [rgba[255 * 4], rgba[255 * 4 + 1], rgba[255 * 4 + 2], rgba[255 * 4 + 3]],
+      [255, 0, 0, 191],
+    );
+  });
+});
+
+describe("normalizeRasterClassOpacities", () => {
+  it("clamps finite values and omits fully opaque lists", () => {
+    assert.deepEqual(normalizeRasterClassOpacities([-1, 0.5, 2], 3), [0, 0.5, 1]);
+    assert.equal(normalizeRasterClassOpacities([1, 1], 2), undefined);
+  });
+
+  it("rejects malformed or incorrectly sized lists", () => {
+    assert.equal(normalizeRasterClassOpacities([0.5], 2), undefined);
+    assert.equal(normalizeRasterClassOpacities([0.5, Number.NaN], 2), undefined);
+  });
 });
 
 describe("buildContinuousColormapRgba", () => {
@@ -211,6 +253,36 @@ describe("savedRasterSymbology", () => {
     );
     assert.ok(result);
     assert.deepEqual(result.customColors, ["#ff0000", "#00ff00"]);
+  });
+
+  it("keeps normalized per-class opacity", () => {
+    const result = savedRasterSymbology(
+      layerWith({
+        classified: true,
+        ramp: "viridis",
+        method: "equal-interval",
+        classCount: 2,
+        breaks: [0, 1, 2],
+        classOpacities: [-1, 0.5],
+      }),
+    );
+    assert.ok(result);
+    assert.deepEqual(result.classOpacities, [0, 0.5]);
+  });
+
+  it("drops opacity lists that do not match the class count", () => {
+    const result = savedRasterSymbology(
+      layerWith({
+        classified: true,
+        ramp: "viridis",
+        method: "equal-interval",
+        classCount: 2,
+        breaks: [0, 1, 2],
+        classOpacities: [0.5],
+      }),
+    );
+    assert.ok(result);
+    assert.equal(result.classOpacities, undefined);
   });
 
   it("drops custom colors that resolve to fewer than two valid entries", () => {


### PR DESCRIPTION
## Summary

- add a color picker and percentage opacity control for every discrete raster class
- persist per-class styling and apply opacity through the GPU colormap alpha channel
- preserve existing opacity values when class counts change and handle class colors correctly when ramps reverse

## Testing

- npm run test:frontend
- npm run build
- pre-commit run --all-files
- Playwright verification with dem.tif in light and dark themes

Addresses https://github.com/opengeos/GeoLibre/discussions/2246#discussioncomment-18289643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-class opacity controls for classified raster layers, with values validated and limited to 0–100%.
  * Opacity settings are preserved when classifications are recalculated and saved.
  * Classified color ramps now display interpolation-aware, reversal-aware swatches.
  * Editing an individual class color converts the ramp to a custom ramp while preserving class ordering.
  * Added localized labels for class opacity controls.

* **Bug Fixes**
  * Updated raster rendering so class opacity changes are reflected consistently in displayed textures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->