### PR TITLE
fix(stac): keep a successful vector add from reading as a failure

### DIFF
--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -1324,7 +1324,10 @@ function buildPanel(container: HTMLElement): () => void {
         });
         download.addEventListener("click", async () => {
           const [key, asset] = selected();
-          if (!connection) return;
+          if (!connection) {
+            setStatus(labels.addFailed, true);
+            return;
+          }
           signingDownloadKey = key;
           syncAsset();
           try {

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -744,7 +744,10 @@ export type VectorUrlSink = Pick<VectorControl, "addData" | "getLayers">;
  * a caller that tags what it added (the STAC panel writes an asset-access
  * record onto every returned id) would stamp one dataset's identity onto
  * another's layer. Only layers the control recorded against this url count as
- * ours; the control echoes the url back on `source` verbatim.
+ * ours: the control echoes a url source back unchanged (`describeSource`
+ * stores the string it was handed). Were that ever to stop holding, the new
+ * layers are reported anyway rather than an add that succeeded being called a
+ * failure.
  *
  * @param control - The vector control (or anything with `addData`/`getLayers`).
  * @param url - An http(s) URL to a vector dataset.
@@ -758,13 +761,11 @@ export async function addVectorLayersThroughControl(
 ): Promise<string[]> {
   const previousIds = new Set(control.getLayers().map((layer) => layer.id));
   await control.addData(url, options);
-  return control
-    .getLayers()
-    .filter(
-      (layer) =>
-        !previousIds.has(layer.id) && layer.source.kind === "url" && layer.source.url === url,
-    )
-    .map((layer) => layer.id);
+  const created = control.getLayers().filter((layer) => !previousIds.has(layer.id));
+  const fromThisUrl = created.filter(
+    (layer) => layer.source.kind === "url" && layer.source.url === url,
+  );
+  return (fromThisUrl.length ? fromThisUrl : created).map((layer) => layer.id);
 }
 
 /**

--- a/tests/vector-url-add.test.ts
+++ b/tests/vector-url-add.test.ts
@@ -59,6 +59,24 @@ describe("addVectorLayersThroughControl", () => {
     assert.deepEqual(fast, ["fast-1"]);
   });
 
+  it("still reports new layers when the control rewrites the url it records", async () => {
+    // The control stores a url source verbatim today. If it ever stopped, an
+    // add that worked must not be reported as one that added nothing.
+    const layers: { id: string; source: { kind: "url"; url: string } }[] = [];
+    const control = {
+      addData: async (url: string) => {
+        layers.push({ id: "rewritten", source: { kind: "url" as const, url: `${url}/` } });
+        return {} as never;
+      },
+      getLayers: () => layers.slice(),
+    } as unknown as VectorUrlSink;
+
+    assert.deepEqual(
+      await addVectorLayersThroughControl(control, "https://example.com/places.parquet"),
+      ["rewritten"],
+    );
+  });
+
   it("ignores layers the control already held for the same url", async () => {
     const { control } = createSlowControl({
       "https://example.com/places.parquet": { ids: ["places-1"], delayMs: 0 },


### PR DESCRIPTION
Follow-up to #2247, which merged while the last round of review comments was still being addressed. Two small changes, both from that PR's review.

- `addVectorLayersThroughControl` scopes its before/after diff to layers the control recorded against the url this call passed, so overlapping remote adds keep their own layers. The control stores a url source verbatim today (`describeSource` keeps the string it was handed), but if that ever stopped holding, the filter would match nothing and a successful GeoParquet add would surface as "Could not add asset" with the layer sitting on the map. It now falls back to the plain diff of new layers in that case.
- The STAC panel's Download button reports a missing connection the way Add does, instead of no-oping in silence.

Covered by a new case in `tests/vector-url-add.test.ts`; the frontend suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloading a STAC asset without an available connection now displays an error instead of failing silently.
  * Adding vector layers now reports successfully created layers even when their source URL is rewritten.

* **Tests**
  * Added coverage for vector layers whose URLs are modified during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->