### PR TITLE
fix: restore project terrain when the toolbar is hidden

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -132,6 +132,7 @@ import { useEmbedBridge } from "../../hooks/useEmbedBridge";
 import { useRasterIdentify } from "../../hooks/useRasterIdentify";
 import { useGlobalRasterIdentify } from "../../hooks/useGlobalRasterIdentify";
 import { useNetcdfIdentify } from "../../hooks/useNetcdfIdentify";
+import { useTerrainRestore } from "../../hooks/useTerrainRestore";
 import { useCogSpectralIdentify } from "../../hooks/useCogSpectralIdentify";
 import {
   useAutoCollapsedPanel,
@@ -965,6 +966,7 @@ export function DesktopShell({
   useRasterIdentify();
   useNetcdfIdentify(mapControllerRef, mapReadyGeneration);
   useCogSpectralIdentify(mapControllerRef, mapReadyGeneration);
+  useTerrainRestore(mapControllerRef, mapReadyGeneration, projectGeneration);
   const [layerPanelWidth, setLayerPanelWidth] = useState(initialSidePanelWidth);
   const [stylePanelWidth, setStylePanelWidth] = useState(initialSidePanelWidth);
   const [stylePanelOpenRequest, setStylePanelOpenRequest] = useState(0);

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1232,17 +1232,15 @@ export function TopToolbar({
   );
   const terrainEnabled = useAppStore((state) => state.preferences.map.terrainEnabled);
 
-  // Terrain is project state, unlike the other optional map chrome. Restore it
-  // after both project loads and controller/style initialization so reopening a
-  // saved project brings back the control and its active terrain surface.
+  // Terrain is project state, unlike the other optional map chrome, so applying
+  // it to the map lives in `useTerrainRestore` (DesktopShell) — this toolbar is
+  // unmounted in `?maponly` embeds and must not own the restore. Only the
+  // checkbox mirrors that state here.
   useEffect(() => {
-    const controller = mapControllerRef.current;
-    if (!controller) return;
-    controller.setBuiltInControlVisible("terrain", terrainEnabled);
     setControlsVisible((current) =>
       current.terrain === terrainEnabled ? current : { ...current, terrain: terrainEnabled },
     );
-  }, [mapControllerRef, mapReadyGeneration, projectGeneration, terrainEnabled]);
+  }, [terrainEnabled]);
   // `keyword` has no deep-link parameter — only the Browser panel's saved CSW
   // entries carry one — so it widens the parsed shape rather than joining it.
   const [initialService, setInitialService] = useState<

--- a/apps/geolibre-desktop/src/hooks/useTerrainRestore.ts
+++ b/apps/geolibre-desktop/src/hooks/useTerrainRestore.ts
@@ -1,0 +1,29 @@
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import { useEffect } from "react";
+
+/**
+ * Apply the project's `terrainEnabled` preference to the live map.
+ *
+ * Terrain is project state rather than optional map chrome, so restoring it
+ * cannot live in the toolbar: embeds that hide the toolbar (`?maponly`, used by
+ * share.geolibre.app for thumbnails) never mount it and would render a saved 3D
+ * project flat. Re-runs on project load and on controller/style initialization
+ * so reopening a project brings back both the control and its terrain surface.
+ *
+ * Args:
+ *     mapControllerRef: Ref to the live MapController.
+ *     mapReadyGeneration: Bumped whenever the controller/style reinitialises.
+ *     projectGeneration: Bumped whenever a project is loaded.
+ */
+export function useTerrainRestore(
+  mapControllerRef: React.RefObject<MapController | null>,
+  mapReadyGeneration: number,
+  projectGeneration: number,
+): void {
+  const terrainEnabled = useAppStore((state) => state.preferences.map.terrainEnabled);
+
+  useEffect(() => {
+    mapControllerRef.current?.setBuiltInControlVisible("terrain", terrainEnabled);
+  }, [mapControllerRef, mapReadyGeneration, projectGeneration, terrainEnabled]);
+}

--- a/tests/terrain-restore.test.ts
+++ b/tests/terrain-restore.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// `preferences.map.terrainEnabled` is project state, but it used to be applied
+// from an effect inside TopToolbar. `?maponly` embeds (share.geolibre.app builds
+// thumbnails with them) hide the toolbar, so it never mounted and a saved 3D
+// project rendered flat — no DEM tiles were ever requested. The restore now
+// lives in DesktopShell via useTerrainRestore, which mounts regardless of
+// chrome. Nothing in the type system stops a future edit from moving it back
+// into chrome-gated code, so pin the arrangement here.
+function source(path: string): string {
+  return readFileSync(fileURLToPath(new URL(`../${path}`, import.meta.url)), "utf8");
+}
+
+const DESKTOP_SHELL = "apps/geolibre-desktop/src/components/layout/DesktopShell.tsx";
+const TOP_TOOLBAR = "apps/geolibre-desktop/src/components/layout/TopToolbar.tsx";
+
+describe("terrain restore is independent of toolbar visibility", () => {
+  it("DesktopShell applies the preference itself", () => {
+    const shell = source(DESKTOP_SHELL);
+    assert.match(
+      shell,
+      /useTerrainRestore\(mapControllerRef, mapReadyGeneration, projectGeneration\)/,
+      `${DESKTOP_SHELL} must call useTerrainRestore so terrain survives ?maponly`,
+    );
+  });
+
+  it("DesktopShell calls it outside the toolbarVisible branch", () => {
+    const shell = source(DESKTOP_SHELL);
+    const restore = shell.indexOf("useTerrainRestore(");
+    const gate = shell.indexOf("layoutOptions.toolbarVisible");
+    assert.notEqual(restore, -1, "useTerrainRestore call is missing");
+    assert.notEqual(gate, -1, "toolbar render gate is missing");
+    assert.ok(restore < gate, "useTerrainRestore must run before/outside the toolbar render gate");
+  });
+
+  it("TopToolbar no longer owns the terrain restore", () => {
+    assert.doesNotMatch(
+      source(TOP_TOOLBAR),
+      /setBuiltInControlVisible\(\s*"terrain"/,
+      `${TOP_TOOLBAR} is unmounted by ?maponly and must not apply terrain`,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

A saved project with `preferences.map.terrainEnabled: true` renders **flat** when opened as a map-only embed (`?maponly=true`). No DEM tiles are requested at all.

This is why [share.geolibre.app/giswqs/3d-terrain](https://share.geolibre.app/giswqs/3d-terrain) has a flat thumbnail — the thumbnail worker builds every capture with `?maponly=true`.

## Cause

`terrainEnabled` was applied from a single effect inside `TopToolbar`:

```ts
controller.setBuiltInControlVisible("terrain", terrainEnabled);
```

But `useLayoutOptions` sets `toolbarVisible: !mapOnly`, and `DesktopShell` renders `<TopToolbar>` only when `layoutOptions.toolbarVisible`. So under `?maponly` the component never mounts, the effect never runs, and terrain is never applied. The effect's own comment already noted terrain is project state — it was just living in chrome-gated code.

## Fix

Move the restore into `useTerrainRestore`, called from `DesktopShell`, which mounts regardless of which chrome is visible. `TopToolbar` keeps only the checkbox mirror of the same store value, so the full UI is unchanged.

## Verification

Measured in a real browser against `share.geolibre.app/giswqs/3d-terrain.geolibre.json` with `?maponly=true&theme=dark&loading=true`, counting requests to `s3.amazonaws.com/elevation-tiles-prod/terrarium/`:

| Build | DEM tiles | Result |
| --- | --- | --- |
| production today | 0 | flat |
| this branch | 13 | 3D relief |

Parameters isolated to confirm `maponly` is the trigger — `theme=dark` (10 tiles) and `loading=true` (20 tiles) both keep terrain working; only `maponly=true` zeroes it.

`tests/terrain-restore.test.ts` pins the arrangement (source-invariant, in the style of `add-data-i18n.test.ts`, since nothing in the type system prevents moving the restore back under chrome). Confirmed it fails on the pre-fix tree.

`npm run typecheck`, `npm run lint` (0 errors), `npm run test`, and `pre-commit` on the changed files all pass.

## Note

This does **not** fix every bad thumbnail. [barataria-bay-s2-acdom](https://share.geolibre.app/giswqs/barataria-bay-s2-acdom) falls back to a placeholder for an unrelated reason: `useScreenshotReadiness` reports `pending: ["aCDOM440"]` for the full 120s even though the layer is visibly rendered. That layer has `metadata.sourceKind: "time-slider"`, which `inspectScreenshotLayers` has no probe for, so it falls through to the native-layer check and waits forever. Tracking separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terrain settings are now restored reliably when maps are reinitialized or projects are loaded.
  * Terrain restoration also works in map-only embeds where the toolbar is hidden.
  * Toolbar terrain controls remain synchronized with the saved terrain preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->