### PR TITLE
fix: detect native layers renderers name from the store layer id

### DIFF
--- a/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
+++ b/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
@@ -24,6 +24,31 @@ export interface LayerLoadProbe {
   deck: (id: string) => { found: boolean; loading: boolean; error: string | null };
 }
 
+/**
+ * Whether `nativeId` is a native layer this store layer draws under, named by
+ * deriving from its own id.
+ *
+ * Renderers that own their MapLibre layers name them `<layer id>-<suffix>` with
+ * a generated suffix — the Time Slider's client-rendered mosaics come through as
+ * `acdom-mosaic-xra0fk3`, for instance. Those ids cannot be predicted when the
+ * mirrored store layer is built, so `metadata.nativeLayerIds` still records only
+ * the store id and the exact-match checks all miss.
+ *
+ * A bare prefix test would let `acdom` claim `acdom-2`'s layers, so a candidate
+ * is rejected when another store layer's id is a longer prefix of it — that
+ * layer is the real owner.
+ */
+function ownsDerivedNativeLayer(
+  layerId: string,
+  nativeId: string,
+  layers: GeoLibreLayer[],
+): boolean {
+  if (!nativeId.startsWith(`${layerId}-`)) return false;
+  return !layers.some(
+    (other) => other.id.length > layerId.length && nativeId.startsWith(`${other.id}-`),
+  );
+}
+
 /** Never infer readiness from a saved layer entry or from a custom layer's mere presence. */
 export function inspectScreenshotLayers(
   map: MapLibreMap,
@@ -96,7 +121,10 @@ export function inspectScreenshotLayers(
     const ids = Array.isArray(layer.metadata.nativeLayerIds) ? layer.metadata.nativeLayerIds : [];
     const rendered = nativeLayers.filter(
       (item) =>
-        ids.includes(item.id) || item.id === layer.id || item.id.startsWith(`layer-${layer.id}-`),
+        ids.includes(item.id) ||
+        item.id === layer.id ||
+        item.id.startsWith(`layer-${layer.id}-`) ||
+        ownsDerivedNativeLayer(layer.id, item.id, layers),
     );
     if (rendered.length === 0) {
       pending.push(layer.name);

--- a/tests/screenshot-readiness.test.ts
+++ b/tests/screenshot-readiness.test.ts
@@ -123,3 +123,65 @@ test("a deck-viz layer is probed through the shared overlay, not failed closed",
     /no deck\.gl output was built/,
   );
 });
+
+/**
+ * A Time Slider layer mirrors into the store with `nativeLayerIds: [sourceId]`,
+ * but its client-rendered mosaic is drawn by maplibre-gl-raster under a
+ * generated id (`acdom-mosaic-xra0fk3`, source `mlrcog0-src-...`) that nothing
+ * can predict when the mirror is built. Before GeoLibre#2257 no native layer
+ * matched, so `inspectScreenshotLayers` reported the layer pending forever and
+ * every share.geolibre.app thumbnail of such a project fell back to a
+ * placeholder after the 120s deadline.
+ */
+const timeSliderLayer: GeoLibreLayer = {
+  id: "acdom",
+  name: "aCDOM440",
+  type: "raster",
+  source: {},
+  visible: true,
+  opacity: 1,
+  style: DEFAULT_LAYER_STYLE,
+  metadata: { sourceKind: "time-slider", nativeLayerIds: ["acdom"], clientRenderedRaster: true },
+};
+
+function mosaicMap(sourceLoaded: boolean, layerIds = ["acdom-mosaic-xra0fk3"]): MapLibreMap {
+  return {
+    getZoom: () => 8,
+    getLayersOrder: () => layerIds,
+    getLayer: (id: string) => ({ id, type: "raster", source: `mlrcog0-src-${id}` }),
+    getSource: () => ({}),
+    isSourceLoaded: () => sourceLoaded,
+  } as unknown as MapLibreMap;
+}
+
+test("a time-slider mosaic drawn under a generated id is found, not pending forever", () => {
+  assert.deepEqual(inspectScreenshotLayers(mosaicMap(true), [timeSliderLayer], [], probe), {
+    pending: [],
+    errors: [],
+  });
+});
+
+test("a found mosaic still waits for its own source to finish loading", () => {
+  assert.deepEqual(inspectScreenshotLayers(mosaicMap(false), [timeSliderLayer], [], probe), {
+    pending: ["aCDOM440"],
+    errors: [],
+  });
+});
+
+test("a layer with no native layer at all is still pending", () => {
+  assert.deepEqual(inspectScreenshotLayers(mosaicMap(true, []), [timeSliderLayer], [], probe), {
+    pending: ["aCDOM440"],
+    errors: [],
+  });
+});
+
+test("a derived native layer belongs to the longest matching layer id", () => {
+  // `acdom` must not claim `acdom-2`'s mosaic: `acdom-2` is the real owner, so
+  // `acdom` has nothing rendered and stays pending.
+  const sibling: GeoLibreLayer = { ...timeSliderLayer, id: "acdom-2", name: "aCDOM440 v2" };
+  const map2 = mosaicMap(true, ["acdom-2-mosaic-xra0fk3"]);
+  assert.deepEqual(inspectScreenshotLayers(map2, [timeSliderLayer, sibling], [], probe), {
+    pending: ["aCDOM440"],
+    errors: [],
+  });
+});


### PR DESCRIPTION
## Problem

[share.geolibre.app/giswqs/barataria-bay-s2-acdom](https://share.geolibre.app/giswqs/barataria-bay-s2-acdom) gets a placeholder thumbnail instead of a screenshot. Reproduced against the deployed viewer with `?maponly=true&loading=true`:

```
[2.1s]   loading | pending=["World Imagery","aCDOM440"]
[4.1s]   loading | pending=["aCDOM440"]
[122.7s] error   | ["Timed out waiting for the visible map to finish loading"]
```

The map is **fully drawn** the whole time — raster, legend, basemap — with no failed requests and no console errors. `aCDOM440` simply never stops being pending, so `useScreenshotReadiness` publishes `error` and the thumbnail worker correctly falls back.

## Cause

`inspectScreenshotLayers` matches a store layer to its MapLibre layers three ways: `metadata.nativeLayerIds`, exact id, or a `layer-<id>-` prefix.

A Time Slider layer mirrors into the store with `nativeLayerIds: [sourceId]` (`maplibre-time-slider.ts`), but a `clientRenderedRaster` mosaic is drawn by maplibre-gl-raster under a **generated** id. Instrumenting the running viewer:

```
[DBG] probe aCDOM440 acdom isRaster=false sourceKind=time-slider deck={"found":false} requiresDeck=false
[DBG] no native layer aCDOM440 acdom ids=["acdom"] totalLayers=116
      matches=[{"id":"acdom-mosaic-xra0fk3","type":"raster",
                "source":"mlrcog0-src-acdom-mosaic-xra0fk3","srcExists":true,"srcLoaded":false}]
```

That id cannot be predicted when the mirror is built (the suffix is generated per render), so all three checks miss, `rendered.length === 0`, and the layer is pending forever. Confirmed the deck path is not involved: the shared overlay is never mounted here (`overlayMounted=false, ids=[]`).

## Fix

Also match native layers derived from the store layer id. Once found, the existing `map.isSourceLoaded(...)` check on that layer is the real readiness signal — which is why the fix reports `ready` rather than merely reporting it sooner.

A bare prefix test would let `acdom` claim `acdom-2`'s layers, so a candidate is rejected when another store layer's id is a longer prefix of it.

## Verification

Same URL, same browser, production vs. this branch:

| Build | Result |
| --- | --- |
| production today | `error` at **122.8s**, pending `["aCDOM440"]` |
| this branch | `ready` at **6.4s**, pending `[]` |

The capture shows the full aCDOM raster over the basemap.

Four tests added to `tests/screenshot-readiness.test.ts` covering the generated-id match, still waiting on the mosaic's own source, no native layer at all, and the `acdom` / `acdom-2` ownership case.

`npm run typecheck`, `npm run lint` (0 errors), `npm run test` (7635 passing), and `pre-commit` on the changed files all pass.

## Related

Independent of #2256, which fixes a different wrong thumbnail (terrain not applied under `?maponly`). Both are needed to fix the two reported projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot readiness checks for raster mosaics used with the Time Slider, including layers with unpredictable generated identifiers.
  * Correctly detects when required map layers are loaded and reports missing layers more reliably.
  * Prevented similarly named layers from being attributed to the wrong source when layer identifiers overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->