### PR TITLE
fix: remove Cesium menu unavailability notices

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -33,7 +33,6 @@ import type { ToolbarChrome } from "./constants";
 const ASSISTANT_DENIED_ID = "processing-menu-assistant-denied";
 const PROCESSING_DENIED_ID = "processing-menu-processing-denied";
 const SIDECAR_DENIED_ID = "processing-menu-sidecar-denied";
-const CESIUM_DENIED_ID = "processing-menu-cesium-denied";
 const ADD_REMOTE_DENIED_ID = "processing-menu-add-remote-denied";
 
 /** Convert a Whitebox subcategory label to its full i18n key. */
@@ -709,7 +708,6 @@ export function ProcessingMenu({
               {show("processing.objectDetection") && (
                 <DropdownMenuItem
                   disabled={cesiumPrimary}
-                  aria-describedby={cesiumPrimary ? CESIUM_DENIED_ID : undefined}
                   onSelect={() => setObjectDetectionOpen(true)}
                 >
                   {t("toolbar.command.objectDetection")}
@@ -720,23 +718,10 @@ export function ProcessingMenu({
               {show("processing.segmentEverything") && (
                 <DropdownMenuItem
                   disabled={cesiumPrimary}
-                  aria-describedby={cesiumPrimary ? CESIUM_DENIED_ID : undefined}
                   onSelect={() => setSegmentEverythingOpen(true)}
                 >
                   {t("toolbar.command.segmentEverything")}
                 </DropdownMenuItem>
-              )}
-              {/* A greyed-out item with no explanation reads as a bug rather
-                  than as policy (see CapabilityNotice) — and a disabled
-                  DropdownMenuItem is `pointer-events-none`, so the reason has
-                  to be a rendered line, not a `title`. */}
-              {cesiumPrimary && (
-                <DropdownMenuLabel
-                  id={CESIUM_DENIED_ID}
-                  className="pt-0 text-xs font-normal text-muted-foreground"
-                >
-                  {t("toolbar.item.mapLibreOnly")}
-                </DropdownMenuLabel>
               )}
               {!mobile && <CapabilityNotice id={SIDECAR_DENIED_ID} capability={sidecarDeniedCap} />}
             </DropdownMenuSubContent>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -50,7 +50,6 @@ const GALLERY_UNAVAILABLE_ID = "project-menu-gallery-unavailable";
 const SAVE_DENIED_ID = "project-menu-save-denied";
 const SHARE_DENIED_ID = "project-menu-share-denied";
 const EXPORT_DATA_DENIED_ID = "project-menu-export-data-denied";
-const CESIUM_DENIED_ID = "project-menu-cesium-denied";
 const EXPORT_IMAGE_DENIED_ID = "project-menu-export-image-denied";
 
 interface ProjectMenuProps {
@@ -423,9 +422,7 @@ export function ProjectMenu({
           <DropdownMenuItem
             onSelect={onOpenOfflineBasemap}
             disabled={cesiumPrimary || !exportDataCapability.granted}
-            // The globe reason wins when both apply: it is the one the user can
-            // act on from here, and only one id can be announced.
-            aria-describedby={cesiumPrimary ? CESIUM_DENIED_ID : exportDataDeniedBy}
+            aria-describedby={exportDataDeniedBy}
           >
             <HardDriveDownload className="me-2 h-3.5 w-3.5" />
             {t("toolbar.item.offlineBasemapEllipsis")}
@@ -445,14 +442,6 @@ export function ProjectMenu({
             of them would be orphaned when only the other is on screen. */}
         {showExportDataActions && (
           <CapabilityNotice id={EXPORT_DATA_DENIED_ID} capability={exportDataCapability} />
-        )}
-        {show("project.offlineRegion") && cesiumPrimary && (
-          <DropdownMenuLabel
-            id={CESIUM_DENIED_ID}
-            className="pt-0 text-xs font-normal text-muted-foreground"
-          >
-            {t("toolbar.item.mapLibreOnly")}
-          </DropdownMenuLabel>
         )}
         {show("project.printLayout") && (
           <CapabilityNotice id={EXPORT_IMAGE_DENIED_ID} capability={exportImageCapability} />

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
@@ -94,8 +94,6 @@ interface ViewMenuProps {
  * camera's rotation/tilt. Hidden on narrow screens (via
  * `chrome.secondaryButtonClass`) so the menu bar stays one row.
  */
-const CESIUM_DENIED_ID = "view-menu-cesium-denied";
-
 export function ViewMenu({
   chrome,
   history,
@@ -162,16 +160,6 @@ export function ViewMenu({
   const showGoogleMaps = show("view.googleMaps");
   const showGoogleEarth = show("view.googleEarth");
   const showExternal = showGoogleMaps || showGoogleEarth;
-  // A disabled DropdownMenuItem is `pointer-events-none`, so a native `title`
-  // can never be hovered — the reason has to be a rendered line the items point
-  // at (the CapabilityNotice convention). One line at the menu's foot serves
-  // all of them, since they are disabled by the same thing (#2217 review).
-  // Only when one of them is actually on screen: a profile that hid them all
-  // leaves the menu showing Rendering engine alone, and `aria-describedby`
-  // must never name an id that is not mounted.
-  const showMapLibreOnlyNote =
-    noMapLibreMap && (showZoom || showNavigation || showReset || showSetView || showExternal);
-  const mapLibreOnlyNote = showMapLibreOnlyNote ? CESIUM_DENIED_ID : undefined;
   const paneCount = mapLayout.rows * mapLayout.cols;
   const gridKey = `${mapLayout.rows}x${mapLayout.cols}`;
   // A custom profile could hide every item; render nothing rather than a menu
@@ -209,21 +197,13 @@ export function ViewMenu({
         <DropdownMenuLabel>{t("toolbar.menu.view")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {show("view.zoomIn") && (
-          <DropdownMenuItem
-            disabled={atMaxZoom || noMapLibreMap}
-            aria-describedby={mapLibreOnlyNote}
-            onSelect={onZoomIn}
-          >
+          <DropdownMenuItem disabled={atMaxZoom || noMapLibreMap} onSelect={onZoomIn}>
             <ZoomIn className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.zoomIn")}</span>
           </DropdownMenuItem>
         )}
         {show("view.zoomOut") && (
-          <DropdownMenuItem
-            disabled={atMinZoom || noMapLibreMap}
-            aria-describedby={mapLibreOnlyNote}
-            onSelect={onZoomOut}
-          >
+          <DropdownMenuItem disabled={atMinZoom || noMapLibreMap} onSelect={onZoomOut}>
             <ZoomOut className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.zoomOut")}</span>
           </DropdownMenuItem>
@@ -232,7 +212,6 @@ export function ViewMenu({
         {show("view.previousView") && (
           <DropdownMenuItem
             disabled={!history.canGoBack || noMapLibreMap}
-            aria-describedby={mapLibreOnlyNote}
             onSelect={history.goBack}
           >
             <ArrowLeft className="me-2 h-3.5 w-3.5 shrink-0 rtl:rotate-180" />
@@ -242,7 +221,6 @@ export function ViewMenu({
         {show("view.nextView") && (
           <DropdownMenuItem
             disabled={!history.canGoForward || noMapLibreMap}
-            aria-describedby={mapLibreOnlyNote}
             onSelect={history.goForward}
           >
             <ArrowRight className="me-2 h-3.5 w-3.5 shrink-0 rtl:rotate-180" />
@@ -254,7 +232,6 @@ export function ViewMenu({
           <DropdownMenuSub>
             <DropdownMenuSubTrigger
               disabled={allResetDisabled || noMapLibreMap}
-              aria-describedby={mapLibreOnlyNote}
               className="data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
             >
               <RotateCcw className="h-3.5 w-3.5 shrink-0" />
@@ -291,11 +268,7 @@ export function ViewMenu({
         )}
         {(showZoom || showNavigation || showReset) && showSetView && <DropdownMenuSeparator />}
         {showSetView && (
-          <DropdownMenuItem
-            disabled={noMapLibreMap}
-            aria-describedby={mapLibreOnlyNote}
-            onSelect={onSetView}
-          >
+          <DropdownMenuItem disabled={noMapLibreMap} onSelect={onSetView}>
             <Crosshair className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.setView")}</span>
           </DropdownMenuItem>
@@ -388,32 +361,16 @@ export function ViewMenu({
           showRenderingEngine) &&
           showExternal && <DropdownMenuSeparator />}
         {showGoogleMaps && (
-          <DropdownMenuItem
-            disabled={noMapLibreMap}
-            aria-describedby={mapLibreOnlyNote}
-            onSelect={onViewInGoogleMaps}
-          >
+          <DropdownMenuItem disabled={noMapLibreMap} onSelect={onViewInGoogleMaps}>
             <MapIcon className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.viewInGoogleMaps")}</span>
           </DropdownMenuItem>
         )}
         {showGoogleEarth && (
-          <DropdownMenuItem
-            disabled={noMapLibreMap}
-            aria-describedby={mapLibreOnlyNote}
-            onSelect={onViewInGoogleEarth}
-          >
+          <DropdownMenuItem disabled={noMapLibreMap} onSelect={onViewInGoogleEarth}>
             <Earth className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.viewInGoogleEarth")}</span>
           </DropdownMenuItem>
-        )}
-        {showMapLibreOnlyNote && (
-          <DropdownMenuLabel
-            id={CESIUM_DENIED_ID}
-            className="pt-0 text-xs font-normal text-muted-foreground"
-          >
-            {t("toolbar.item.mapLibreOnly")}
-          </DropdownMenuLabel>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -2913,7 +2913,6 @@
       "renderingEngine": "محرك العرض",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "غير متاح على الكرة الأرضية ثلاثية الأبعاد. عُد إلى MapLibre 2D من العرض ← محرك العرض.",
       "viewInGoogleMaps": "عرض في Google Maps",
       "viewInGoogleEarth": "عرض في Google Earth",
       "zoomIn": "تكبير",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Rendering-Engine",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Auf dem 3D-Globus nicht verfügbar. Wechseln Sie über Ansicht → Rendering-Engine zurück zu MapLibre 2D.",
       "viewInGoogleMaps": "In Google Maps ansehen",
       "viewInGoogleEarth": "In Google Earth ansehen",
       "zoomIn": "Vergrößern",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Rendering engine",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Unavailable on the 3D globe. Switch View → Rendering engine back to MapLibre 2D.",
       "viewInGoogleMaps": "View in Google Maps",
       "viewInGoogleEarth": "View in Google Earth",
       "zoomIn": "Zoom In",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Motor de representación",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "No disponible en el globo 3D. Vuelva a MapLibre 2D en Ver → Motor de representación.",
       "viewInGoogleMaps": "Ver en Google Maps",
       "viewInGoogleEarth": "Ver en Google Earth",
       "zoomIn": "Acercar",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "موتور ترسیم",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "روی کرهٔ سه‌بعدی در دسترس نیست. از نما ← موتور ترسیم به MapLibre 2D بازگردید.",
       "viewInGoogleMaps": "دیدن در Google Maps",
       "viewInGoogleEarth": "دیدن در Google Earth",
       "zoomIn": "بزرگ‌نمایی",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Moteur de rendu",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Indisponible sur le globe 3D. Revenez à MapLibre 2D via Affichage → Moteur de rendu.",
       "viewInGoogleMaps": "Voir dans Google Maps",
       "viewInGoogleEarth": "Voir dans Google Earth",
       "zoomIn": "Zoomer",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "रेंडरिंग इंजन",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "3D ग्लोब पर उपलब्ध नहीं है। दृश्य → रेंडरिंग इंजन से MapLibre 2D पर वापस जाएँ।",
       "viewInGoogleMaps": "Google Maps में देखें",
       "viewInGoogleEarth": "Google Earth में देखें",
       "zoomIn": "ज़ूम इन",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -2679,7 +2679,6 @@
       "renderingEngine": "Mesin render",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Tidak tersedia pada bola dunia 3D. Kembali ke MapLibre 2D melalui Tampilan → Mesin render.",
       "viewInGoogleMaps": "Lihat di Google Maps",
       "viewInGoogleEarth": "Lihat di Google Earth",
       "zoomIn": "Perbesar",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Motore di rendering",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Non disponibile sul globo 3D. Torna a MapLibre 2D da Visualizza → Motore di rendering.",
       "viewInGoogleMaps": "Visualizza in Google Maps",
       "viewInGoogleEarth": "Visualizza in Google Earth",
       "zoomIn": "Aumenta zoom",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -2679,7 +2679,6 @@
       "renderingEngine": "レンダリングエンジン",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "3D地球儀では利用できません。「表示 → レンダリングエンジン」からMapLibre 2Dに戻してください。",
       "viewInGoogleMaps": "Google マップで表示",
       "viewInGoogleEarth": "Google Earth で表示",
       "zoomIn": "ズームイン",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "რენდერინგის ძრავა",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "3D გლობუსზე მიუწვდომელია. დაბრუნდით MapLibre 2D-ზე ხედი → რენდერინგის ძრავა-დან.",
       "viewInGoogleMaps": "ნახვა Google Maps-ში",
       "viewInGoogleEarth": "ნახვა Google Earth-ში",
       "zoomIn": "მიახლოება",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -2679,7 +2679,6 @@
       "renderingEngine": "렌더링 엔진",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "3D 지구본에서는 사용할 수 없습니다. 보기 → 렌더링 엔진에서 MapLibre 2D로 되돌리세요.",
       "viewInGoogleMaps": "Google 지도에서 보기",
       "viewInGoogleEarth": "Google Earth에서 보기",
       "zoomIn": "확대",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Renderengine",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Niet beschikbaar op de 3D-globe. Schakel via Beeld → Renderengine terug naar MapLibre 2D.",
       "viewInGoogleMaps": "Bekijken in Google Maps",
       "viewInGoogleEarth": "Bekijken in Google Earth",
       "zoomIn": "Inzoomen",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Motor de renderização",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Indisponível no globo 3D. Volte para o MapLibre 2D em Exibir → Motor de renderização.",
       "viewInGoogleMaps": "Ver no Google Maps",
       "viewInGoogleEarth": "Ver no Google Earth",
       "zoomIn": "Ampliar",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -2820,7 +2820,6 @@
       "renderingEngine": "Механизм отрисовки",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Недоступно на 3D-глобусе. Вернитесь к MapLibre 2D через Вид → Механизм отрисовки.",
       "viewInGoogleMaps": "Открыть в Google Maps",
       "viewInGoogleEarth": "Открыть в Google Earth",
       "zoomIn": "Приблизить",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -2679,7 +2679,6 @@
       "renderingEngine": "เอนจินการแสดงผล",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "ใช้ไม่ได้บนลูกโลก 3 มิติ กลับไปใช้ MapLibre 2D ที่ มุมมอง → เอนจินการแสดงผล",
       "viewInGoogleMaps": "ดูใน Google Maps",
       "viewInGoogleEarth": "ดูใน Google Earth",
       "zoomIn": "ซูมเข้า",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -2726,7 +2726,6 @@
       "renderingEngine": "Çizim motoru",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "3D kürede kullanılamaz. Görünüm → Çizim motoru üzerinden MapLibre 2D'ye geri dönün.",
       "viewInGoogleMaps": "Google Haritalar'da görüntüle",
       "viewInGoogleEarth": "Google Earth'te görüntüle",
       "zoomIn": "Yakınlaştır",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -2679,7 +2679,6 @@
       "renderingEngine": "Bộ kết xuất",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "Không khả dụng trên quả địa cầu 3D. Hãy quay lại MapLibre 2D qua Xem → Bộ kết xuất.",
       "viewInGoogleMaps": "Xem trên Google Maps",
       "viewInGoogleEarth": "Xem trong Google Earth",
       "zoomIn": "Phóng to",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -2679,7 +2679,6 @@
       "renderingEngine": "渲染引擎",
       "rendererMapLibre": "MapLibre 2D",
       "rendererCesium": "Cesium 3D",
-      "mapLibreOnly": "在 3D 地球上不可用。请通过“视图 → 渲染引擎”切换回 MapLibre 2D。",
       "viewInGoogleMaps": "在 Google 地图中查看",
       "viewInGoogleEarth": "在 Google Earth 中查看",
       "zoomIn": "放大",


### PR DESCRIPTION
## Summary

Remove the long Cesium unavailability message that stretched the View, Project, and Processing menus. Delete its accessibility references and translation key from all 19 locale catalogs while preserving disabled states for unsupported actions.

## Validation

- [x] Pre-commit checks on changed files, including formatting, ESLint, and the production build
- [x] All 40 i18n catalog tests
- [x] Verified no remaining message or accessibility ID references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Removed explanatory “MapLibre-only” notices from toolbar menus when using the 3D globe view.
  * Restricted actions remain unavailable in the 3D globe view, but no longer display the previous explanation.

* **Localization**
  * Removed the obsolete “MapLibre-only” message from all supported translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->