### PR TITLE
feat: expose screenshot readiness through a query parameter

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -76,6 +76,7 @@ import { openRightPanel } from "@geolibre/plugins";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
 import { useProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useProjectHistory } from "../../hooks/useProjectHistory";
+import { useScreenshotReadiness } from "../../hooks/useScreenshotReadiness";
 import {
   isRasterFileName,
   isGeoLibreProjectFileName,
@@ -1354,6 +1355,14 @@ export function DesktopShell({
    */
   const primaryRenderer = useAppStore((s) => s.primaryRenderer);
   const cesiumPrimary = primaryRenderer === "cesium";
+  useScreenshotReadiness(
+    mapControllerRef,
+    mapReadyGeneration,
+    externalPluginsReady,
+    projectUrlLoadState?.status === "loading" || dataUrlLoadState?.status === "loading",
+    projectUrlLoadState?.error ?? dataUrlLoadState?.error ?? null,
+    cesiumPrimary,
+  );
   const setObjectDetectionOpen = useAppStore((s) => s.setObjectDetectionOpen);
   const setSegmentEverythingOpen = useAppStore((s) => s.setSegmentEverythingOpen);
   // Switching to the globe destroys the MapLibre map, which would otherwise

--- a/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
+++ b/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
@@ -1,0 +1,116 @@
+import { useEffect, type RefObject } from "react";
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import { getRasterLoadState, getSharedDeckLoadState } from "@geolibre/plugins";
+import { inspectScreenshotLayers, screenshotReadinessEnabled } from "../lib/screenshot-readiness";
+
+/** Opt-in DOM contract for browser automation; adds no pixels to the screenshot. */
+export function useScreenshotReadiness(
+  controller: RefObject<MapController | null>,
+  generation: number,
+  pluginsReady: boolean,
+  projectBusy: boolean,
+  loadError: string | null,
+  cesium: boolean,
+): void {
+  useEffect(() => {
+    if (!screenshotReadinessEnabled(window.location.search)) return;
+    const root = document.documentElement;
+    const map = controller.current?.getMap();
+    const failures = new Set<string>();
+    let settledSince = 0;
+    let started = performance.now();
+    let frame = 0;
+    let checkedAt = 0;
+    const publish = (
+      state: "loading" | "ready" | "error",
+      pending: string[] = [],
+      errors: string[] = [],
+    ) => {
+      const values = {
+        geolibreLoadState: state,
+        geolibreLoadPending: JSON.stringify(pending),
+        geolibreLoadErrors: JSON.stringify(errors),
+      };
+      for (const [key, value] of Object.entries(values)) {
+        if (root.dataset[key] !== value) root.dataset[key] = value;
+      }
+    };
+    const invalidate = () => {
+      settledSince = 0;
+      if (root.dataset.geolibreLoadState === "ready") started = performance.now();
+      publish("loading");
+    };
+    const onError = (event: { error: { message: string } }) => {
+      failures.add(event.error.message);
+      publish("error", [], [...failures]);
+    };
+    publish("loading");
+    map?.on("dataloading", invalidate);
+    map?.on("movestart", invalidate);
+    map?.on("styledata", invalidate);
+    map?.on("error", onError);
+    const unsubscribe = useAppStore.subscribe((state, previous) => {
+      if (
+        state.layers !== previous.layers ||
+        state.layerGroups !== previous.layerGroups ||
+        state.projectGeneration !== previous.projectGeneration
+      )
+        invalidate();
+    });
+    const tick = () => {
+      frame = requestAnimationFrame(tick);
+      // Check on painted frames, but avoid walking every layer at display FPS.
+      if (performance.now() - checkedAt < 100) return;
+      checkedAt = performance.now();
+      const errors = [...failures];
+      if (loadError) errors.push(loadError);
+      if (cesium) errors.push("Screenshot readiness is not supported for the Cesium renderer");
+      const store = useAppStore.getState();
+      const result =
+        map && pluginsReady && !projectBusy && !cesium
+          ? inspectScreenshotLayers(map, store.layers, store.layerGroups, {
+              raster: getRasterLoadState,
+              deck: getSharedDeckLoadState,
+            })
+          : { pending: ["Project and map initialization"], errors: [] };
+      errors.push(...result.errors);
+      if (errors.length) {
+        settledSince = 0;
+        publish("error", result.pending, errors);
+        return;
+      }
+      const complete =
+        map &&
+        !projectBusy &&
+        pluginsReady &&
+        result.pending.length === 0 &&
+        map.loaded() &&
+        map.areTilesLoaded() &&
+        !map.isMoving() &&
+        document.fonts.status === "loaded";
+      if (!complete) settledSince = 0;
+      else settledSince ||= performance.now();
+      // Keep the predicates true across painted frames, including raster fade
+      // and asynchronous plugin/store updates after the initial map idle.
+      if (complete && performance.now() - settledSince >= 500) publish("ready");
+      else if (performance.now() - started > 120_000) {
+        publish("error", result.pending, [
+          "Timed out waiting for the visible map to finish loading",
+        ]);
+      } else publish("loading", result.pending);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(frame);
+      unsubscribe();
+      map?.off("dataloading", invalidate);
+      map?.off("movestart", invalidate);
+      map?.off("styledata", invalidate);
+      map?.off("error", onError);
+      delete root.dataset.geolibreLoadState;
+      delete root.dataset.geolibreLoadPending;
+      delete root.dataset.geolibreLoadErrors;
+    };
+  }, [controller, generation, pluginsReady, projectBusy, loadError, cesium]);
+}

--- a/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
+++ b/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
@@ -41,9 +41,13 @@ export function useScreenshotReadiness(
       if (root.dataset.geolibreLoadState === "ready") started = performance.now();
       publish("loading");
     };
+    // A map `error` is not terminal on its own: a single tile 404 during a pan
+    // is often resolved by a retry, and `error` IS terminal for consumers (the
+    // documented wait is `ready` or `error`). Record it and let `tick` decide --
+    // dropped once the map reaches a settled, fully loaded state, reported when
+    // it never does.
     const onError = (event: { error: { message: string } }) => {
       failures.add(event.error.message);
-      publish("error", [], [...failures]);
     };
     publish("loading");
     map?.on("dataloading", invalidate);
@@ -63,7 +67,7 @@ export function useScreenshotReadiness(
       // Check on painted frames, but avoid walking every layer at display FPS.
       if (performance.now() - checkedAt < 100) return;
       checkedAt = performance.now();
-      const errors = [...failures];
+      const errors: string[] = [];
       if (loadError) errors.push(loadError);
       if (cesium) errors.push("Screenshot readiness is not supported for the Cesium renderer");
       const store = useAppStore.getState();
@@ -77,7 +81,7 @@ export function useScreenshotReadiness(
       errors.push(...result.errors);
       if (errors.length) {
         settledSince = 0;
-        publish("error", result.pending, errors);
+        publish("error", result.pending, [...failures, ...errors]);
         return;
       }
       const complete =
@@ -93,9 +97,14 @@ export function useScreenshotReadiness(
       else settledSince ||= performance.now();
       // Keep the predicates true across painted frames, including raster fade
       // and asynchronous plugin/store updates after the initial map idle.
-      if (complete && performance.now() - settledSince >= 500) publish("ready");
-      else if (performance.now() - started > 120_000) {
+      if (complete && performance.now() - settledSince >= 500) {
+        // Every tile the viewport needs is loaded and the map is idle, so any
+        // `error` event recorded along the way was transient.
+        failures.clear();
+        publish("ready");
+      } else if (performance.now() - started > 120_000) {
         publish("error", result.pending, [
+          ...failures,
           "Timed out waiting for the visible map to finish loading",
         ]);
       } else publish("loading", result.pending);

--- a/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
+++ b/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
@@ -15,7 +15,12 @@ export function screenshotReadinessEnabled(search: string): boolean {
 }
 
 export interface LayerLoadProbe {
-  raster: (id: string) => { loading: boolean; error: string | null; native: boolean };
+  raster: (id: string) => {
+    loading: boolean;
+    error: string | null;
+    native: boolean;
+    deckTracked: boolean;
+  };
   deck: (id: string) => { found: boolean; loading: boolean; error: string | null };
 }
 
@@ -55,7 +60,13 @@ export function inspectScreenshotLayers(
         pending.push(layer.name);
         continue;
       }
-      requiresDeck = !raster.native;
+      // A raster is either drawn as a native MapLibre layer (checked below), or
+      // by deck.gl. Only the interleaved deck path registers with the shared
+      // overlay; the overlaid one (Tauri) owns a private deck canvas the probe
+      // cannot see, so the control's own state above is all the evidence there
+      // is -- requiring a deck entry would leave it pending forever.
+      if (!raster.native && !raster.deckTracked) continue;
+      requiresDeck = raster.deckTracked;
     }
     const deck = probe.deck(layer.id);
     if (deck.found) {

--- a/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
+++ b/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
@@ -78,11 +78,18 @@ export function inspectScreenshotLayers(
       pending.push(layer.name);
       continue;
     }
+    // deck-viz layers register with the shared overlay under their own layer id,
+    // so the probe above IS their readiness check. Reaching here means the
+    // overlay built no deck layer for this one, which is a broken/unsupported
+    // configuration rather than a rendered layer -- fail closed, but say so
+    // accurately.
+    if (layer.type === "deckgl-viz") {
+      errors.push(`${layer.name}: no deck.gl output was built for this layer`);
+      continue;
+    }
     // Streaming/custom renderers need their own probe. Fail closed instead of
     // returning ready for an idle basemap while a point cloud is still fetching.
-    if (
-      ["lidar", "3d-tiles", "gaussian-splat", "zarr", "deckgl-viz", "video"].includes(layer.type)
-    ) {
+    if (["lidar", "3d-tiles", "gaussian-splat", "zarr", "video"].includes(layer.type)) {
       errors.push(`${layer.name}: screenshot readiness is not supported for ${layer.type}`);
       continue;
     }

--- a/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
+++ b/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
@@ -1,0 +1,100 @@
+import {
+  effectiveLayerRenderState,
+  styleValue,
+  type GeoLibreLayer,
+  type LayerGroup,
+} from "@geolibre/core";
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+export function screenshotReadinessEnabled(search: string): boolean {
+  const params = new URLSearchParams(search);
+  return (
+    params.has("loading") &&
+    ["", "true", "1", "yes", "on"].includes(params.get("loading")!.trim().toLowerCase())
+  );
+}
+
+export interface LayerLoadProbe {
+  raster: (id: string) => { loading: boolean; error: string | null; native: boolean };
+  deck: (id: string) => { found: boolean; loading: boolean; error: string | null };
+}
+
+/** Never infer readiness from a saved layer entry or from a custom layer's mere presence. */
+export function inspectScreenshotLayers(
+  map: MapLibreMap,
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+  probe: LayerLoadProbe,
+): { pending: string[]; errors: string[] } {
+  const pending: string[] = [];
+  const errors: string[] = [];
+  // getStyle() serializes sources (potentially large embedded GeoJSON).
+  const nativeLayers = map.getLayersOrder().flatMap((id) => {
+    const native = map.getLayer(id);
+    return native ? [native] : [];
+  });
+  const zoom = map.getZoom();
+  for (const layer of layers) {
+    const effective = effectiveLayerRenderState(layer, groups);
+    if (!effective.visible || effective.opacity === 0) continue;
+    if (zoom < styleValue(layer.style, "minZoom") || zoom >= styleValue(layer.style, "maxZoom"))
+      continue;
+    if (typeof layer.metadata.error === "string") {
+      errors.push(`${layer.name}: ${layer.metadata.error}`);
+      continue;
+    }
+    const isRaster = layer.metadata.sourceKind === "maplibre-gl-raster";
+    let requiresDeck = false;
+    if (isRaster) {
+      const raster = probe.raster(layer.id);
+      if (raster.error) {
+        errors.push(`${layer.name}: ${raster.error}`);
+        continue;
+      }
+      if (raster.loading) {
+        pending.push(layer.name);
+        continue;
+      }
+      requiresDeck = !raster.native;
+    }
+    const deck = probe.deck(layer.id);
+    if (deck.found) {
+      if (deck.error) errors.push(`${layer.name}: ${deck.error}`);
+      else if (deck.loading) pending.push(layer.name);
+      continue;
+    }
+    if (requiresDeck) {
+      pending.push(layer.name);
+      continue;
+    }
+    // Streaming/custom renderers need their own probe. Fail closed instead of
+    // returning ready for an idle basemap while a point cloud is still fetching.
+    if (
+      ["lidar", "3d-tiles", "gaussian-splat", "zarr", "deckgl-viz", "video"].includes(layer.type)
+    ) {
+      errors.push(`${layer.name}: screenshot readiness is not supported for ${layer.type}`);
+      continue;
+    }
+    const ids = Array.isArray(layer.metadata.nativeLayerIds) ? layer.metadata.nativeLayerIds : [];
+    const rendered = nativeLayers.filter(
+      (item) =>
+        ids.includes(item.id) || item.id === layer.id || item.id.startsWith(`layer-${layer.id}-`),
+    );
+    if (rendered.length === 0) {
+      pending.push(layer.name);
+      continue;
+    }
+    if (rendered.some((item) => item.type === "custom")) {
+      errors.push(`${layer.name}: screenshot readiness is not supported for this custom renderer`);
+      continue;
+    }
+    if (
+      rendered.some(
+        (item) =>
+          "source" in item && (!map.getSource(item.source) || !map.isSourceLoaded(item.source)),
+      )
+    )
+      pending.push(layer.name);
+  }
+  return { pending, errors };
+}

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -23,6 +23,7 @@ A chrome-free `maponly` embed shows only the map, as in this shared 3D Tiles pro
 | Parameter    | Example                                                    | Description                                                                                                                           |
 | ------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`        | `url=https://share.geolibre.app/you/project.geolibre.json` | Loads a `.geolibre.json` project from a public URL.                                                                                   |
+| `loading`    | `loading=true` | Exposes screenshot readiness on the document element. Accepts a bare flag, `true`, `1`, `yes`, or `on`; disabled by default. See below. |
 | `data`       | `data=https://assets.geolibre.app/data/places.geojson`     | Loads public GeoJSON, GeoParquet, PMTiles, a COG, or a ZIP/REST response containing multiple GeoJSON files.                           |
 | `style`      | `style=https://assets.geolibre.app/data/sample.style.json` | Applies a GeoLibre/MapLibre vector style or raster-style JSON to the data loaded by `data`.                                            |
 | `layout`     | `layout=viewer`                                            | `viewer` provides read-only chrome: Layers, View, Controls, basemaps, search/identify, Help, and any quick filters the project's layers carry, with authoring UI hidden. `compact` is the icon-only full-app layout; `embed` and `iframe` are aliases. |
@@ -83,6 +84,57 @@ preselecting a tool or applying any parameters. A known id the current engine
 doesn't expose (WASM in the browser, the Python sidecar on desktop) likewise
 isn't preselected. Tool ids match the Processing menu — the same ids used across
 the [Whitebox toolbox](processing.md).
+
+## Waiting for a screenshot
+
+Add `&loading=true` to a project link to enable a machine-readable readiness
+signal without adding a visible overlay to the screenshot:
+
+```text
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/national-land-cover-database-nlcd.geolibre.json&maponly&loading=true
+```
+
+The `<html>` element exposes three attributes:
+
+| Attribute | Value |
+| --- | --- |
+| `data-geolibre-load-state` | `loading`, `ready`, or `error` |
+| `data-geolibre-load-pending` | JSON array of pending layer names (or initialization work) |
+| `data-geolibre-load-errors` | JSON array of failure messages |
+
+`ready` means the project/data URL has loaded, visible layers have attached,
+their current-viewport tiles have loaded, the camera has stopped, and browser
+fonts have loaded. These checks must remain satisfied for 500 ms across animation
+frames. Changing the view or layers returns the signal to `loading`. Hidden
+layers (including hidden groups), fully transparent layers, and layers outside
+their zoom range do not block readiness. This does not download an entire
+dataset or tiles outside the viewport.
+
+The check supports native MapLibre layers and the raster control's COG layers,
+including its shared deck.gl renderer. Custom renderers without a readiness
+probe, such as Cesium, LiDAR, Zarr, splats, and video, report an explicit error
+instead of assuming they are ready. Map/tile failures also report `error`;
+loading that does not settle within 120 seconds reports a timeout. Check the
+errors before capturing; neither the embed API's `ready` event nor a browser's
+`networkidle` state establishes this rendering readiness.
+
+For example, with Playwright:
+
+```javascript
+await page.setViewportSize({ width: 1600, height: 1000 });
+await page.goto(projectLink + "&maponly&loading=true");
+await page.waitForFunction(
+  () => ["ready", "error"].includes(document.documentElement.dataset.geolibreLoadState),
+  undefined,
+  { timeout: 150_000 },
+);
+const result = await page.evaluate(() => ({
+  state: document.documentElement.dataset.geolibreLoadState,
+  errors: JSON.parse(document.documentElement.dataset.geolibreLoadErrors || "[]"),
+}));
+if (result.state !== "ready") throw new Error(result.errors.join("; "));
+await page.screenshot({ path: "map.png" });
+```
 
 ## Embedding in a page
 

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -110,11 +110,13 @@ layers (including hidden groups), fully transparent layers, and layers outside
 their zoom range do not block readiness. This does not download an entire
 dataset or tiles outside the viewport.
 
-The check supports native MapLibre layers and the raster control's COG layers,
-including its shared deck.gl renderer. Custom renderers without a readiness
-probe, such as Cesium, LiDAR, Zarr, splats, and video, report an explicit error
-instead of assuming they are ready. Map/tile failures also report `error`;
-loading that does not settle within 120 seconds reports a timeout. Check the
+The check supports native MapLibre layers, the raster control's COG layers, and
+deck.gl visualization layers, including their shared deck.gl renderer. Custom
+renderers without a readiness probe, such as Cesium, LiDAR, Zarr, splats, and
+video, report an explicit error instead of assuming they are ready. A map or
+tile failure the map recovers from does not block `ready`; one it never
+recovers from is reported alongside the timeout, as is any loading that does
+not settle within 120 seconds. Check the
 errors before capturing; neither the embed API's `ready` event nor a browser's
 `networkidle` state establishes this rendering readiness.
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -246,6 +246,7 @@ export {
   closeRasterLayerPanel,
   openRasterLayerPanel,
   restoreRasterLayers,
+  getRasterLoadState,
   readRasterPixel,
   setLocalRasterFileReader,
   setLocalRasterPicker,
@@ -256,6 +257,7 @@ export {
   type NonTiledRasterRequest,
   type PickedLocalRaster,
 } from "./plugins/maplibre-raster";
+export { getSharedDeckLoadState } from "./plugins/shared-deck-overlay";
 export {
   RASTER_MAX_CLASSES,
   RASTER_MAX_STORED_CLASSES,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -537,10 +537,18 @@ export function getRasterMainVisibility(layerId: string): boolean {
 /** Live header state; saved project metadata is not evidence of a completed load. */
 export function getRasterLoadState(layerId: string) {
   const raster = rasterControl?.getRaster(layerId);
+  const native = rasterControl ? rendersNativeMapLibreLayer(rasterControl.getEngine()) : false;
   return {
     loading: !raster || raster.loading,
     error: raster?.error?.message ?? null,
-    native: rasterControl ? rendersNativeMapLibreLayer(rasterControl.getEngine()) : false,
+    native,
+    // The deck.gl engine only routes through the shared interleaved overlay --
+    // and so is only visible to getSharedDeckLoadState -- when the control was
+    // created interleaved. On Tauri it renders overlaid, into its own deck
+    // canvas that never calls setSharedDeckLayers (see
+    // patchWebRasterOverlayFactory), so the control's own header state above is
+    // the only load signal there.
+    deckTracked: !native && rasterControl !== null && rasterControlInterleaved,
   };
 }
 

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -534,6 +534,16 @@ export function getRasterMainVisibility(layerId: string): boolean {
   return rasterControl?.getRaster(layerId)?.state.visible ?? true;
 }
 
+/** Live header state; saved project metadata is not evidence of a completed load. */
+export function getRasterLoadState(layerId: string) {
+  const raster = rasterControl?.getRaster(layerId);
+  return {
+    loading: !raster || raster.loading,
+    error: raster?.error?.message ?? null,
+    native: rasterControl ? rendersNativeMapLibreLayer(rasterControl.getEngine()) : false,
+  };
+}
+
 export function closeRasterLayerPanel(app: GeoLibreAppAPI): void {
   if (restorePanelExpandTimeout !== null) {
     window.clearTimeout(restorePanelExpandTimeout);

--- a/packages/plugins/src/plugins/shared-deck-overlay.ts
+++ b/packages/plugins/src/plugins/shared-deck-overlay.ts
@@ -55,6 +55,17 @@ let ensureInFlight: Promise<MapboxOverlay | null> | null = null;
 
 // The per-source layer lists, aggregated into one setProps on every render.
 const layersBySource = new Map<SharedDeckSource, Layer[]>();
+const loadErrors = new Map<string, string>();
+
+/** Inspect live deck layers, including their asynchronous tile sublayers. */
+export function getSharedDeckLoadState(layerId: string) {
+  const layers = aggregatedLayers().filter((layer) => layer.id === layerId);
+  return {
+    found: layers.length > 0,
+    loading: !overlayMounted || layers.some((layer) => !layer.isLoaded),
+    error: loadErrors.get(layerId) ?? null,
+  };
+}
 
 // The luma device from the shared Deck, forwarded to producers that need it to
 // allocate GPU resources (the raster control's classification colormap
@@ -112,10 +123,19 @@ async function runEnsureSharedDeckOverlay(app: GeoLibreAppAPI): Promise<MapboxOv
     }
   }
   boundMap = map;
+  loadErrors.clear();
   device = null;
   overlay = new deckGL.mapbox.MapboxOverlay({
     interleaved: true,
     layers: [],
+    onError: (error, layer) => {
+      // A tile error can leave isLoaded=true with a hole in the raster.
+      // Attribute sublayer errors to the producer's top-level layer.
+      let root = layer;
+      while (root?.parent) root = root.parent;
+      if (root) loadErrors.set(root.id, error.message);
+      console.error("[GeoLibre] deck layer failed", error);
+    },
     onDeviceInitialized: (initializedDevice: unknown) => {
       device = initializedDevice;
       for (const listener of deviceListeners) {
@@ -148,6 +168,10 @@ async function runEnsureSharedDeckOverlay(app: GeoLibreAppAPI): Promise<MapboxOv
  * @param layers - That producer's deck layers, in its own draw order.
  */
 export function setSharedDeckLayers(source: SharedDeckSource, layers: Layer[]): void {
+  const ids = new Set(layers.map((layer) => layer.id));
+  for (const previous of layersBySource.get(source) ?? []) {
+    if (!ids.has(previous.id)) loadErrors.delete(previous.id);
+  }
   if (layers.length > 0) layersBySource.set(source, layers);
   else layersBySource.delete(source);
   renderSharedDeckOverlay();

--- a/packages/plugins/src/plugins/shared-deck-overlay.ts
+++ b/packages/plugins/src/plugins/shared-deck-overlay.ts
@@ -60,9 +60,18 @@ const loadErrors = new Map<string, string>();
 /** Inspect live deck layers, including their asynchronous tile sublayers. */
 export function getSharedDeckLoadState(layerId: string) {
   const layers = aggregatedLayers().filter((layer) => layer.id === layerId);
+  const loading = !overlayMounted || layers.some((layer) => !layer.isLoaded);
+  // A recorded error deliberately outlives isLoaded flipping back to true: a
+  // failed tile still resolves as loaded and leaves a hole in the raster. It
+  // must not outlive the layer's NEXT fetch though -- a top-level layer id is
+  // stable for the layer's whole life, so a one-off network blip would
+  // otherwise pin readiness at `error` forever. Once the layer is loading
+  // again a retry is in flight, so drop the stale error and let `onError`
+  // re-record it if that attempt fails too.
+  if (loading && layers.length > 0) loadErrors.delete(layerId);
   return {
     found: layers.length > 0,
-    loading: !overlayMounted || layers.some((layer) => !layer.isLoaded),
+    loading,
     error: loadErrors.get(layerId) ?? null,
   };
 }

--- a/tests/screenshot-readiness.test.ts
+++ b/tests/screenshot-readiness.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type { Map as MapLibreMap } from "maplibre-gl";
+import {
+  inspectScreenshotLayers,
+  screenshotReadinessEnabled,
+  type LayerLoadProbe,
+} from "../apps/geolibre-desktop/src/lib/screenshot-readiness";
+
+const layer: GeoLibreLayer = {
+  id: "nlcd",
+  name: "NLCD",
+  type: "cog",
+  source: {},
+  visible: true,
+  opacity: 1,
+  style: DEFAULT_LAYER_STYLE,
+  metadata: { sourceKind: "maplibre-gl-raster" },
+};
+const map = {
+  getZoom: () => 4,
+  getLayersOrder: () => ["nlcd"],
+  getLayer: () => ({ id: "nlcd", type: "raster", source: "tiles" }),
+  getSource: () => ({}),
+  isSourceLoaded: () => true,
+} as unknown as MapLibreMap;
+const probe: LayerLoadProbe = {
+  raster: () => ({ loading: false, error: null, native: true }),
+  deck: () => ({ found: false, loading: false, error: null }),
+};
+
+test("screenshot readiness is opt-in, including in map-only embeds", () => {
+  for (const value of ["", "=true", "=1", "=yes", "=on", "=TRUE"]) {
+    assert.equal(screenshotReadinessEnabled(`?maponly&loading${value}`), true);
+  }
+  for (const query of ["", "?maponly", "?loading=false", "?loading=0", "?loading=no"]) {
+    assert.equal(screenshotReadinessEnabled(query), false);
+  }
+});
+
+test("an attached native layer cannot mask an unfinished COG header", () => {
+  const result = inspectScreenshotLayers(map, [layer], [], {
+    ...probe,
+    raster: () => ({ loading: true, error: null, native: true }),
+  });
+  assert.deepEqual(result, { pending: ["NLCD"], errors: [] });
+});
+
+test("a loaded COG header cannot mask unfinished deck tiles or tile failures", () => {
+  assert.deepEqual(
+    inspectScreenshotLayers(map, [layer], [], {
+      ...probe,
+      deck: () => ({ found: true, loading: true, error: null }),
+    }),
+    { pending: ["NLCD"], errors: [] },
+  );
+  assert.deepEqual(
+    inspectScreenshotLayers(map, [layer], [], {
+      ...probe,
+      deck: () => ({ found: true, loading: false, error: "Tile request failed" }),
+    }),
+    { pending: [], errors: ["NLCD: Tile request failed"] },
+  );
+});
+
+test("missing native layers and unfinished native sources remain pending", () => {
+  const missing = { ...map, getLayersOrder: () => [] } as unknown as MapLibreMap;
+  assert.deepEqual(inspectScreenshotLayers(missing, [layer], [], probe).pending, ["NLCD"]);
+  const fetching = { ...map, isSourceLoaded: () => false } as unknown as MapLibreMap;
+  assert.deepEqual(inspectScreenshotLayers(fetching, [layer], [], probe).pending, ["NLCD"]);
+  assert.deepEqual(inspectScreenshotLayers(map, [layer], [], probe), { pending: [], errors: [] });
+});
+
+test("hidden layers do not block a screenshot, unsupported visible renderers fail closed", () => {
+  const lidar = { ...layer, type: "lidar" as const, metadata: {} };
+  assert.deepEqual(inspectScreenshotLayers(map, [{ ...lidar, visible: false }], [], probe), {
+    pending: [],
+    errors: [],
+  });
+  assert.match(
+    inspectScreenshotLayers(map, [lidar], [], probe).errors[0],
+    /not supported for lidar/,
+  );
+});

--- a/tests/screenshot-readiness.test.ts
+++ b/tests/screenshot-readiness.test.ts
@@ -106,3 +106,20 @@ test("hidden layers do not block a screenshot, unsupported visible renderers fai
     /not supported for lidar/,
   );
 });
+
+test("a deck-viz layer is probed through the shared overlay, not failed closed", () => {
+  const viz = { ...layer, type: "deckgl-viz" as const, metadata: {} };
+  assert.deepEqual(
+    inspectScreenshotLayers(map, [viz], [], {
+      ...probe,
+      deck: () => ({ found: true, loading: true, error: null }),
+    }),
+    { pending: ["NLCD"], errors: [] },
+  );
+  // Nothing was built for it, so there is no rendering to wait on -- fail
+  // closed rather than call an absent layer ready.
+  assert.match(
+    inspectScreenshotLayers(map, [viz], [], probe).errors[0],
+    /no deck\.gl output was built/,
+  );
+});

--- a/tests/screenshot-readiness.test.ts
+++ b/tests/screenshot-readiness.test.ts
@@ -26,7 +26,7 @@ const map = {
   isSourceLoaded: () => true,
 } as unknown as MapLibreMap;
 const probe: LayerLoadProbe = {
-  raster: () => ({ loading: false, error: null, native: true }),
+  raster: () => ({ loading: false, error: null, native: true, deckTracked: false }),
   deck: () => ({ found: false, loading: false, error: null }),
 };
 
@@ -42,7 +42,7 @@ test("screenshot readiness is opt-in, including in map-only embeds", () => {
 test("an attached native layer cannot mask an unfinished COG header", () => {
   const result = inspectScreenshotLayers(map, [layer], [], {
     ...probe,
-    raster: () => ({ loading: true, error: null, native: true }),
+    raster: () => ({ loading: true, error: null, native: true, deckTracked: false }),
   });
   assert.deepEqual(result, { pending: ["NLCD"], errors: [] });
 });
@@ -62,6 +62,29 @@ test("a loaded COG header cannot mask unfinished deck tiles or tile failures", (
     }),
     { pending: [], errors: ["NLCD: Tile request failed"] },
   );
+});
+
+test("a deck-rendered raster waits for the shared overlay only when interleaved", () => {
+  // Interleaved (web): the shared deck overlay is the load signal, so a raster
+  // it has not registered yet is still pending.
+  const interleaved: LayerLoadProbe = {
+    ...probe,
+    raster: () => ({ loading: false, error: null, native: false, deckTracked: true }),
+  };
+  assert.deepEqual(inspectScreenshotLayers(map, [layer], [], interleaved), {
+    pending: ["NLCD"],
+    errors: [],
+  });
+  // Overlaid (Tauri): a private deck canvas the probe cannot see, so the
+  // control's own loaded header is the whole answer -- never pending forever.
+  const overlaid: LayerLoadProbe = {
+    ...probe,
+    raster: () => ({ loading: false, error: null, native: false, deckTracked: false }),
+  };
+  assert.deepEqual(inspectScreenshotLayers(map, [layer], [], overlaid), {
+    pending: [],
+    errors: [],
+  });
 });
 
 test("missing native layers and unfinished native sources remain pending", () => {

--- a/tests/shared-deck-overlay.test.ts
+++ b/tests/shared-deck-overlay.test.ts
@@ -159,7 +159,18 @@ describe("shared-deck-overlay", () => {
       id: "subtile",
       parent: raster,
     });
+    // The error survives while the layer stays loaded (a failed tile resolves as
+    // loaded but leaves a hole), and clears once the layer fetches again so a
+    // transient blip cannot pin readiness at `error` for the layer's whole life.
     assert.equal(getSharedDeckLoadState(raster.id).error, "Tile failed");
+    raster.isLoaded = false;
+    assert.deepEqual(getSharedDeckLoadState(raster.id), {
+      found: true,
+      loading: true,
+      error: null,
+    });
+    raster.isLoaded = true;
+    assert.equal(getSharedDeckLoadState(raster.id).error, null, "the retry succeeded");
     setSharedDeckLayers("raster", []);
     assert.equal(getSharedDeckLoadState(raster.id).found, false);
     assert.equal(getSharedDeckLoadState(raster.id).error, null);

--- a/tests/shared-deck-overlay.test.ts
+++ b/tests/shared-deck-overlay.test.ts
@@ -3,12 +3,13 @@ import { describe, it } from "node:test";
 import type { GeoLibreAppAPI, GeoLibreDeckGL } from "../packages/plugins/src/types";
 import {
   ensureSharedDeckOverlay,
+  getSharedDeckLoadState,
   onSharedDeckDevice,
   setSharedDeckLayers,
 } from "../packages/plugins/src/plugins/shared-deck-overlay";
 
 // A deck layer stand-in. Only identity/label matter for these assertions.
-type FakeLayer = { id: string };
+type FakeLayer = { id: string; isLoaded?: boolean; parent?: FakeLayer };
 const layer = (id: string): FakeLayer => ({ id });
 const ids = (layers: unknown): string[] => (layers as FakeLayer[]).map((l) => l.id);
 
@@ -18,8 +19,14 @@ class FakeMapboxOverlay {
   static instances: FakeMapboxOverlay[] = [];
   props: { layers?: FakeLayer[] } = {};
   onDeviceInitialized?: (device: unknown) => void;
-  constructor(props: { layers?: FakeLayer[]; onDeviceInitialized?: (device: unknown) => void }) {
+  onError?: (error: Error, layer: FakeLayer) => void;
+  constructor(props: {
+    layers?: FakeLayer[];
+    onDeviceInitialized?: (device: unknown) => void;
+    onError?: (error: Error, layer: FakeLayer) => void;
+  }) {
     this.onDeviceInitialized = props.onDeviceInitialized;
+    this.onError = props.onError;
     FakeMapboxOverlay.instances.push(this);
   }
   setProps(props: { layers?: FakeLayer[] }): void {
@@ -135,6 +142,27 @@ describe("shared-deck-overlay", () => {
 
     unsubscribe();
     unsubscribeLate();
+  });
+
+  it("keeps failed subtiles distinct from a successfully loaded parent", (context) => {
+    context.mock.method(console, "error", () => {});
+    const raster = { id: "raster-readiness", isLoaded: false };
+    setSharedDeckLayers("raster", [raster] as never);
+    assert.equal(getSharedDeckLoadState(raster.id).loading, true);
+    raster.isLoaded = true;
+    assert.deepEqual(getSharedDeckLoadState(raster.id), {
+      found: true,
+      loading: false,
+      error: null,
+    });
+    FakeMapboxOverlay.instances.at(-1)?.onError?.(new Error("Tile failed"), {
+      id: "subtile",
+      parent: raster,
+    });
+    assert.equal(getSharedDeckLoadState(raster.id).error, "Tile failed");
+    setSharedDeckLayers("raster", []);
+    assert.equal(getSharedDeckLoadState(raster.id).found, false);
+    assert.equal(getSharedDeckLoadState(raster.id).error, null);
   });
 
   it("rebinds to a fresh overlay on a new map and re-applies live layers", async () => {


### PR DESCRIPTION
## Summary

Opening a shared project could finish loading its configuration before its raster tiles rendered, leaving screenshot automation without a reliable completion signal. Add the opt-in `loading=true` query parameter to expose `loading`, `ready`, or `error` through `data-geolibre-load-state` on `<html>`, with JSON attributes listing pending layers and errors.

Readiness checks visible native MapLibre layers, COG headers and shared deck.gl tile state, map movement, and browser fonts. The conditions must remain satisfied for 500 ms; view/layer changes invalidate readiness. Failed requests, unsupported renderers, and a 120-second timeout report errors. The documentation includes a Playwright capture example and explains the current-viewport scope and renderer limitations.

## Validation

- [x] TypeScript check and scoped pre-commit checks, including production build and ESLint.
- [x] 62 tests covering screenshot readiness, shared deck overlays, and raster synchronization.
- [x] Real-browser verification with the shared NLCD project: loading to ready, rendered screenshot, and ready to loading to ready after zooming.
- [x] Real HTTP 404 project URL reports error; `loading=false` omits the readiness attributes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Embedding integrations can opt in with `loading=true` to receive machine-readable screenshot readiness status.
  - Readiness now reflects map, layer, plugin, and renderer loading, including errors and unsupported visible layer types.
  - Status reports loading, ready, or error states and updates after view or layer changes.

- **Documentation**
  - Added embedding guidance and a Playwright example for waiting until content is ready before capturing screenshots.

- **Bug Fixes**
  - Improved detection and reporting of raster and deck-rendered layer loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->