### PR TITLE
Add local 3D model import and georeferenced Shanghai sample

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -22,7 +22,7 @@ import {
   detectAndParseDeckVizInput,
 } from "../../../../lib/deck-viz-input";
 import { SHANGHAI_MODEL_SAMPLE, modelSampleBounds } from "../../../../lib/model-samples";
-import { embedLocalGltf } from "../../../../lib/local-gltf";
+import { MAX_LOCAL_GLTF_BYTES, embedLocalGltf } from "../../../../lib/local-gltf";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
 import { DECK_VIZ_SIZE_WARN_BYTES } from "../constants";
 import { errorMessage, geoJsonToPointRows } from "../helpers";
@@ -172,12 +172,17 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       setDeckVizModelUrl(url);
       setModelFileName(selected.path.split(/[/\\]/).pop() || selected.path);
     } catch (error) {
+      const reason = error instanceof Error ? error.message : "";
       source.setError(
-        t(
-          error instanceof Error && error.message === "externalResources"
-            ? "addData.deckViz.modelExternalResources"
-            : "addData.deckViz.modelFileError",
-        ),
+        reason === "modelTooLarge"
+          ? t("addData.deckViz.modelTooLarge", {
+              limit: Math.round(MAX_LOCAL_GLTF_BYTES / (1024 * 1024)),
+            })
+          : t(
+              reason === "externalResources"
+                ? "addData.deckViz.modelExternalResources"
+                : "addData.deckViz.modelFileError",
+            ),
       );
     } finally {
       setIsLoadingModel(false);
@@ -197,6 +202,10 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     return {
       modelUrl: deckVizModelUrl.trim(),
       sizeScale: numOr(deckVizModelScale, DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale),
+      // Persisted explicitly so a meter-scale model keeps its geographic size
+      // at every zoom, without changing how projects saved before this field
+      // existed (they keep the 1 px default floor) render.
+      sizeMinPixels: 0,
       bearing: numOr(deckVizModelBearing, 0),
       altitude: numOr(deckVizModelAltitude, 0),
     };
@@ -542,7 +551,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
                 disabled={isLoadingModel || source.isSubmitting}
                 onClick={() => void handleLocalModel()}
               >
-                <FileUp className="mr-2 size-4" />
+                <FileUp className="me-2 size-4" />
                 {t("addData.deckViz.chooseModelFile")}
               </Button>
               {modelFileName ? (

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -47,6 +47,7 @@ interface DeckVizSourceProps {
   initialDeckVizKind?: string;
 }
 
+/** Add a deck.gl layer from tabular data, a model sample, or an embedded local model. */
 export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const { t } = useTranslation();
   const startKind = initialDeckVizKind || "scatterplot";
@@ -160,12 +161,13 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       if (!selected?.data) return;
       const url = await embedLocalGltf(selected.data);
       const example = deckVizDef?.example.scenegraph;
-      if (
-        example &&
-        deckVizModelUrl === example.modelUrl &&
-        Number(deckVizModelScale) === example.sizeScale
-      ) {
-        setDeckVizModelScale(String(DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale));
+      if (example && deckVizModelUrl === example.modelUrl) {
+        // Loading is asynchronous; keep scale edits made while reading the file.
+        setDeckVizModelScale((current) =>
+          Number(current) === example.sizeScale
+            ? String(DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale)
+            : current,
+        );
       }
       setDeckVizModelUrl(url);
       setModelFileName(selected.path.split(/[/\\]/).pop() || selected.path);

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -21,10 +21,23 @@ import {
   type DeckVizParsedInput,
   detectAndParseDeckVizInput,
 } from "../../../../lib/deck-viz-input";
+import { SHANGHAI_MODEL_SAMPLE, modelSampleBounds } from "../../../../lib/model-samples";
+import { embedLocalGltf } from "../../../../lib/local-gltf";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
 import { DECK_VIZ_SIZE_WARN_BYTES } from "../constants";
 import { errorMessage, geoJsonToPointRows } from "../helpers";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
+
+const airplaneSample = getDeckVizLayerDef("scenegraph")!.example;
+const MODEL_SAMPLES = [
+  {
+    id: "airplane",
+    labelKey: "addData.deckViz.sampleAirplane" as const,
+    location: airplaneSample.scenegraphLocation!,
+    scenegraph: airplaneSample.scenegraph!,
+  },
+  SHANGHAI_MODEL_SAMPLE,
+];
 
 interface DeckVizSourceProps {
   /**
@@ -59,6 +72,8 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const [closeAfterDeckVizAdd, setCloseAfterDeckVizAdd] = useState(true);
   // Scenegraph (glTF 3D model) layer-specific inputs.
   const [deckVizModelUrl, setDeckVizModelUrl] = useState(startSg?.modelUrl ?? "");
+  const [modelFileName, setModelFileName] = useState("");
+  const [isLoadingModel, setIsLoadingModel] = useState(false);
   const [deckVizModelMode, setDeckVizModelMode] = useState<"single" | "data">("single");
   const [deckVizModelScale, setDeckVizModelScale] = useState(
     String(startSg?.sizeScale ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale),
@@ -85,6 +100,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
 
   const handleDeckVizKindChange = (nextKind: string) => {
     setDeckVizKind(nextKind);
+    setModelFileName("");
     setDeckVizParsed(null);
     setDeckVizMapping({});
     setDeckVizStatus(null);
@@ -107,6 +123,55 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       const [lng, lat] = nextDef?.example.scenegraphLocation ?? ["", ""];
       setDeckVizModelLng(String(lng));
       setDeckVizModelLat(String(lat));
+    }
+  };
+
+  const handleModelSample = (id: string) => {
+    const sample = MODEL_SAMPLES.find((item) => item.id === id);
+    if (!sample) {
+      setDeckVizModelUrl("");
+      setModelFileName("");
+      return;
+    }
+    setDeckVizModelUrl(sample.scenegraph.modelUrl);
+    setModelFileName("");
+    setDeckVizModelLng(String(sample.location[0]));
+    setDeckVizModelLat(String(sample.location[1]));
+    setDeckVizModelScale(String(sample.scenegraph.sizeScale));
+    setDeckVizModelBearing(String(sample.scenegraph.bearing));
+    setDeckVizModelAltitude(String(sample.scenegraph.altitude));
+    setDeckVizModelMode("single");
+    setDeckVizParsed(null);
+    setDeckVizMapping({});
+    setDeckVizStatus(null);
+    source.setError(null);
+    source.setLayerName(t(sample.labelKey));
+  };
+
+  const handleLocalModel = async () => {
+    setIsLoadingModel(true);
+    source.setError(null);
+    try {
+      const selected = await openLocalDataFileWithFallback({
+        filters: [{ name: "glTF / GLB", extensions: ["glb", "gltf"] }],
+        accept: ".glb,.gltf",
+        readBinary: true,
+      });
+      if (!selected?.data) return;
+      const url = await embedLocalGltf(selected.data);
+      const example = deckVizDef?.example.scenegraph;
+      if (example && deckVizModelUrl === example.modelUrl &&
+          Number(deckVizModelScale) === example.sizeScale) {
+        setDeckVizModelScale(String(DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale));
+      }
+      setDeckVizModelUrl(url);
+      setModelFileName(selected.path.split(/[/\\]/).pop() || selected.path);
+    } catch (error) {
+      source.setError(t(error instanceof Error && error.message === "externalResources"
+        ? "addData.deckViz.modelExternalResources"
+        : "addData.deckViz.modelFileError"));
+    } finally {
+      setIsLoadingModel(false);
     }
   };
 
@@ -175,6 +240,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     style: DeckVizStyle;
     sourcePath: string;
     scenegraph?: DeckVizScenegraphConfig;
+    bounds?: [number, number, number, number];
   }) => {
     const def = getDeckVizLayerDef(deckVizKind);
     if (!def) throw new Error(t("addData.deckViz.errorUnknownType"));
@@ -220,10 +286,10 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       );
     }
 
-    const bounds =
+    const bounds = params.bounds ?? (
       parsed.format === "geojson"
         ? undefined
-        : (computeDeckVizBounds(parsed.rows ?? [], mapping) ?? undefined);
+        : (computeDeckVizBounds(parsed.rows ?? [], mapping) ?? undefined));
     const layer = createDeckVizStoreLayer({
       name: source.layerName.trim() || def.label,
       config: {
@@ -353,7 +419,8 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
         },
         mapping: { lng: "lng", lat: "lat" },
         style: deckVizStyle,
-        sourcePath: scenegraph?.modelUrl ?? "",
+        bounds: scenegraph ? modelSampleBounds(scenegraph, lng, lat) : undefined,
+        sourcePath: modelFileName || scenegraph?.modelUrl || "",
         scenegraph,
       });
       return;
@@ -373,6 +440,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const submitDisabled =
     source.isSubmitting ||
     isLoadingDeckViz ||
+    isLoadingModel ||
     (isScenegraphKind && !deckVizModelUrl.trim()) ||
     (!deckVizParsed && !(isScenegraphKind && deckVizModelMode === "single"));
 
@@ -415,13 +483,49 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
         {isScenegraphKind ? (
           <div className="space-y-3 rounded-md border border-border p-3">
             <div className="space-y-1.5">
+              <Label htmlFor="deckviz-model-sample">{t("addData.deckViz.sampleDataset")}</Label>
+              <Select id="deckviz-model-sample"
+                value={MODEL_SAMPLES.find((sample) => sample.scenegraph.modelUrl === deckVizModelUrl)?.id ?? ""}
+                disabled={isLoadingModel || source.isSubmitting}
+                onChange={(event) => handleModelSample(event.target.value)}>
+                <option value="">{t("addData.deckViz.sampleCustom")}</option>
+                {MODEL_SAMPLES.map((sample) => (
+                  <option key={sample.id} value={sample.id}>{t(sample.labelKey)}</option>
+                ))}
+              </Select>
+            </div>
+            <div className="space-y-1.5">
               <Label htmlFor="deckviz-model-url">{t("toolbar.scenegraph.modelUrl")}</Label>
               <Input
                 id="deckviz-model-url"
                 placeholder={t("addData.deckViz.modelUrlPlaceholder")}
-                value={deckVizModelUrl}
-                onChange={(event) => setDeckVizModelUrl(event.target.value)}
+                value={modelFileName ? "" : deckVizModelUrl}
+                disabled={isLoadingModel}
+                onChange={(event) => {
+                  const nextUrl = event.target.value;
+                  const example = deckVizDef?.example.scenegraph;
+                  // The airplane demo needs magnification. Do not carry its
+                  // 3000x scale into a user-supplied meter-scale GLB. Preserve
+                  // a scale the user has already edited deliberately.
+                  if (
+                    example &&
+                    deckVizModelUrl.trim() === example.modelUrl &&
+                    nextUrl.trim() !== example.modelUrl &&
+                    Number(deckVizModelScale) === example.sizeScale
+                  ) {
+                    setDeckVizModelScale(String(DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale));
+                  }
+                  setDeckVizModelUrl(nextUrl);
+                  setModelFileName("");
+                }}
               />
+              <Button type="button" variant="outline" disabled={isLoadingModel || source.isSubmitting}
+                onClick={() => void handleLocalModel()}>
+                <FileUp className="mr-2 size-4" />
+                {t("addData.deckViz.chooseModelFile")}
+              </Button>
+              {modelFileName ? <p className="break-all text-xs" role="status">{modelFileName}</p> : null}
+              <p className="text-xs text-muted-foreground">{t("addData.deckViz.modelFileHint")}</p>
             </div>
 
             <div className="space-y-1.5">

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -13,7 +13,7 @@ import {
 } from "@geolibre/plugins";
 import { Button, ColorField, Input, Label, Select } from "@geolibre/ui";
 import { Columns3, FileUp, Globe2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   autoDetectFieldMapping,
@@ -75,6 +75,9 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const [deckVizModelUrl, setDeckVizModelUrl] = useState(startSg?.modelUrl ?? "");
   const [modelFileName, setModelFileName] = useState("");
   const [isLoadingModel, setIsLoadingModel] = useState(false);
+  // Identifies the current local-model read so a slow one cannot apply its
+  // model (or its error) to a form the user has since changed.
+  const modelLoadToken = useRef(0);
   const [deckVizModelMode, setDeckVizModelMode] = useState<"single" | "data">("single");
   const [deckVizModelScale, setDeckVizModelScale] = useState(
     String(startSg?.sizeScale ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale),
@@ -100,6 +103,10 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const showDeckVizDataLoader = !(isScenegraphKind && deckVizModelMode === "single");
 
   const handleDeckVizKindChange = (nextKind: string) => {
+    // Reading a model file is asynchronous and the layer-type select stays
+    // enabled meanwhile, so retire any pending read: its result belongs to the
+    // form the user just left.
+    modelLoadToken.current += 1;
     setDeckVizKind(nextKind);
     setModelFileName("");
     setDeckVizParsed(null);
@@ -150,6 +157,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   };
 
   const handleLocalModel = async () => {
+    const token = (modelLoadToken.current += 1);
     setIsLoadingModel(true);
     source.setError(null);
     try {
@@ -160,6 +168,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       });
       if (!selected?.data) return;
       const url = await embedLocalGltf(selected.data);
+      if (modelLoadToken.current !== token) return;
       const example = deckVizDef?.example.scenegraph;
       if (example && deckVizModelUrl === example.modelUrl) {
         // Loading is asynchronous; keep scale edits made while reading the file.
@@ -172,6 +181,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       setDeckVizModelUrl(url);
       setModelFileName(selected.path.split(/[/\\]/).pop() || selected.path);
     } catch (error) {
+      if (modelLoadToken.current !== token) return;
       const reason = error instanceof Error ? error.message : "";
       source.setError(
         reason === "modelTooLarge"

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -160,16 +160,23 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       if (!selected?.data) return;
       const url = await embedLocalGltf(selected.data);
       const example = deckVizDef?.example.scenegraph;
-      if (example && deckVizModelUrl === example.modelUrl &&
-          Number(deckVizModelScale) === example.sizeScale) {
+      if (
+        example &&
+        deckVizModelUrl === example.modelUrl &&
+        Number(deckVizModelScale) === example.sizeScale
+      ) {
         setDeckVizModelScale(String(DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale));
       }
       setDeckVizModelUrl(url);
       setModelFileName(selected.path.split(/[/\\]/).pop() || selected.path);
     } catch (error) {
-      source.setError(t(error instanceof Error && error.message === "externalResources"
-        ? "addData.deckViz.modelExternalResources"
-        : "addData.deckViz.modelFileError"));
+      source.setError(
+        t(
+          error instanceof Error && error.message === "externalResources"
+            ? "addData.deckViz.modelExternalResources"
+            : "addData.deckViz.modelFileError",
+        ),
+      );
     } finally {
       setIsLoadingModel(false);
     }
@@ -286,8 +293,9 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       );
     }
 
-    const bounds = params.bounds ?? (
-      parsed.format === "geojson"
+    const bounds =
+      params.bounds ??
+      (parsed.format === "geojson"
         ? undefined
         : (computeDeckVizBounds(parsed.rows ?? [], mapping) ?? undefined));
     const layer = createDeckVizStoreLayer({
@@ -484,13 +492,20 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
           <div className="space-y-3 rounded-md border border-border p-3">
             <div className="space-y-1.5">
               <Label htmlFor="deckviz-model-sample">{t("addData.deckViz.sampleDataset")}</Label>
-              <Select id="deckviz-model-sample"
-                value={MODEL_SAMPLES.find((sample) => sample.scenegraph.modelUrl === deckVizModelUrl)?.id ?? ""}
+              <Select
+                id="deckviz-model-sample"
+                value={
+                  MODEL_SAMPLES.find((sample) => sample.scenegraph.modelUrl === deckVizModelUrl)
+                    ?.id ?? ""
+                }
                 disabled={isLoadingModel || source.isSubmitting}
-                onChange={(event) => handleModelSample(event.target.value)}>
+                onChange={(event) => handleModelSample(event.target.value)}
+              >
                 <option value="">{t("addData.deckViz.sampleCustom")}</option>
                 {MODEL_SAMPLES.map((sample) => (
-                  <option key={sample.id} value={sample.id}>{t(sample.labelKey)}</option>
+                  <option key={sample.id} value={sample.id}>
+                    {t(sample.labelKey)}
+                  </option>
                 ))}
               </Select>
             </div>
@@ -519,12 +534,20 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
                   setModelFileName("");
                 }}
               />
-              <Button type="button" variant="outline" disabled={isLoadingModel || source.isSubmitting}
-                onClick={() => void handleLocalModel()}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isLoadingModel || source.isSubmitting}
+                onClick={() => void handleLocalModel()}
+              >
                 <FileUp className="mr-2 size-4" />
                 {t("addData.deckViz.chooseModelFile")}
               </Button>
-              {modelFileName ? <p className="break-all text-xs" role="status">{modelFileName}</p> : null}
+              {modelFileName ? (
+                <p className="break-all text-xs" role="status">
+                  {modelFileName}
+                </p>
+              ) : null}
               <p className="text-xs text-muted-foreground">{t("addData.deckViz.modelFileHint")}</p>
             </div>
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -139,8 +139,18 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const handleModelSample = (id: string) => {
     const sample = MODEL_SAMPLES.find((item) => item.id === id);
     if (!sample) {
+      // "Custom model" drops the whole placement the previous sample filled
+      // in, not just its URL: its coordinates and transform describe that
+      // model, not whatever the user is about to supply. Scale goes back to
+      // the neutral default rather than the example's magnification.
+      const [lng, lat] = deckVizDef?.example.scenegraphLocation ?? ["", ""];
       setDeckVizModelUrl("");
       setModelFileName("");
+      setDeckVizModelLng(String(lng));
+      setDeckVizModelLat(String(lat));
+      setDeckVizModelScale(String(DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale));
+      setDeckVizModelBearing("0");
+      setDeckVizModelAltitude("0");
       return;
     }
     setDeckVizModelUrl(sample.scenegraph.modelUrl);

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -105,8 +105,10 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const handleDeckVizKindChange = (nextKind: string) => {
     // Reading a model file is asynchronous and the layer-type select stays
     // enabled meanwhile, so retire any pending read: its result belongs to the
-    // form the user just left.
+    // form the user just left. Drop the loading flag with it, or the new form
+    // stays unsubmittable until a read the user abandoned settles.
     modelLoadToken.current += 1;
+    setIsLoadingModel(false);
     setDeckVizKind(nextKind);
     setModelFileName("");
     setDeckVizParsed(null);
@@ -195,7 +197,8 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
             ),
       );
     } finally {
-      setIsLoadingModel(false);
+      // A retired read must not clear the flag for the one that replaced it.
+      if (modelLoadToken.current === token) setIsLoadingModel(false);
     }
   };
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -911,7 +911,15 @@
       "cellSize": "Cell size",
       "lineWidth": "Line width",
       "extrusion": "3D extrusion",
-      "modelUrlPlaceholder": "https://example.com/model.glb"
+      "modelUrlPlaceholder": "https://example.com/model.glb",
+      "chooseModelFile": "Choose local model",
+      "sampleDataset": "Sample dataset",
+      "sampleCustom": "Custom model",
+      "sampleAirplane": "Airplane — San Francisco",
+      "sampleShanghai": "Shanghai — central city",
+      "modelFileHint": "Choose a GLB or self-contained glTF file. Local models are embedded in saved projects, increasing the project size.",
+      "modelExternalResources": "This model references separate files. Export it as a GLB with embedded textures and buffers, then try again.",
+      "modelFileError": "Could not read this model. Choose a valid glTF 2.0 or GLB file."
     },
     "nonGeographicCoordinates": "Coordinates in {{names}} are not longitude/latitude, so nothing will be drawn on the map. The CRS is mislabelled — reproject the data (or fix its .prj) and load it again."
   },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -919,6 +919,7 @@
       "sampleShanghai": "Shanghai — central city",
       "modelFileHint": "Choose a GLB or self-contained glTF file. Local models are embedded in saved projects, increasing the project size.",
       "modelExternalResources": "This model references separate files. Export it as a GLB with embedded textures and buffers, then try again.",
+      "modelTooLarge": "This model is larger than the {{limit}} MB limit for embedding in a project. Host it and add it by URL instead.",
       "modelFileError": "Could not read this model. Choose a valid glTF 2.0 or GLB file."
     },
     "nonGeographicCoordinates": "Coordinates in {{names}} are not longitude/latitude, so nothing will be drawn on the map. The CRS is mislabelled — reproject the data (or fix its .prj) and load it again."

--- a/apps/geolibre-desktop/src/lib/local-gltf.ts
+++ b/apps/geolibre-desktop/src/lib/local-gltf.ts
@@ -1,0 +1,50 @@
+/** Validate a self-contained glTF 2 asset before embedding it in a project. */
+export function localGltfMime(data: ArrayBuffer): string {
+  const bytes = new Uint8Array(data);
+  const view = new DataView(data);
+  let json: unknown;
+  let mime: string;
+  if (bytes.length >= 4 && view.getUint32(0, true) === 0x46546c67) {
+    if (bytes.length < 20 || view.getUint32(4, true) !== 2 ||
+        view.getUint32(8, true) !== bytes.length || view.getUint32(16, true) !== 0x4e4f534a) {
+      throw new Error("invalid");
+    }
+    const jsonLength = view.getUint32(12, true);
+    if (jsonLength % 4 || jsonLength > bytes.length - 20) throw new Error("invalid");
+    let offset = 12;
+    while (offset < bytes.length) {
+      if (offset + 8 > bytes.length) throw new Error("invalid");
+      const length = view.getUint32(offset, true);
+      if (length % 4 || length > bytes.length - offset - 8) throw new Error("invalid");
+      offset += 8 + length;
+    }
+    json = JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + jsonLength)));
+    mime = "model/gltf-binary";
+  } else {
+    json = JSON.parse(new TextDecoder().decode(bytes));
+    mime = "model/gltf+json";
+  }
+  const asset = json as {
+    asset?: { version?: string };
+    buffers?: Array<{ uri?: string }>;
+    images?: Array<{ uri?: string }>;
+  } | null;
+  if (asset?.asset?.version !== "2.0") throw new Error("invalid");
+  for (const resource of [...(asset.buffers ?? []), ...(asset.images ?? [])]) {
+    if (resource.uri !== undefined && !/^data:/i.test(resource.uri)) {
+      throw new Error("externalResources");
+    }
+  }
+  return mime;
+}
+
+/** Data URLs are portable across project saves, unlike session-only blob URLs. */
+export async function embedLocalGltf(data: ArrayBuffer): Promise<string> {
+  const mime = localGltfMime(data);
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(new Blob([data], { type: mime }));
+  });
+}

--- a/apps/geolibre-desktop/src/lib/local-gltf.ts
+++ b/apps/geolibre-desktop/src/lib/local-gltf.ts
@@ -28,22 +28,39 @@ export function localGltfMime(data: ArrayBuffer): string {
     json = JSON.parse(new TextDecoder().decode(bytes));
     mime = "model/gltf+json";
   }
-  const asset = json as {
-    asset?: { version?: string };
-    buffers?: Array<{ uri?: string }>;
-    images?: Array<{ uri?: string }>;
-  } | null;
+  const asset = json as { asset?: { version?: string } } | null;
   if (asset?.asset?.version !== "2.0") throw new Error("invalid");
-  for (const resource of [...(asset.buffers ?? []), ...(asset.images ?? [])]) {
-    if (resource.uri !== undefined && !/^data:/i.test(resource.uri)) {
-      throw new Error("externalResources");
-    }
-  }
+  if (hasExternalUri(json)) throw new Error("externalResources");
   return mime;
 }
 
+/**
+ * Any `uri` anywhere in the asset can pull in a sidecar file, not just the
+ * top-level `buffers`/`images` entries: texture extensions (KHR_texture_basisu,
+ * MSFT_texture_dds) and vendor extensions carry their own. `extras` is
+ * free-form application data, so it is skipped rather than validated.
+ */
+function hasExternalUri(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasExternalUri);
+  if (!value || typeof value !== "object") return false;
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "extras") continue;
+    if (key === "uri" && typeof entry === "string" && !/^data:/i.test(entry)) return true;
+    if (hasExternalUri(entry)) return true;
+  }
+  return false;
+}
+
+/**
+ * Matches the inline GLB cap used for KML `<Model>` imports: base64 inflates
+ * the bytes by ~4/3 in the saved project, so an uncapped pick can hang the tab
+ * and produce an unusable `.geolibre.json`.
+ */
+export const MAX_LOCAL_GLTF_BYTES = 24 * 1024 * 1024;
+
 /** Data URLs are portable across project saves, unlike session-only blob URLs. */
 export async function embedLocalGltf(data: ArrayBuffer): Promise<string> {
+  if (data.byteLength > MAX_LOCAL_GLTF_BYTES) throw new Error("modelTooLarge");
   const mime = localGltfMime(data);
   return new Promise((resolve, reject) => {
     const reader = new FileReader();

--- a/apps/geolibre-desktop/src/lib/local-gltf.ts
+++ b/apps/geolibre-desktop/src/lib/local-gltf.ts
@@ -5,8 +5,12 @@ export function localGltfMime(data: ArrayBuffer): string {
   let json: unknown;
   let mime: string;
   if (bytes.length >= 4 && view.getUint32(0, true) === 0x46546c67) {
-    if (bytes.length < 20 || view.getUint32(4, true) !== 2 ||
-        view.getUint32(8, true) !== bytes.length || view.getUint32(16, true) !== 0x4e4f534a) {
+    if (
+      bytes.length < 20 ||
+      view.getUint32(4, true) !== 2 ||
+      view.getUint32(8, true) !== bytes.length ||
+      view.getUint32(16, true) !== 0x4e4f534a
+    ) {
       throw new Error("invalid");
     }
     const jsonLength = view.getUint32(12, true);

--- a/apps/geolibre-desktop/src/lib/local-gltf.ts
+++ b/apps/geolibre-desktop/src/lib/local-gltf.ts
@@ -39,14 +39,25 @@ export function localGltfMime(data: ArrayBuffer): string {
  * top-level `buffers`/`images` entries: texture extensions (KHR_texture_basisu,
  * MSFT_texture_dds) and vendor extensions carry their own. `extras` is
  * free-form application data, so it is skipped rather than validated.
+ *
+ * The walk keeps its own stack: a recursive one overflows on nesting that
+ * `JSON.parse` itself accepts, turning a readable file into a generic "invalid
+ * model" error.
  */
-function hasExternalUri(value: unknown): boolean {
-  if (Array.isArray(value)) return value.some(hasExternalUri);
-  if (!value || typeof value !== "object") return false;
-  for (const [key, entry] of Object.entries(value)) {
-    if (key === "extras") continue;
-    if (key === "uri" && typeof entry === "string" && !/^data:/i.test(entry)) return true;
-    if (hasExternalUri(entry)) return true;
+function hasExternalUri(root: unknown): boolean {
+  const pending: unknown[] = [root];
+  while (pending.length) {
+    const value = pending.pop();
+    if (Array.isArray(value)) {
+      for (const entry of value) pending.push(entry);
+      continue;
+    }
+    if (!value || typeof value !== "object") continue;
+    for (const [key, entry] of Object.entries(value)) {
+      if (key === "extras") continue;
+      if (key === "uri" && typeof entry === "string" && !/^data:/i.test(entry)) return true;
+      pending.push(entry);
+    }
   }
   return false;
 }

--- a/apps/geolibre-desktop/src/lib/model-samples.ts
+++ b/apps/geolibre-desktop/src/lib/model-samples.ts
@@ -13,14 +13,15 @@ export const SHANGHAI_MODEL_SAMPLE: ModelSample = {
   labelKey: "addData.deckViz.sampleShanghai",
   // WGS84 ground-level origin of the meter-scale, Y-up exported model.
   location: [121.495, 31.235],
+  // Only the fields the dialog prefills belong here: picking a sample copies
+  // the model URL, scale, bearing and altitude into the form, and the config
+  // that is actually submitted is rebuilt from those inputs. Anything else set
+  // here would look configurable without taking effect.
   scenegraph: {
     modelUrl: "https://data.source.coop/giswqs/opengeos/shanghai-3d-model.glb",
     sizeScale: 1,
-    sizeMinPixels: 0,
     bearing: 0,
     altitude: 0,
-    orientationRoll: 90,
-    translation: [0, 0, 0],
   },
   bounds: [121.47, 31.22, 121.52, 31.25],
 };

--- a/apps/geolibre-desktop/src/lib/model-samples.ts
+++ b/apps/geolibre-desktop/src/lib/model-samples.ts
@@ -1,0 +1,36 @@
+import type { DeckVizScenegraphConfig } from "@geolibre/plugins";
+
+interface ModelSample {
+  id: string;
+  labelKey: "addData.deckViz.sampleAirplane" | "addData.deckViz.sampleShanghai";
+  location: [number, number];
+  scenegraph: DeckVizScenegraphConfig;
+  bounds?: [number, number, number, number];
+}
+
+export const SHANGHAI_MODEL_SAMPLE: ModelSample = {
+  id: "shanghai",
+  labelKey: "addData.deckViz.sampleShanghai",
+  // WGS84 ground-level origin of the meter-scale, Y-up exported model.
+  location: [121.495, 31.235],
+  scenegraph: {
+    modelUrl: "https://data.source.coop/giswqs/opengeos/shanghai-3d-model.glb",
+    sizeScale: 1,
+    sizeMinPixels: 0,
+    bearing: 0,
+    altitude: 0,
+    orientationRoll: 90,
+    translation: [0, 0, 0],
+  },
+  bounds: [121.470, 31.220, 121.520, 31.250],
+};
+
+/** Use geographic sample bounds only while its original placement is intact. */
+export function modelSampleBounds(config: DeckVizScenegraphConfig, lng: number, lat: number) {
+  return [SHANGHAI_MODEL_SAMPLE].find((sample) =>
+    sample.scenegraph.modelUrl === config.modelUrl &&
+    sample.location[0] === lng && sample.location[1] === lat &&
+    sample.scenegraph.sizeScale === config.sizeScale &&
+    sample.scenegraph.bearing === config.bearing,
+  )?.bounds;
+}

--- a/apps/geolibre-desktop/src/lib/model-samples.ts
+++ b/apps/geolibre-desktop/src/lib/model-samples.ts
@@ -22,15 +22,17 @@ export const SHANGHAI_MODEL_SAMPLE: ModelSample = {
     orientationRoll: 90,
     translation: [0, 0, 0],
   },
-  bounds: [121.470, 31.220, 121.520, 31.250],
+  bounds: [121.47, 31.22, 121.52, 31.25],
 };
 
 /** Use geographic sample bounds only while its original placement is intact. */
 export function modelSampleBounds(config: DeckVizScenegraphConfig, lng: number, lat: number) {
-  return [SHANGHAI_MODEL_SAMPLE].find((sample) =>
-    sample.scenegraph.modelUrl === config.modelUrl &&
-    sample.location[0] === lng && sample.location[1] === lat &&
-    sample.scenegraph.sizeScale === config.sizeScale &&
-    sample.scenegraph.bearing === config.bearing,
+  return [SHANGHAI_MODEL_SAMPLE].find(
+    (sample) =>
+      sample.scenegraph.modelUrl === config.modelUrl &&
+      sample.location[0] === lng &&
+      sample.location[1] === lat &&
+      sample.scenegraph.sizeScale === config.sizeScale &&
+      sample.scenegraph.bearing === config.bearing,
   )?.bounds;
 }

--- a/e2e/scenegraph.spec.ts
+++ b/e2e/scenegraph.spec.ts
@@ -100,3 +100,57 @@ test("Shanghai sample fills the geographic origin and meter-scale placement", as
     page.locator('[data-testid="layer-row"][data-layer-name="Shanghai — central city"]'),
   ).toBeVisible();
 });
+
+test("preserves scale edits made while a local model is being embedded", async ({ page }) => {
+  await page.addInitScript(() => {
+    delete (window as unknown as Record<string, unknown>).showSaveFilePicker;
+    const read = FileReader.prototype.readAsDataURL;
+    FileReader.prototype.readAsDataURL = function (blob) {
+      if (blob.type === "model/gltf+json") {
+        // Hold embedding until the test has edited the still-enabled scale input.
+        (window as unknown as { finishModelRead: () => void }).finishModelRead = () => {
+          read.call(this, blob);
+        };
+      } else {
+        read.call(this, blob);
+      }
+    };
+  });
+  await waitForMap(page);
+  await page.getByRole("button", { name: "Add Data" }).click();
+  await page.getByRole("menuitem", { name: "3D Model (glTF)" }).click();
+  const dialog = page.getByRole("dialog");
+  const picker = page.waitForEvent("filechooser");
+  await dialog.getByRole("button", { name: "Choose local model" }).click();
+  await (
+    await picker
+  ).setFiles({
+    name: "delayed.gltf",
+    mimeType: "model/gltf+json",
+    buffer: Buffer.from(
+      JSON.stringify({ asset: { version: "2.0" }, scene: 0, scenes: [{ nodes: [] }] }),
+    ),
+  });
+  await page.waitForFunction(
+    () =>
+      typeof (window as unknown as { finishModelRead?: unknown }).finishModelRead === "function",
+  );
+  await dialog.getByLabel("Scale", { exact: true }).fill("25");
+  await page.evaluate(() =>
+    (window as unknown as { finishModelRead: () => void }).finishModelRead(),
+  );
+  await expect(dialog.getByRole("status")).toHaveText("delayed.gltf");
+  await expect(dialog.getByLabel("Scale", { exact: true })).toHaveValue("25");
+  await dialog.getByRole("button", { name: "Add layer" }).click();
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Project", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Save", exact: true }).click();
+  await page.getByRole("dialog").getByRole("button", { name: "Save", exact: true }).click();
+  const stream = await (await downloadPromise).createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  const saved = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  const model = saved.layers.find((layer: { type: string }) => layer.type === "deckgl-viz");
+  expect(model.metadata.vizConfig.scenegraph.sizeScale).toBe(25);
+  expect(model.metadata.vizConfig.scenegraph.modelUrl).toMatch(/^data:model\/gltf\+json;base64,/);
+});

--- a/e2e/scenegraph.spec.ts
+++ b/e2e/scenegraph.spec.ts
@@ -59,3 +59,36 @@ test("blocks single-location placement without a valid coordinate", async ({ pag
   await expect(dialog.getByText("Enter a valid longitude and latitude.")).toBeVisible();
   await expect(dialog).toBeVisible();
 });
+
+test("imports an embedded local glTF and rejects missing companion files", async ({ page }) => {
+  await waitForMap(page);
+  await page.getByRole("button", { name: "Add Data" }).click();
+  await page.getByRole("menuitem", { name: "3D Model (glTF)" }).click();
+  const dialog = page.getByRole("dialog");
+  const choose = async (name: string, model: object) => {
+    const picker = page.waitForEvent("filechooser");
+    await dialog.getByRole("button", { name: "Choose local model" }).click();
+    await (await picker).setFiles({ name, mimeType: "model/gltf+json", buffer: Buffer.from(JSON.stringify(model)) });
+  };
+  await choose("missing.gltf", { asset: { version: "2.0" }, buffers: [{ uri: "mesh.bin" }] });
+  await expect(dialog.getByText(/This model references separate files/)).toBeVisible();
+  await choose("local.gltf", { asset: { version: "2.0" }, scene: 0, scenes: [{ nodes: [] }] });
+  await expect(dialog.getByRole("status")).toHaveText("local.gltf");
+  await expect(dialog.getByLabel("Scale", { exact: true })).toHaveValue("1");
+  await dialog.getByRole("button", { name: "Add layer" }).click();
+  await expect(page.locator('[data-testid="layer-row"][data-layer-name="3D model (glTF)"]')).toBeVisible();
+});
+
+test("Shanghai sample fills the geographic origin and meter-scale placement", async ({ page }) => {
+  await waitForMap(page);
+  await page.getByRole("button", { name: "Add Data" }).click();
+  await page.getByRole("menuitem", { name: "3D Model (glTF)" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Sample dataset").selectOption("shanghai");
+  await expect(dialog.getByLabel("glTF / GLB model URL")).toHaveValue("https://data.source.coop/giswqs/opengeos/shanghai-3d-model.glb");
+  await expect(dialog.getByLabel("Longitude", { exact: true })).toHaveValue("121.495");
+  await expect(dialog.getByLabel("Latitude", { exact: true })).toHaveValue("31.235");
+  await expect(dialog.getByLabel("Scale", { exact: true })).toHaveValue("1");
+  await dialog.getByRole("button", { name: "Add layer" }).click();
+  await expect(page.locator('[data-testid="layer-row"][data-layer-name="Shanghai — central city"]')).toBeVisible();
+});

--- a/e2e/scenegraph.spec.ts
+++ b/e2e/scenegraph.spec.ts
@@ -68,7 +68,9 @@ test("imports an embedded local glTF and rejects missing companion files", async
   const choose = async (name: string, model: object) => {
     const picker = page.waitForEvent("filechooser");
     await dialog.getByRole("button", { name: "Choose local model" }).click();
-    await (await picker).setFiles({ name, mimeType: "model/gltf+json", buffer: Buffer.from(JSON.stringify(model)) });
+    await (
+      await picker
+    ).setFiles({ name, mimeType: "model/gltf+json", buffer: Buffer.from(JSON.stringify(model)) });
   };
   await choose("missing.gltf", { asset: { version: "2.0" }, buffers: [{ uri: "mesh.bin" }] });
   await expect(dialog.getByText(/This model references separate files/)).toBeVisible();
@@ -76,7 +78,9 @@ test("imports an embedded local glTF and rejects missing companion files", async
   await expect(dialog.getByRole("status")).toHaveText("local.gltf");
   await expect(dialog.getByLabel("Scale", { exact: true })).toHaveValue("1");
   await dialog.getByRole("button", { name: "Add layer" }).click();
-  await expect(page.locator('[data-testid="layer-row"][data-layer-name="3D model (glTF)"]')).toBeVisible();
+  await expect(
+    page.locator('[data-testid="layer-row"][data-layer-name="3D model (glTF)"]'),
+  ).toBeVisible();
 });
 
 test("Shanghai sample fills the geographic origin and meter-scale placement", async ({ page }) => {
@@ -85,10 +89,14 @@ test("Shanghai sample fills the geographic origin and meter-scale placement", as
   await page.getByRole("menuitem", { name: "3D Model (glTF)" }).click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Sample dataset").selectOption("shanghai");
-  await expect(dialog.getByLabel("glTF / GLB model URL")).toHaveValue("https://data.source.coop/giswqs/opengeos/shanghai-3d-model.glb");
+  await expect(dialog.getByLabel("glTF / GLB model URL")).toHaveValue(
+    "https://data.source.coop/giswqs/opengeos/shanghai-3d-model.glb",
+  );
   await expect(dialog.getByLabel("Longitude", { exact: true })).toHaveValue("121.495");
   await expect(dialog.getByLabel("Latitude", { exact: true })).toHaveValue("31.235");
   await expect(dialog.getByLabel("Scale", { exact: true })).toHaveValue("1");
   await dialog.getByRole("button", { name: "Add layer" }).click();
-  await expect(page.locator('[data-testid="layer-row"][data-layer-name="Shanghai — central city"]')).toBeVisible();
+  await expect(
+    page.locator('[data-testid="layer-row"][data-layer-name="Shanghai — central city"]'),
+  ).toBeVisible();
 });

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -93,8 +93,8 @@ export interface DeckVizScenegraphConfig {
 
 export const DEFAULT_DECK_VIZ_SCENEGRAPH: DeckVizScenegraphConfig = {
   modelUrl: "",
-  sizeScale: 1000,
-  sizeMinPixels: 1,
+  sizeScale: 1,
+  sizeMinPixels: 0,
   bearing: 0,
   orientationRoll: 90,
   translation: [0, 0, 0],
@@ -820,10 +820,11 @@ const DEFINITIONS: DeckVizLayerDef[] = [
         scenegraph: sg.modelUrl,
         _lighting: "pbr",
         sizeScale: sg.sizeScale,
-        // Floor the on-screen size so distant models stay visible; leave the
-        // ceiling unset so zooming in scales the model up naturally instead of
-        // clamping a single large asset (building, turbine) to a small dot.
-        sizeMinPixels: sg.sizeMinPixels ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeMinPixels ?? 1,
+        // Preserve geographic size at every zoom. This floor applies to each
+        // model unit, not the whole asset: a 1 px floor makes a 4,763 m city
+        // at least 4,763 px wide, even after zooming out. Symbol-like models
+        // can still opt into a floor explicitly.
+        sizeMinPixels: sg.sizeMinPixels ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeMinPixels ?? 0,
         getPosition: (record: AnyRecord) => {
           const [lng, lat] = position(record);
           const altitude = (hasAlt ? readNumber(record, altKey) : 0) + sg.altitude;

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -94,7 +94,10 @@ export interface DeckVizScenegraphConfig {
 export const DEFAULT_DECK_VIZ_SCENEGRAPH: DeckVizScenegraphConfig = {
   modelUrl: "",
   sizeScale: 1,
-  sizeMinPixels: 0,
+  // Kept at 1 px per model unit for projects saved before the dialog wrote
+  // this field: dropping the floor for them would shrink small demo-scale
+  // models to nothing when zoomed out. New placements persist an explicit 0.
+  sizeMinPixels: 1,
   bearing: 0,
   orientationRoll: 90,
   translation: [0, 0, 0],
@@ -820,11 +823,11 @@ const DEFINITIONS: DeckVizLayerDef[] = [
         scenegraph: sg.modelUrl,
         _lighting: "pbr",
         sizeScale: sg.sizeScale,
-        // Preserve geographic size at every zoom. This floor applies to each
-        // model unit, not the whole asset: a 1 px floor makes a 4,763 m city
-        // at least 4,763 px wide, even after zooming out. Symbol-like models
-        // can still opt into a floor explicitly.
-        sizeMinPixels: sg.sizeMinPixels ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeMinPixels ?? 0,
+        // The floor applies to each model unit, not the whole asset: a 1 px
+        // floor makes a 4,763 m city at least 4,763 px wide even after zooming
+        // out, so meter-scale models place an explicit 0 to keep their
+        // geographic size. Symbol-like models can opt back into a floor.
+        sizeMinPixels: sg.sizeMinPixels ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeMinPixels ?? 1,
         getPosition: (record: AnyRecord) => {
           const [lng, lat] = position(record);
           const altitude = (hasAlt ? readNumber(record, altKey) : 0) + sg.altitude;

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -303,7 +303,7 @@ describe("scenegraph (glTF 3D model) layer", () => {
     assert.ok(config?.scenegraph);
     assert.equal(config.scenegraph.modelUrl, "https://example.com/model.glb");
     assert.equal(config.scenegraph.sizeScale, 250);
-    assert.equal(config.scenegraph.sizeMinPixels, 0);
+    assert.equal(config.scenegraph.sizeMinPixels, 1);
     assert.equal(config.scenegraph.bearing, 45);
     assert.equal(config.scenegraph.orientationRoll, 90);
     assert.deepEqual(config.scenegraph.translation, [0, 0, 0]);
@@ -325,7 +325,8 @@ describe("scenegraph (glTF 3D model) layer", () => {
     const config = readDeckVizConfig(layer);
     assert.equal(config?.scenegraph?.sizeScale, DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale);
     assert.equal(config?.scenegraph?.sizeScale, 1);
-    assert.equal(config?.scenegraph?.sizeMinPixels, 0);
+    // Projects saved before the dialog persisted this field keep the 1 px floor.
+    assert.equal(config?.scenegraph?.sizeMinPixels, 1);
     assert.equal(config?.scenegraph?.bearing, 0);
     assert.equal(config?.scenegraph?.orientationRoll, 90);
     assert.deepEqual(config?.scenegraph?.translation, [0, 0, 0]);
@@ -404,7 +405,7 @@ describe("scenegraph (glTF 3D model) layer", () => {
       },
     });
     const props = captured.props!;
-    assert.equal(props.sizeMinPixels, 0);
+    assert.equal(props.sizeMinPixels, 1);
     const record = { lng: 1, lat: 2 };
     assert.deepEqual((props.getPosition as (r: unknown) => number[])(record), [1, 2, 12]);
     assert.deepEqual((props.getOrientation as (r: unknown) => number[])(record), [0, 30, 90]);

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -303,7 +303,7 @@ describe("scenegraph (glTF 3D model) layer", () => {
     assert.ok(config?.scenegraph);
     assert.equal(config.scenegraph.modelUrl, "https://example.com/model.glb");
     assert.equal(config.scenegraph.sizeScale, 250);
-    assert.equal(config.scenegraph.sizeMinPixels, 1);
+    assert.equal(config.scenegraph.sizeMinPixels, 0);
     assert.equal(config.scenegraph.bearing, 45);
     assert.equal(config.scenegraph.orientationRoll, 90);
     assert.deepEqual(config.scenegraph.translation, [0, 0, 0]);
@@ -324,7 +324,8 @@ describe("scenegraph (glTF 3D model) layer", () => {
     });
     const config = readDeckVizConfig(layer);
     assert.equal(config?.scenegraph?.sizeScale, DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale);
-    assert.equal(config?.scenegraph?.sizeMinPixels, 1);
+    assert.equal(config?.scenegraph?.sizeScale, 1);
+    assert.equal(config?.scenegraph?.sizeMinPixels, 0);
     assert.equal(config?.scenegraph?.bearing, 0);
     assert.equal(config?.scenegraph?.orientationRoll, 90);
     assert.deepEqual(config?.scenegraph?.translation, [0, 0, 0]);
@@ -403,6 +404,7 @@ describe("scenegraph (glTF 3D model) layer", () => {
       },
     });
     const props = captured.props!;
+    assert.equal(props.sizeMinPixels, 0);
     const record = { lng: 1, lat: 2 };
     assert.deepEqual((props.getPosition as (r: unknown) => number[])(record), [1, 2, 12]);
     assert.deepEqual((props.getOrientation as (r: unknown) => number[])(record), [0, 30, 90]);

--- a/tests/local-gltf.test.ts
+++ b/tests/local-gltf.test.ts
@@ -6,7 +6,11 @@ import {
 } from "../packages/plugins/src/plugins/deckgl-viz/store-layer";
 import { DEFAULT_DECK_VIZ_STYLE } from "../packages/plugins/src/plugins/deckgl-viz/registry";
 import { test } from "node:test";
-import { localGltfMime } from "../apps/geolibre-desktop/src/lib/local-gltf";
+import {
+  MAX_LOCAL_GLTF_BYTES,
+  embedLocalGltf,
+  localGltfMime,
+} from "../apps/geolibre-desktop/src/lib/local-gltf";
 
 const encode = (value: unknown) => new TextEncoder().encode(JSON.stringify(value)).buffer;
 const glb = (value: unknown) => {
@@ -39,6 +43,24 @@ test("rejects sidecar resources in both glTF and GLB", () => {
       }
     }
   }
+});
+test("rejects an external uri nested in a texture extension", () => {
+  const model = {
+    asset: { version: "2.0" },
+    images: [
+      { extensions: { KHR_texture_basisu: { uri: "https://example.com/city.ktx2" } } },
+      // Free-form application data is not a resource reference.
+      { extras: { uri: "C:/exports/original.png" }, uri: "data:image/png;base64,AAAA" },
+    ],
+  };
+  assert.throws(() => localGltfMime(encode(model)), /externalResources/);
+  assert.equal(
+    localGltfMime(encode({ asset: { version: "2.0" }, images: [model.images[1]] })),
+    "model/gltf+json",
+  );
+});
+test("rejects a model past the inline embedding cap", async () => {
+  await assert.rejects(embedLocalGltf(new ArrayBuffer(MAX_LOCAL_GLTF_BYTES + 1)), /modelTooLarge/);
 });
 test("rejects wrong formats, versions and truncated containers", () => {
   for (const data of [

--- a/tests/local-gltf.test.ts
+++ b/tests/local-gltf.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../apps/geolibre-desktop/src/lib/local-gltf";
 
 const encode = (value: unknown) => new TextEncoder().encode(JSON.stringify(value)).buffer;
+const encodeText = (json: string) => new TextEncoder().encode(json).buffer;
 const glb = (value: unknown) => {
   const json = new TextEncoder().encode(JSON.stringify(value));
   const length = Math.ceil(json.length / 4) * 4;
@@ -59,21 +60,24 @@ test("rejects an external uri nested in a texture extension", () => {
     "model/gltf+json",
   );
 });
-test("validates deeply nested assets without overflowing the stack", () => {
-  const deep: { scenes: unknown } = { scenes: [] };
-  let node: unknown[] = deep.scenes as unknown[];
-  for (let i = 0; i < 5000; i += 1) {
-    const child: unknown[] = [];
-    node.push(child);
-    node = child;
+// Built as text rather than through JSON.stringify, which recurses and blows
+// the stack on the deeper fixtures. Stack budgets differ by host, so the test
+// picks the deepest asset this runtime can parse: the walk is what is under
+// test, not the parser.
+const deepAsset = (depth: number, innermost: string) =>
+  `{"asset":{"version":"2.0"},"scenes":${"[".repeat(depth)}${innermost}${"]".repeat(depth)}}`;
+const deepestParsable = [4000, 2000, 1000, 500].find((depth) => {
+  try {
+    JSON.parse(deepAsset(depth, ""));
+    return true;
+  } catch {
+    return false;
   }
-  node.push({ uri: "https://example.com/buried.bin" });
-  assert.throws(
-    () => localGltfMime(encode({ asset: { version: "2.0" }, ...deep })),
-    /externalResources/,
-  );
-  node.pop();
-  assert.equal(localGltfMime(encode({ asset: { version: "2.0" }, ...deep })), "model/gltf+json");
+})!;
+test("validates deeply nested assets without overflowing the stack", () => {
+  const buried = deepAsset(deepestParsable, '{"uri":"https://example.com/buried.bin"}');
+  assert.throws(() => localGltfMime(encodeText(buried)), /externalResources/);
+  assert.equal(localGltfMime(encodeText(deepAsset(deepestParsable, ""))), "model/gltf+json");
 });
 test("rejects a model past the inline embedding cap", async () => {
   await assert.rejects(embedLocalGltf(new ArrayBuffer(MAX_LOCAL_GLTF_BYTES + 1)), /modelTooLarge/);

--- a/tests/local-gltf.test.ts
+++ b/tests/local-gltf.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { createEmptyProject, parseProject, serializeProject } from "../packages/core/src/project";
-import { createDeckVizStoreLayer, readDeckVizConfig } from "../packages/plugins/src/plugins/deckgl-viz/store-layer";
+import {
+  createDeckVizStoreLayer,
+  readDeckVizConfig,
+} from "../packages/plugins/src/plugins/deckgl-viz/store-layer";
 import { DEFAULT_DECK_VIZ_STYLE } from "../packages/plugins/src/plugins/deckgl-viz/registry";
 import { test } from "node:test";
 import { localGltfMime } from "../apps/geolibre-desktop/src/lib/local-gltf";
@@ -11,14 +14,19 @@ const glb = (value: unknown) => {
   const length = Math.ceil(json.length / 4) * 4;
   const data = new ArrayBuffer(20 + length);
   const view = new DataView(data);
-  [0x46546c67, 2, data.byteLength, length, 0x4e4f534a].forEach((n, i) => view.setUint32(i * 4, n, true));
+  [0x46546c67, 2, data.byteLength, length, 0x4e4f534a].forEach((n, i) =>
+    view.setUint32(i * 4, n, true),
+  );
   new Uint8Array(data, 20).fill(32);
   new Uint8Array(data, 20).set(json);
   return data;
 };
 
 test("accepts embedded JSON glTF and binary GLB", () => {
-  const model = { asset: { version: "2.0" }, buffers: [{ uri: "data:application/octet-stream;base64,AAAA" }] };
+  const model = {
+    asset: { version: "2.0" },
+    buffers: [{ uri: "data:application/octet-stream;base64,AAAA" }],
+  };
   assert.equal(localGltfMime(encode(model)), "model/gltf+json");
   assert.equal(localGltfMime(glb(model)), "model/gltf-binary");
 });
@@ -33,7 +41,13 @@ test("rejects sidecar resources in both glTF and GLB", () => {
   }
 });
 test("rejects wrong formats, versions and truncated containers", () => {
-  for (const data of [new ArrayBuffer(0), encode(null), encode({}), encode({ asset: { version: "1.0" } }), glb({ asset: { version: "2.0" } }).slice(0, -1)]) {
+  for (const data of [
+    new ArrayBuffer(0),
+    encode(null),
+    encode({}),
+    encode({ asset: { version: "1.0" } }),
+    glb({ asset: { version: "2.0" } }).slice(0, -1),
+  ]) {
     assert.throws(() => localGltfMime(data));
   }
 });
@@ -41,11 +55,20 @@ test("embedded model bytes survive a project save and reopen", () => {
   const bytes = glb({ asset: { version: "2.0" }, scenes: [{ nodes: [] }] });
   const modelUrl = `data:${localGltfMime(bytes)};base64,${Buffer.from(bytes).toString("base64")}`;
   const project = createEmptyProject("Local model");
-  project.layers.push(createDeckVizStoreLayer({
-    name: "local.glb", sourcePath: "local.glb", rows: [{ lng: 121.495, lat: 31.235 }],
-    config: { layerKind: "scenegraph", format: "json-array", fieldMapping: { lng: "lng", lat: "lat" },
-      style: { ...DEFAULT_DECK_VIZ_STYLE }, scenegraph: { modelUrl, sizeScale: 1, bearing: 0, altitude: 0 } },
-  }));
+  project.layers.push(
+    createDeckVizStoreLayer({
+      name: "local.glb",
+      sourcePath: "local.glb",
+      rows: [{ lng: 121.495, lat: 31.235 }],
+      config: {
+        layerKind: "scenegraph",
+        format: "json-array",
+        fieldMapping: { lng: "lng", lat: "lat" },
+        style: { ...DEFAULT_DECK_VIZ_STYLE },
+        scenegraph: { modelUrl, sizeScale: 1, bearing: 0, altitude: 0 },
+      },
+    }),
+  );
   const restored = parseProject(serializeProject(project));
   assert.equal(readDeckVizConfig(restored.layers[0])?.scenegraph?.modelUrl, modelUrl);
 });

--- a/tests/local-gltf.test.ts
+++ b/tests/local-gltf.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { createEmptyProject, parseProject, serializeProject } from "../packages/core/src/project";
+import { createDeckVizStoreLayer, readDeckVizConfig } from "../packages/plugins/src/plugins/deckgl-viz/store-layer";
+import { DEFAULT_DECK_VIZ_STYLE } from "../packages/plugins/src/plugins/deckgl-viz/registry";
+import { test } from "node:test";
+import { localGltfMime } from "../apps/geolibre-desktop/src/lib/local-gltf";
+
+const encode = (value: unknown) => new TextEncoder().encode(JSON.stringify(value)).buffer;
+const glb = (value: unknown) => {
+  const json = new TextEncoder().encode(JSON.stringify(value));
+  const length = Math.ceil(json.length / 4) * 4;
+  const data = new ArrayBuffer(20 + length);
+  const view = new DataView(data);
+  [0x46546c67, 2, data.byteLength, length, 0x4e4f534a].forEach((n, i) => view.setUint32(i * 4, n, true));
+  new Uint8Array(data, 20).fill(32);
+  new Uint8Array(data, 20).set(json);
+  return data;
+};
+
+test("accepts embedded JSON glTF and binary GLB", () => {
+  const model = { asset: { version: "2.0" }, buffers: [{ uri: "data:application/octet-stream;base64,AAAA" }] };
+  assert.equal(localGltfMime(encode(model)), "model/gltf+json");
+  assert.equal(localGltfMime(glb(model)), "model/gltf-binary");
+});
+test("rejects sidecar resources in both glTF and GLB", () => {
+  for (const uri of ["texture.png", "../mesh.bin", "https://example.com/a.png"]) {
+    for (const field of ["buffers", "images"]) {
+      const model = { asset: { version: "2.0" }, [field]: [{ uri }] };
+      for (const data of [encode(model), glb(model)]) {
+        assert.throws(() => localGltfMime(data), /externalResources/);
+      }
+    }
+  }
+});
+test("rejects wrong formats, versions and truncated containers", () => {
+  for (const data of [new ArrayBuffer(0), encode(null), encode({}), encode({ asset: { version: "1.0" } }), glb({ asset: { version: "2.0" } }).slice(0, -1)]) {
+    assert.throws(() => localGltfMime(data));
+  }
+});
+test("embedded model bytes survive a project save and reopen", () => {
+  const bytes = glb({ asset: { version: "2.0" }, scenes: [{ nodes: [] }] });
+  const modelUrl = `data:${localGltfMime(bytes)};base64,${Buffer.from(bytes).toString("base64")}`;
+  const project = createEmptyProject("Local model");
+  project.layers.push(createDeckVizStoreLayer({
+    name: "local.glb", sourcePath: "local.glb", rows: [{ lng: 121.495, lat: 31.235 }],
+    config: { layerKind: "scenegraph", format: "json-array", fieldMapping: { lng: "lng", lat: "lat" },
+      style: { ...DEFAULT_DECK_VIZ_STYLE }, scenegraph: { modelUrl, sizeScale: 1, bearing: 0, altitude: 0 } },
+  }));
+  const restored = parseProject(serializeProject(project));
+  assert.equal(readDeckVizConfig(restored.layers[0])?.scenegraph?.modelUrl, modelUrl);
+});

--- a/tests/local-gltf.test.ts
+++ b/tests/local-gltf.test.ts
@@ -59,6 +59,22 @@ test("rejects an external uri nested in a texture extension", () => {
     "model/gltf+json",
   );
 });
+test("validates deeply nested assets without overflowing the stack", () => {
+  const deep: { scenes: unknown } = { scenes: [] };
+  let node: unknown[] = deep.scenes as unknown[];
+  for (let i = 0; i < 5000; i += 1) {
+    const child: unknown[] = [];
+    node.push(child);
+    node = child;
+  }
+  node.push({ uri: "https://example.com/buried.bin" });
+  assert.throws(
+    () => localGltfMime(encode({ asset: { version: "2.0" }, ...deep })),
+    /externalResources/,
+  );
+  node.pop();
+  assert.equal(localGltfMime(encode({ asset: { version: "2.0" }, ...deep })), "model/gltf+json");
+});
 test("rejects a model past the inline embedding cap", async () => {
   await assert.rejects(embedLocalGltf(new ArrayBuffer(MAX_LOCAL_GLTF_BYTES + 1)), /modelTooLarge/);
 });

--- a/tests/model-samples.test.ts
+++ b/tests/model-samples.test.ts
@@ -1,12 +1,27 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { SHANGHAI_MODEL_SAMPLE, modelSampleBounds } from "../apps/geolibre-desktop/src/lib/model-samples";
+import {
+  SHANGHAI_MODEL_SAMPLE,
+  modelSampleBounds,
+} from "../apps/geolibre-desktop/src/lib/model-samples";
 
 test("Shanghai fits the complete city only at its registered placement", () => {
   const sample = SHANGHAI_MODEL_SAMPLE;
-  assert.deepEqual(modelSampleBounds(sample.scenegraph, ...sample.location), [121.47, 31.22, 121.52, 31.25]);
+  assert.deepEqual(
+    modelSampleBounds(sample.scenegraph, ...sample.location),
+    [121.47, 31.22, 121.52, 31.25],
+  );
   assert.equal(modelSampleBounds(sample.scenegraph, 0, 0), undefined);
-  assert.equal(modelSampleBounds({ ...sample.scenegraph, sizeScale: 3000 }, ...sample.location), undefined);
-  assert.equal(modelSampleBounds({ ...sample.scenegraph, bearing: 45 }, ...sample.location), undefined);
-  assert.equal(modelSampleBounds({ ...sample.scenegraph, modelUrl: "custom.glb" }, ...sample.location), undefined);
+  assert.equal(
+    modelSampleBounds({ ...sample.scenegraph, sizeScale: 3000 }, ...sample.location),
+    undefined,
+  );
+  assert.equal(
+    modelSampleBounds({ ...sample.scenegraph, bearing: 45 }, ...sample.location),
+    undefined,
+  );
+  assert.equal(
+    modelSampleBounds({ ...sample.scenegraph, modelUrl: "custom.glb" }, ...sample.location),
+    undefined,
+  );
 });

--- a/tests/model-samples.test.ts
+++ b/tests/model-samples.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { SHANGHAI_MODEL_SAMPLE, modelSampleBounds } from "../apps/geolibre-desktop/src/lib/model-samples";
+
+test("Shanghai fits the complete city only at its registered placement", () => {
+  const sample = SHANGHAI_MODEL_SAMPLE;
+  assert.deepEqual(modelSampleBounds(sample.scenegraph, ...sample.location), [121.47, 31.22, 121.52, 31.25]);
+  assert.equal(modelSampleBounds(sample.scenegraph, 0, 0), undefined);
+  assert.equal(modelSampleBounds({ ...sample.scenegraph, sizeScale: 3000 }, ...sample.location), undefined);
+  assert.equal(modelSampleBounds({ ...sample.scenegraph, bearing: 45 }, ...sample.location), undefined);
+  assert.equal(modelSampleBounds({ ...sample.scenegraph, modelUrl: "custom.glb" }, ...sample.location), undefined);
+});


### PR DESCRIPTION
The 3D Model (glTF) panel now accepts local GLB and self-contained glTF files alongside URLs. Local models are embedded in the project so they survive saving and reopening; files referencing separate buffers or textures receive an actionable error.

A sample dataset dropdown includes the existing airplane and the hosted Shanghai model. Shanghai prefills longitude 121.495, latitude 31.235, scale 1, bearing 0, and altitude 0, and supplies the full city extent for Zoom to layer. Edited placement or scale stops using the original sample bounds.

Default model scale is now 1, and the minimum pixel size is 0, so meter-scale cities retain geographic size when zooming out. Replacing the airplane example resets its untouched 3000× scale while preserving a scale the user has edited.

Validation:
- TypeScript project build and targeted ESLint passed.
- 32 unit tests passed, covering model formats, missing sidecars, project save/reopen, scenegraph defaults, and sample bounds.
- Four Chromium browser tests passed against the local Vite app; the Shanghai test was rerun after the final sample refactor.
- Manually loaded a textured GLB through the browser file picker and inspected the rendered result with no model-loading errors.

Local embedding increases saved project size. New interface strings use the English fallback catalog. Native desktop file-picker behavior was not exercised in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundled 3D model samples, including airplane and Shanghai scenes.
  * Added local GLB/glTF file selection with embedded model support.
  * Added model loading indicators, validation, and clear errors for unsupported external resources.
  * Model URLs and filenames are preserved when saving projects.

* **Bug Fixes**
  * Improved scenegraph model scaling and geographic sizing with explicit minimum-size settings.
  * Prevented submission while models are still loading.
  * Preserved scale edits made while local models are being embedded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->