### PR TITLE
chore: bump time slider to 1.8.7

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -93,7 +93,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
-    "maplibre-gl-time-slider": "^1.8.6",
+    "maplibre-gl-time-slider": "^1.8.7",
     "maplibre-gl-usgs-lidar": "^0.11.5",
     "maplibre-gl-vector": "^0.10.13",
     "openai": "^7.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
-        "maplibre-gl-time-slider": "^1.8.6",
+        "maplibre-gl-time-slider": "^1.8.7",
         "maplibre-gl-usgs-lidar": "^0.11.5",
         "maplibre-gl-vector": "^0.10.13",
         "openai": "^7.8.0",
@@ -19803,9 +19803,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.6.tgz",
-      "integrity": "sha512-AhhQps2KhvLX1pXcXTg/X0CvdZCY6b/lWtIGD8BYJ3cBooHX73dqFhTWR47w318Qo3qQiCI8PJMeYZrvuFOpzw==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.7.tgz",
+      "integrity": "sha512-wXASk+YmePHJ20Xf2jj6JdYscEHi/GKIASr8gN2yD+gve4YIvaNwL3u0XRZLp7kQ6GZWNiTlWL2Lx7GA+OCDSA==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -25510,7 +25510,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
-        "maplibre-gl-time-slider": "^1.8.6",
+        "maplibre-gl-time-slider": "^1.8.7",
         "maplibre-gl-usgs-lidar": "^0.11.5",
         "maplibre-gl-vector": "^0.10.13",
         "netcdfjs": "^4.0.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -68,7 +68,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
-    "maplibre-gl-time-slider": "^1.8.6",
+    "maplibre-gl-time-slider": "^1.8.7",
     "maplibre-gl-usgs-lidar": "^0.11.5",
     "maplibre-gl-vector": "^0.10.13",
     "netcdfjs": "^4.0.0",


### PR DESCRIPTION
## Summary
- update both GeoLibre time-slider dependencies to 1.8.7
- refresh the lockfile to the published package with duplicate source-ID handling

## Test plan
- [x] Run 172 focused time-slider and project tests
- [x] Run the desktop TypeScript build
- [x] Run all pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the map time slider component to the latest available patch version, improving reliability and compatibility across the desktop app and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->