### PR TITLE
feat(map): implement CesiumEngine, the globe as a MapEngine

### DIFF
--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1151,6 +1151,18 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    // Bind the IPv4 loopback explicitly. Vite's default (`localhost`) resolves
+    // through the OS, which on a dual-stack Linux box binds `[::1]` only — so a
+    // reverse proxy dialing `127.0.0.1:5173` (e.g. `tailscale serve`, which
+    // targets IPv4 loopback by default) gets connection-refused and returns
+    // 502. Still loopback-only: this does not expose the dev server on the LAN.
+    host: "127.0.0.1",
+    // Vite rejects requests whose Host header it does not recognise. Reaching
+    // the dev server over Tailscale (`tailscale serve --bg 5173`) forwards the
+    // original `<machine>.<tailnet>.ts.net` Host, which would otherwise be
+    // answered with "Blocked request". `.ts.net` names are only resolvable
+    // inside the tailnet, so allowing them does not widen public exposure.
+    allowedHosts: [".ts.net"],
     watch: {
       // Never watch the Rust side. `tauri dev` runs this dev server as its
       // `beforeDevCommand` and then starts cargo in the same tree, so the

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -10,13 +10,8 @@ import {
 import type { CesiumWidget, ImageryLayer } from "@cesium/engine";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { applyBasemapAppearance, applyBasemapImagery } from "./cesium-basemap";
-import {
-  applyMapViewToCamera,
-  groundHeightAt,
-  isSameView,
-  readMapViewFromCamera,
-} from "./cesium-camera";
-import { CesiumLayerSync } from "./cesium-layer-sync";
+import { isSameView } from "./cesium-camera";
+import { CesiumEngine } from "./cesium-engine";
 
 // The Cesium 3D-globe view (see private/cesium-view-plan.md). M1 wired the
 // build, token, and split-pane mount; M2 synced the camera with the shared store
@@ -105,31 +100,11 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<CesiumWidget | null>(null);
   const cesiumRef = useRef<typeof import("@cesium/engine") | null>(null);
-  const layerSyncRef = useRef<CesiumLayerSync | null>(null);
+  const engineRef = useRef<CesiumEngine | null>(null);
   // The imagery layers currently drawing the project basemap, at the bottom of
   // the stack. Tracked so a basemap change replaces exactly these and leaves
   // the data layers above them alone.
   const baseImageryLayersRef = useRef<ImageryLayer[]>([]);
-  // The last view we pushed into the camera. Applying a view fires Cesium's
-  // moveEnd with a (rounding-drifted) echo of that same view; comparing against
-  // this lets the moveEnd handler tell a real user move from that echo.
-  const lastAppliedRef = useRef<MapViewState | null>(null);
-  // Ground height (metres) the last applyView placed the camera against. Terrain
-  // streams in after the camera is positioned, so the first apply over a new
-  // area sees height 0; comparing against this tells a settled terrain load
-  // whether the camera now needs correcting.
-  const lastGroundHeightRef = useRef(0);
-  // Set by real pointer/wheel/touch input on the globe canvas and consumed by
-  // the moveEnd handler. Cesium's camera.moveEnd carries no user-driven flag
-  // (unlike MapLibre's moveend.originalEvent), so this stands in for it: an
-  // autonomous camera settle (terrain streaming in, a container resize) leaves
-  // it false and must not mark the project dirty.
-  const userMovedRef = useRef(false);
-  // Whether the camera's current position came from the user rather than from
-  // `applyView`. Unlike `userMovedRef` (which moveEnd consumes) this stays set
-  // until the next programmatic apply, and it is what stops the terrain
-  // correction below from fighting live navigation — see the handler for why.
-  const userOwnsCameraRef = useRef(false);
   // Flips true once the viewer exists so the store-driven apply effects re-run
   // and drive the freshly created camera.
   const [ready, setReady] = useState(false);
@@ -242,16 +217,21 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
     applyBasemapLook();
   }
 
-  // Push a store view into the camera and remember it as the expected echo.
+  // Push a store view into the camera. The engine remembers it as the expected
+  // echo and re-applies it if terrain settles at a different height.
   function applyView(view: MapViewState): void {
-    const Cesium = cesiumRef.current;
-    const viewer = viewerRef.current;
-    if (!Cesium || !viewer || viewer.isDestroyed()) return;
-    lastAppliedRef.current = view;
-    // This placement is ours, so the terrain correction may adjust it.
-    userOwnsCameraRef.current = false;
-    lastGroundHeightRef.current = groundHeightAt(Cesium, viewer, view.center[0], view.center[1]);
-    applyMapViewToCamera(Cesium, viewer, view);
+    engineRef.current?.applyView(view);
+  }
+
+  /**
+   * Whether `view` is the one the globe itself last published, arriving back
+   * here through the store. Re-applying it would `lookAt` the camera again —
+   * repositioning it to the last settled view and undoing whatever the user has
+   * scrolled since.
+   */
+  function isEchoOfOurOwnCamera(view: MapViewState): boolean {
+    const applied = engineRef.current?.getLastAppliedView();
+    return Boolean(applied && isSameView(view, applied));
   }
 
   // Create the viewer exactly once. The deps are intentionally empty; everything
@@ -260,7 +240,6 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
     if (!containerRef.current || viewerRef.current) return;
     const container = containerRef.current;
     let cancelled = false;
-    let cleanupInput: (() => void) | undefined;
 
     prepareCesiumEnvironment();
 
@@ -298,52 +277,28 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         }
         cesiumRef.current = Cesium;
         viewerRef.current = viewer;
-        layerSyncRef.current = new CesiumLayerSync(Cesium, viewer);
 
         // Note for anyone reintroducing `Viewer`: it installs a double-click
         // "track entity" gesture that flies to and camera-locks a picked
         // feature, which fights the store-driven camera sync and isn't wired to
         // GeoLibre — the pane used to remove that input action explicitly.
         // CesiumWidget never installs it, so every camera move now reaches the
-        // moveEnd handler through the pointer/wheel/touch input flagged below,
-        // and a real move can't be mistaken for an autonomous one.
+        // engine's moveEnd handler through the pointer/wheel/touch input it
+        // flags, and a real move can't be mistaken for an autonomous one.
 
-        // Flag genuine camera-moving input on the globe so the moveEnd handler
-        // can tell a real move from an autonomous settle. Only motion events
-        // count: Cesium's moveEnd fires solely on actual camera movement, so a
-        // plain click/tap (pointerdown/touchstart) that doesn't move the camera
-        // must NOT arm the flag — otherwise a later autonomous settle (terrain,
-        // resize) would consume that stale flag and dirty the project. A hover
-        // isn't a move either, so pointermove only counts while a button is down.
-        const markUserMove = () => {
-          userMovedRef.current = true;
-          userOwnsCameraRef.current = true;
-        };
-        const markUserDrag = (event: PointerEvent) => {
-          if (event.buttons !== 0) {
-            userMovedRef.current = true;
-            userOwnsCameraRef.current = true;
-          }
-        };
-        const canvas = viewer.canvas;
-        const opts: AddEventListenerOptions = { passive: true };
-        canvas.addEventListener("pointermove", markUserDrag, opts);
-        canvas.addEventListener("wheel", markUserMove, opts);
-        canvas.addEventListener("touchmove", markUserMove, opts);
-        cleanupInput = () => {
-          canvas.removeEventListener("pointermove", markUserDrag, opts);
-          canvas.removeEventListener("wheel", markUserMove, opts);
-          canvas.removeEventListener("touchmove", markUserMove, opts);
-        };
+        // The engine owns everything from here: the camera state machine (echo
+        // suppression, user-driven tracking, the terrain correction), input
+        // tracking, publishing moves back to the store, and layer sync. It is
+        // constructed before the terrain await below so its listeners are armed
+        // for the whole mount, exactly as the hand-rolled versions were.
+        const engine = new CesiumEngine(Cesium, viewer, { viewId: viewIdRef.current });
+        engineRef.current = engine;
 
         // With a token, add Cesium World Terrain so tilted views show relief.
-        if (token) {
-          try {
-            viewer.terrainProvider = await Cesium.createWorldTerrainAsync();
-          } catch {
-            // Terrain is best-effort; the globe still renders without it.
-          }
-        }
+        // Awaited before the camera is seeded: ground height is what turns
+        // MapLibre's zoom into a camera distance, so seeding first would place
+        // the first frame against the ellipsoid.
+        if (token) await engine.enableWorldTerrain();
         // The unmount cleanup may have run during the terrain await (destroying
         // the viewer); re-check before touching it, mirroring the guard after the
         // dynamic import above and CesiumLayerSync's post-await checks. Otherwise
@@ -369,73 +324,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         // first frame. Basemap first so it lands at the bottom of an empty
         // imagery stack rather than having to be lowered past the data layers.
         applyBasemap();
-        layerSyncRef.current?.sync(paneLayersRef.current);
-
-        // Terrain arrives after the camera is placed, and the ground height is
-        // what turns MapLibre's zoom into a camera distance. Until the tiles for
-        // the view land, `groundHeightAt` reports 0 and the camera is positioned
-        // against the ellipsoid — over Las Vegas that renders ~2× too close at
-        // zoom 15. Re-apply once the queue drains and the height has actually
-        // changed, so the globe settles onto the real surface. The guard makes
-        // this a no-op without terrain (height stays 0) and stops it recursing:
-        // the re-apply's own load settles at the same height.
-        //
-        // It corrects a *programmatic* placement only. Navigating loads finer
-        // terrain, which drains the queue at a new height mid-gesture; without
-        // the `userOwnsCameraRef` guard that re-applied `lastAppliedRef` — the
-        // last settled view — and yanked the camera back, so a wheel zoom over
-        // terrain snapped straight back to where it started and the store never
-        // saw the move (the yank's own moveEnd read as the suppressed echo).
-        // Once the user is driving, their camera is authoritative and Cesium's
-        // own navigation already keeps it above the terrain.
-        viewer.scene.globe.tileLoadProgressEvent.addEventListener((queued: number) => {
-          const ns = cesiumRef.current;
-          const view = lastAppliedRef.current;
-          if (queued > 0 || !ns || !view || viewer.isDestroyed()) return;
-          if (userOwnsCameraRef.current) return;
-          const height = groundHeightAt(ns, viewer, view.center[0], view.center[1]);
-          if (Math.abs(height - lastGroundHeightRef.current) < 1) return;
-          applyView(view);
-        });
-
-        // Mirror a user's globe navigation back into the shared camera. Echoes
-        // of our own applyView are filtered by the isSameView guard.
-        viewer.camera.moveEnd.addEventListener(() => {
-          if (!cesiumRef.current || viewer.isDestroyed()) return;
-          const view = readMapViewFromCamera(cesiumRef.current, viewer);
-          if (lastAppliedRef.current && isSameView(view, lastAppliedRef.current)) {
-            return;
-          }
-          lastAppliedRef.current = view;
-          // Only the moves that follow real user input dirty the project; an
-          // autonomous settle still syncs the camera (markDirty=false) so the
-          // panes stay in step without flipping isDirty on a freshly opened
-          // project. Mirrors SecondaryMapCanvas's `userDriven` semantics.
-          const userDriven = userMovedRef.current;
-          userMovedRef.current = false;
-          const live = useAppStore.getState();
-          // Write only when the view actually differs from the stored camera:
-          // `setMapView` has no same-camera guard in the store, and
-          // `setSecondaryMapView`'s guard uses exact equality (which Cesium's
-          // lossy readback never hits), so both are gated here with isSameView.
-          if (isPrimaryRef.current) {
-            // The primary globe owns `mapView` outright (there is no pane record
-            // to mirror into), so it writes regardless of the `syncView` toggle
-            // — that toggle governs the secondary panes, and the primary map is
-            // the camera they follow.
-            if (!isSameView(view, live.mapView)) live.setMapView(view, userDriven);
-            return;
-          }
-          if (live.mapLayout.syncView && !isSameView(view, live.mapView)) {
-            live.setMapView(view, userDriven);
-          }
-          const paneId = viewIdRef.current;
-          if (paneId === undefined) return;
-          const paneView = live.secondaryMapViews.find((p) => p.id === paneId)?.view;
-          if (!paneView || !isSameView(view, paneView)) {
-            live.setSecondaryMapView(paneId, view, userDriven);
-          }
-        });
+        engine.syncLayers(paneLayersRef.current);
 
         if (!cancelled) setReady(true);
       } catch (err) {
@@ -446,9 +335,10 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
 
     return () => {
       cancelled = true;
-      cleanupInput?.();
-      layerSyncRef.current?.destroy();
-      layerSyncRef.current = null;
+      // Drops the engine's listeners and its layer sync; the viewer itself is
+      // destroyed below.
+      engineRef.current?.destroy();
+      engineRef.current = null;
       // The viewer's destroy() below tears the imagery down with it; just drop
       // the handles so a remount starts from an empty stack and redraws.
       baseImageryLayersRef.current = [];
@@ -483,7 +373,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   // mount effect's initial sync already covers the value captured at ready time.
   useEffect(() => {
     if (!ready) return;
-    layerSyncRef.current?.sync(paneLayers);
+    engineRef.current?.syncLayers(paneLayers);
   }, [ready, paneLayers]);
 
   // Synced: follow the shared global camera. Depend on primitives so an
@@ -495,7 +385,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
     // store. Re-applying it would `lookAt` the camera again — repositioning it
     // to the last settled view and undoing whatever the user has scrolled since.
     // Only a camera that genuinely differs is worth applying.
-    if (lastAppliedRef.current && isSameView(globalView, lastAppliedRef.current)) return;
+    if (isEchoOfOurOwnCamera(globalView)) return;
     applyView(globalView);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -512,7 +402,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   useEffect(() => {
     if (!ready || syncView || !entryView) return;
     // Same echo guard as the synced effect above.
-    if (lastAppliedRef.current && isSameView(entryView, lastAppliedRef.current)) return;
+    if (isEchoOfOurOwnCamera(entryView)) return;
     applyView(entryView);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/packages/map/src/cesium-camera.ts
+++ b/packages/map/src/cesium-camera.ts
@@ -71,13 +71,13 @@ export function normalizeBearing(deg: number): number {
 }
 
 /** The vertical field of view of a viewer's camera, with a safe fallback. */
-function cameraFovy(viewer: CesiumWidget): number {
+export function cameraFovy(viewer: CesiumWidget): number {
   const frustum = viewer.camera.frustum as { fovy?: number };
   return frustum.fovy && frustum.fovy > 0 ? frustum.fovy : DEFAULT_FOVY;
 }
 
 /** The viewer canvas height in CSS pixels, guarding against a 0 during layout. */
-function canvasHeight(viewer: CesiumWidget): number {
+export function canvasHeight(viewer: CesiumWidget): number {
   const canvas = viewer.scene.canvas;
   return canvas.clientHeight || canvas.height || 1;
 }

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -69,6 +69,8 @@ export const CESIUM_CAPABILITIES: MapEngineCapabilities = Object.freeze({
 
 /** Seconds a menu-driven camera move takes on the globe. */
 const CAMERA_FLIGHT_SECONDS = 0.5;
+/** Zoom floor when framing a point-sized extent; matches MapController.fitBounds. */
+const POINT_FIT_ZOOM = 14;
 
 export interface CesiumEngineOptions {
   /**
@@ -204,15 +206,13 @@ export class CesiumEngine implements MapEngine {
     animation: StoryChapterAnimation = "flyTo",
     _rotate = false,
   ): void {
-    // A story camera is scripted, not user input, so it must not dirty the
-    // project — hence animateTo(..., { userDriven: false }). Auto-rotation is
-    // MapLibre-only for now: it drives a per-frame bearing tick against the 2D
-    // map, and the globe has no equivalent hook yet.
+    // Auto-rotation is MapLibre-only for now: it drives a per-frame bearing tick
+    // against the 2D map, and the globe has no equivalent hook yet.
     if (animation === "jumpTo") {
       this.applyView(location);
       return;
     }
-    this.animateTo(location, { userDriven: false });
+    this.animateTo(location);
   }
 
   flyTo(camera: FlyToCamera): void {
@@ -224,7 +224,7 @@ export class CesiumEngine implements MapEngine {
         bearing: camera.bearing ?? current.bearing,
         pitch: camera.pitch ?? current.pitch,
       },
-      { seconds: camera.duration === undefined ? undefined : camera.duration / 1000 },
+      camera.duration === undefined ? undefined : camera.duration / 1000,
     );
   }
 
@@ -255,7 +255,21 @@ export class CesiumEngine implements MapEngine {
     if (!viewer) return;
     const [west, south, east, north] = bounds;
     if (![west, south, east, north].every((value) => Number.isFinite(value))) return;
-    this.markUserDriven();
+    // A degenerate point-sized box cannot be fit; fly to the point instead.
+    // `fitLayer` on a single-point layer produces exactly this box, and a
+    // zero-area Rectangle has no "zoom to fit" — Cesium would derive a
+    // nonsensical camera distance from it. Mirrors MapController.fitBounds,
+    // including its zoom floor, so a single marker frames the same on both
+    // engines.
+    if (west === east && south === north) {
+      this.animateTo({
+        center: [west, south],
+        zoom: Math.max(this.readView().zoom, POINT_FIT_ZOOM),
+        bearing: 0,
+        pitch: 0,
+      });
+      return;
+    }
     viewer.camera.flyTo({
       destination: this.Cesium.Rectangle.fromDegrees(west, south, east, north),
       duration: CAMERA_FLIGHT_SECONDS,
@@ -524,26 +538,31 @@ export class CesiumEngine implements MapEngine {
    * Flag the camera move that follows as user-driven, so the `moveEnd` handler
    * marks the project dirty.
    *
-   * Cesium's `moveEnd` cannot tell a menu click from a terrain settle, and the
-   * only signal the canvas ever had was raw pointer/wheel/touch input. A caller
-   * that drives the camera through this engine — View → Zoom in, a shortcut, a
-   * panel's "fly to" — *is* the user, so it has to raise the same flag their
-   * scroll wheel would. Without this, menu-driven camera changes would sync to
-   * the store but silently leave the project clean.
+   * Raw input only. Cesium's `moveEnd` carries no user-driven flag, so this
+   * stands in for MapLibre's `moveend.originalEvent` — and, like it, is set by
+   * the user's own gesture and nothing else. A programmatic move does *not*
+   * raise it: see {@link animateTo}.
    */
   private markUserDriven(): void {
     this.userMoved = true;
     this.userOwnsCamera = true;
   }
 
-  /** Animate the camera to `view`, defaulting to a user-driven, dirtying move. */
-  private animateTo(
-    view: MapViewState,
-    options: { userDriven?: boolean; seconds?: number } = {},
-  ): void {
+  /**
+   * Animate the camera to `view`. Never marks the project dirty.
+   *
+   * This matches the 2D map exactly, and the match is the point. `MapController`
+   * drives MapLibre's own camera API with no `eventData`, so the resulting
+   * `moveend` has no `originalEvent` and `MapCanvas` publishes it with
+   * `markDirty=false` — clicking View → Zoom in, resetting the bearing, or
+   * previewing a story chapter syncs the camera without flagging unsaved
+   * changes. An engine that dirtied on the same actions would make identical
+   * clicks behave differently depending on which renderer is drawing, which is
+   * precisely what #2260 exists to prevent.
+   */
+  private animateTo(view: MapViewState, seconds?: number): void {
     const viewer = this.live();
     if (!viewer) return;
-    if (options.userDriven ?? true) this.markUserDriven();
     // Cesium has no "ease to a MapLibre view" primitive, so the flight is
     // expressed the same way applyView expresses a placement — a lookAt in the
     // target's local frame — with `flyTo`'s duration doing the animating.
@@ -568,7 +587,7 @@ export class CesiumEngine implements MapEngine {
           this.Cesium.Math.toRadians(mapLibrePitchToCesiumDeg(view.pitch)),
           range,
         ),
-        duration: options.seconds ?? CAMERA_FLIGHT_SECONDS,
+        duration: seconds ?? CAMERA_FLIGHT_SECONDS,
       },
     );
   }

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -76,8 +76,22 @@ function clampZoom(value: number, fallback: number): number {
   return Math.min(24, Math.max(0, value));
 }
 
-/** Seconds a menu-driven camera move takes on the globe. */
-const CAMERA_FLIGHT_SECONDS = 0.5;
+/**
+ * Animation lengths, in seconds, matched to the 2D map's.
+ *
+ * The same click must not visibly run at a different speed depending on which
+ * renderer is drawing, so each of these is pinned to what `MapController` does
+ * rather than to one house default (#2265 review).
+ */
+/** MapLibre's `easeTo` default (500 ms), which backs `zoomIn`/`zoomOut`/`easeToView`. */
+const EASE_SECONDS = 0.5;
+/**
+ * MapLibre's `resetNorth`/`resetNorthPitch` animate over 1 s, and
+ * `MapController.resetPitch` sets 1000 ms explicitly to match its siblings.
+ */
+const RESET_SECONDS = 1;
+/** `MapController.flyTo` and `MapController.fitBounds` both use 800 ms. */
+const FLY_SECONDS = 0.8;
 /** Zoom floor when framing a point-sized extent; matches MapController.fitBounds. */
 const POINT_FIT_ZOOM = 14;
 
@@ -217,12 +231,24 @@ export class CesiumEngine implements MapEngine {
     return readMapViewFromCamera(this.Cesium, viewer);
   }
 
+  /**
+   * Animate to `view` with a linear ease, matching `map.easeTo`'s 500 ms.
+   *
+   * Note the globe cannot reproduce MapLibre's *shape* distinction: `easeTo`
+   * interpolates the camera directly while `flyTo` traces a curved
+   * zoom-out-then-in arc, whereas Cesium exposes one flight primitive that both
+   * {@link easeToView} and {@link flyToView} necessarily share. Only the
+   * durations differ here. If a caller ever depends on the arc — a story
+   * transition that reads as "travelling" rather than "sliding" — it needs a
+   * real Cesium implementation, not a duration tweak.
+   */
   easeToView(view: MapViewState): void {
-    this.animateTo(view);
+    this.animateTo(view, EASE_SECONDS);
   }
 
+  /** Animate to a story-chapter location. See {@link easeToView} on the arc. */
   flyToView(location: StoryChapterLocation): void {
-    this.animateTo(location);
+    this.animateTo(location, FLY_SECONDS);
   }
 
   applyStoryChapterCamera(
@@ -236,7 +262,7 @@ export class CesiumEngine implements MapEngine {
       this.applyView(location);
       return;
     }
-    this.animateTo(location);
+    this.animateTo(location, animation === "easeTo" ? EASE_SECONDS : FLY_SECONDS);
   }
 
   flyTo(camera: FlyToCamera): void {
@@ -248,7 +274,7 @@ export class CesiumEngine implements MapEngine {
         bearing: camera.bearing ?? current.bearing,
         pitch: camera.pitch ?? current.pitch,
       },
-      camera.duration === undefined ? undefined : camera.duration / 1000,
+      camera.duration === undefined ? FLY_SECONDS : camera.duration / 1000,
     );
   }
 
@@ -263,15 +289,15 @@ export class CesiumEngine implements MapEngine {
   }
 
   resetNorth(): void {
-    this.animateTo({ ...this.readView(), bearing: 0 });
+    this.animateTo({ ...this.readView(), bearing: 0 }, RESET_SECONDS);
   }
 
   resetNorthPitch(): void {
-    this.animateTo({ ...this.readView(), bearing: 0, pitch: 0 });
+    this.animateTo({ ...this.readView(), bearing: 0, pitch: 0 }, RESET_SECONDS);
   }
 
   resetPitch(): void {
-    this.animateTo({ ...this.readView(), pitch: 0 });
+    this.animateTo({ ...this.readView(), pitch: 0 }, RESET_SECONDS);
   }
 
   fitBounds(bounds: [number, number, number, number]): void {
@@ -286,17 +312,20 @@ export class CesiumEngine implements MapEngine {
     // including its zoom floor, so a single marker frames the same on both
     // engines.
     if (west === east && south === north) {
-      this.animateTo({
-        center: [west, south],
-        zoom: Math.max(this.readView().zoom, POINT_FIT_ZOOM),
-        bearing: 0,
-        pitch: 0,
-      });
+      this.animateTo(
+        {
+          center: [west, south],
+          zoom: Math.max(this.readView().zoom, POINT_FIT_ZOOM),
+          bearing: 0,
+          pitch: 0,
+        },
+        FLY_SECONDS,
+      );
       return;
     }
     viewer.camera.flyTo({
       destination: this.Cesium.Rectangle.fromDegrees(west, south, east, north),
-      duration: CAMERA_FLIGHT_SECONDS,
+      duration: FLY_SECONDS,
     });
   }
 
@@ -618,7 +647,7 @@ export class CesiumEngine implements MapEngine {
           this.Cesium.Math.toRadians(mapLibrePitchToCesiumDeg(view.pitch)),
           range,
         ),
-        duration: seconds ?? CAMERA_FLIGHT_SECONDS,
+        duration: seconds ?? EASE_SECONDS,
       },
     );
   }

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -1,0 +1,705 @@
+import {
+  useAppStore,
+  type GeoLibreLayer,
+  type MapPreferences,
+  type MapProjection,
+  type MapViewState,
+  type StoryChapterAnimation,
+  type StoryChapterLocation,
+} from "@geolibre/core";
+import type { CesiumWidget } from "@cesium/engine";
+import type { FeatureCollection } from "geojson";
+import type * as maplibregl from "maplibre-gl";
+import {
+  applyMapViewToCamera,
+  cameraFovy,
+  mapLibrePitchToCesiumDeg,
+  normalizeBearing,
+  canvasHeight,
+  groundHeightAt,
+  isSameView,
+  readMapViewFromCamera,
+  zoomToRange,
+} from "./cesium-camera";
+import { CesiumLayerSync } from "./cesium-layer-sync";
+import { getLayerBounds } from "./geojson-loader";
+import type {
+  BuiltInMapControl,
+  IdentifiedFeature,
+  ManualPlacementOptions,
+  MapEngine,
+  MapEngineCapabilities,
+  FlyToCamera,
+} from "./map-engine";
+
+type CesiumNs = typeof import("@cesium/engine");
+
+/**
+ * What the globe can do (issue #2260).
+ *
+ * The four `false` flags are not "not yet wired" — they are the operations
+ * Cesium has no equivalent for, or that this engine deliberately does not claim:
+ *
+ * - `styleSpec` / `nativeMapInstance`: Cesium draws imagery layers and
+ *   primitives, not a Mapbox Style document, and there is no `maplibregl.Map`
+ *   behind it. Everything that edits paint properties or reads the MapLibre
+ *   canvas stays 2D-only.
+ * - `customLayers`: a MapLibre `CustomLayerInterface` is a callback into
+ *   MapLibre's own WebGL pass; deck.gl's MapLibre interop is the same shape.
+ * - `picking`: `identifyFeatures` needs `scene.drillPick` plus a mapping from a
+ *   picked primitive back to a `GeoLibreLayer` id and feature id, which
+ *   `CesiumLayerSync` does not record today. Claiming it before that exists
+ *   would make Identify report "no features here" instead of "not available".
+ * - `onMapDrawing` / `domControls`: no manual-placement pin and nowhere to host
+ *   an `IControl`. The control host is issue #2263.
+ *
+ * `terrain: true` is the flag worth noting in the other direction — terrain is
+ * native on the globe, and the old `primaryRenderer === "cesium"` gates disabled
+ * it anyway.
+ */
+export const CESIUM_CAPABILITIES: MapEngineCapabilities = Object.freeze({
+  styleSpec: false,
+  nativeMapInstance: false,
+  customLayers: false,
+  terrain: true,
+  picking: false,
+  onMapDrawing: false,
+  domControls: false,
+});
+
+/** Seconds a menu-driven camera move takes on the globe. */
+const CAMERA_FLIGHT_SECONDS = 0.5;
+
+export interface CesiumEngineOptions {
+  /**
+   * Id of the `secondaryMapViews` record this globe draws, or `undefined` when
+   * it *is* the primary map area. Decides which camera the engine publishes to
+   * and whether per-pane visibility overrides apply — see `CesiumCanvas`.
+   */
+  viewId?: string;
+}
+
+/**
+ * The 3D globe as a {@link MapEngine} (issue #2260).
+ *
+ * This owns the globe's camera state machine, which used to live in
+ * `CesiumCanvas`'s mount effect. Moving it here is what lets menus, panels, and
+ * shortcuts drive the globe the way they drive the 2D map: a caller that runs
+ * `zoomIn()` has to land in the same echo-suppression and dirty-tracking logic
+ * as a user's own scroll, and a second, independent camera owner would fight it
+ * (see {@link markUserDriven}).
+ *
+ * The engine is constructed with an existing `CesiumWidget` rather than creating
+ * one, mirroring `CesiumLayerSync`: `CesiumCanvas` owns the widget's async
+ * lifecycle (the lazy `import()`, the cancellation dance, the container), and
+ * the engine owns everything after it exists. That is the same split as
+ * `MapCanvas`/`MapController`, minus `init` — construction is the one thing the
+ * engines legitimately do differently, which is why `MapEngine` does not declare
+ * it.
+ */
+export class CesiumEngine implements MapEngine {
+  readonly kind = "cesium" as const;
+  readonly capabilities: MapEngineCapabilities = CESIUM_CAPABILITIES;
+
+  private readonly Cesium: CesiumNs;
+  private viewer: CesiumWidget | null;
+  private readonly viewId: string | undefined;
+  private readonly layerSync: CesiumLayerSync;
+
+  /**
+   * The last view this engine pushed into the camera. Applying a view fires
+   * Cesium's `moveEnd` with a (rounding-drifted) echo of that same view;
+   * comparing against this is what tells a real user move from that echo.
+   */
+  private lastApplied: MapViewState | null = null;
+  /**
+   * Ground height (metres) the last `applyView` placed the camera against.
+   * Terrain streams in after the camera is positioned, so the first apply over
+   * a new area sees height 0; comparing against this tells a settled terrain
+   * load whether the camera now needs correcting.
+   */
+  private lastGroundHeight = 0;
+  /**
+   * Set by real user input (or by a caller going through {@link markUserDriven})
+   * and consumed by the `moveEnd` handler. Cesium's `camera.moveEnd` carries no
+   * user-driven flag (unlike MapLibre's `moveend.originalEvent`), so this stands
+   * in for it: an autonomous settle (terrain streaming, a container resize)
+   * leaves it false and must not mark the project dirty.
+   */
+  private userMoved = false;
+  /**
+   * Whether the camera's current position came from the user rather than from
+   * {@link applyView}. Unlike {@link userMoved} (which `moveEnd` consumes) this
+   * stays set until the next programmatic apply, and it is what stops the
+   * terrain correction from fighting live navigation.
+   */
+  private userOwnsCamera = false;
+
+  private terrainEnabled = false;
+  private terrainExaggeration = 1;
+  private disposers: Array<() => void> = [];
+
+  constructor(Cesium: CesiumNs, viewer: CesiumWidget, options: CesiumEngineOptions = {}) {
+    this.Cesium = Cesium;
+    this.viewer = viewer;
+    this.viewId = options.viewId;
+    this.layerSync = new CesiumLayerSync(Cesium, viewer);
+    this.terrainExaggeration = viewer.scene.verticalExaggeration ?? 1;
+    this.installInputTracking();
+    this.installTerrainCorrection();
+    this.installCameraPublisher();
+  }
+
+  /** Whether this globe is the primary map area rather than a grid pane. */
+  private get isPrimary(): boolean {
+    return this.viewId === undefined;
+  }
+
+  /** The viewer, or `null` once it has been destroyed out from under us. */
+  private live(): CesiumWidget | null {
+    const viewer = this.viewer;
+    return viewer && !viewer.isDestroyed() ? viewer : null;
+  }
+
+  // ---------------------------------------------------------------- lifecycle
+
+  destroy(): void {
+    for (const dispose of this.disposers.splice(0)) dispose();
+    this.layerSync.destroy();
+    // The widget itself belongs to CesiumCanvas, which destroys it; dropping the
+    // handle here is what stops a late listener from touching a dead viewer.
+    this.viewer = null;
+  }
+
+  // ------------------------------------------------------------------- camera
+
+  applyView(view: MapViewState): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    this.lastApplied = view;
+    // This placement is ours, so the terrain correction may adjust it.
+    this.userOwnsCamera = false;
+    this.lastGroundHeight = groundHeightAt(this.Cesium, viewer, view.center[0], view.center[1]);
+    applyMapViewToCamera(this.Cesium, viewer, view);
+  }
+
+  readView(): MapViewState {
+    const viewer = this.live();
+    if (!viewer) {
+      return this.lastApplied ?? useAppStore.getState().mapView;
+    }
+    return readMapViewFromCamera(this.Cesium, viewer);
+  }
+
+  easeToView(view: MapViewState): void {
+    this.animateTo(view);
+  }
+
+  flyToView(location: StoryChapterLocation): void {
+    this.animateTo(location);
+  }
+
+  applyStoryChapterCamera(
+    location: StoryChapterLocation,
+    animation: StoryChapterAnimation = "flyTo",
+    _rotate = false,
+  ): void {
+    // A story camera is scripted, not user input, so it must not dirty the
+    // project — hence animateTo(..., { userDriven: false }). Auto-rotation is
+    // MapLibre-only for now: it drives a per-frame bearing tick against the 2D
+    // map, and the globe has no equivalent hook yet.
+    if (animation === "jumpTo") {
+      this.applyView(location);
+      return;
+    }
+    this.animateTo(location, { userDriven: false });
+  }
+
+  flyTo(camera: FlyToCamera): void {
+    const current = this.readView();
+    this.animateTo(
+      {
+        center: camera.center ?? current.center,
+        zoom: camera.zoom ?? current.zoom,
+        bearing: camera.bearing ?? current.bearing,
+        pitch: camera.pitch ?? current.pitch,
+      },
+      { seconds: camera.duration === undefined ? undefined : camera.duration / 1000 },
+    );
+  }
+
+  zoomIn(): void {
+    const view = this.readView();
+    this.animateTo({ ...view, zoom: view.zoom + 1 });
+  }
+
+  zoomOut(): void {
+    const view = this.readView();
+    this.animateTo({ ...view, zoom: Math.max(view.zoom - 1, 0) });
+  }
+
+  resetNorth(): void {
+    this.animateTo({ ...this.readView(), bearing: 0 });
+  }
+
+  resetNorthPitch(): void {
+    this.animateTo({ ...this.readView(), bearing: 0, pitch: 0 });
+  }
+
+  resetPitch(): void {
+    this.animateTo({ ...this.readView(), pitch: 0 });
+  }
+
+  fitBounds(bounds: [number, number, number, number]): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    const [west, south, east, north] = bounds;
+    if (![west, south, east, north].every((value) => Number.isFinite(value))) return;
+    this.markUserDriven();
+    viewer.camera.flyTo({
+      destination: this.Cesium.Rectangle.fromDegrees(west, south, east, north),
+      duration: CAMERA_FLIGHT_SECONDS,
+    });
+  }
+
+  fitLayer(layer: GeoLibreLayer): void {
+    const bounds = getLayerBounds(layer);
+    if (bounds) this.fitBounds(bounds);
+  }
+
+  readCameraAltitude(): number | null {
+    const viewer = this.live();
+    if (!viewer) return null;
+    const carto = this.Cesium.Cartographic.fromCartesian(viewer.camera.positionWC);
+    if (!carto || !Number.isFinite(carto.height)) return null;
+    const ground = groundHeightAt(
+      this.Cesium,
+      viewer,
+      this.Cesium.Math.toDegrees(carto.longitude),
+      this.Cesium.Math.toDegrees(carto.latitude),
+    );
+    return carto.height - ground;
+  }
+
+  /** Always `"globe"`: Cesium draws an ellipsoid, never a flat projection. */
+  readProjection(): MapProjection {
+    return "globe";
+  }
+
+  applyMapPreferences(preferences: MapPreferences): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    // MapLibre's min/max zoom become camera distance limits, which is the
+    // closest Cesium analogue. The latitude the conversion needs is the camera's
+    // own, so the limits track the scale the user actually sees. Bounds and
+    // maxPitch have no equivalent the globe can enforce without fighting
+    // Cesium's own navigation, so they are left to the 2D map.
+    const { latitude } = this.Cesium.Cartographic.fromCartesian(viewer.camera.positionWC) ?? {
+      latitude: 0,
+    };
+    const latDeg = this.Cesium.Math.toDegrees(latitude);
+    const height = canvasHeight(viewer);
+    const fovy = cameraFovy(viewer);
+    const controller = viewer.scene.screenSpaceCameraController;
+    if (Number.isFinite(preferences.maxZoom)) {
+      controller.minimumZoomDistance = Math.max(
+        zoomToRange(preferences.maxZoom, latDeg, height, fovy),
+        1,
+      );
+    }
+    if (Number.isFinite(preferences.minZoom)) {
+      controller.maximumZoomDistance = Math.max(
+        zoomToRange(preferences.minZoom, latDeg, height, fovy),
+        1,
+      );
+    }
+  }
+
+  // ------------------------------------------------------------------- layers
+
+  syncLayers(layers: GeoLibreLayer[]): void {
+    this.layerSync.sync(layers);
+  }
+
+  /**
+   * The globe has no style-swap window to wait out — `CesiumLayerSync` already
+   * defers each layer's own async create — so this is `syncLayers`.
+   */
+  waitAndSyncLayers(layers: GeoLibreLayer[]): void {
+    this.syncLayers(layers);
+  }
+
+  /**
+   * The globe never holds features the store does not: `CesiumLayerSync` builds
+   * its `GeoJsonDataSource`s *from* `layer.geojson`, so there is nothing to read
+   * back that the caller cannot read from the store. Returns the layer's own
+   * collection rather than `null` so callers that only need the features work.
+   */
+  getLayerGeoJson(layerId: string): Promise<FeatureCollection | null> {
+    const layer = useAppStore.getState().layers.find((entry) => entry.id === layerId);
+    return Promise.resolve(layer?.geojson ?? null);
+  }
+
+  getLayerRasterSource(layerId: string): Record<string, unknown> | null {
+    const layer = useAppStore.getState().layers.find((entry) => entry.id === layerId);
+    return layer?.source ? { ...layer.source } : null;
+  }
+
+  // ------------------------------------------------------------------ basemap
+
+  /**
+   * Basemap visibility and opacity are applied by `CesiumCanvas`, which holds
+   * the imagery-layer handles the store's Background row drives. The engine
+   * carries the members so callers stay engine-agnostic.
+   */
+  setBasemapVisible(_visible: boolean): void {}
+
+  setBasemapOpacity(_opacity: number): void {}
+
+  /**
+   * No-op: the globe has no style document. It draws the basemap by translating
+   * the store's `basemapStyleUrl` through `basemapToCesiumImagery()`, so a
+   * basemap change reaches it through the store, not through this call.
+   * Guarded by {@link MapEngineCapabilities.styleSpec}.
+   */
+  setStyle(_url: string): void {}
+
+  /** Empty: there are no style layers to name without a style document. */
+  getBasemapStyleLayerIds(): string[] {
+    return [];
+  }
+
+  setBlankBackgroundColor(_color: string | null): void {}
+
+  // ---------------------------------------------------------- story rendering
+
+  /**
+   * Story playback fades layers through their MapLibre paint properties, which
+   * the globe does not have. `CesiumLayerSync` applies `layer.opacity` on sync,
+   * so a story that writes opacity to the store still fades on the globe.
+   */
+  setStoryLayerOpacity(_layerId: string, _opacity: number, _durationMs?: number): void {}
+
+  restoreLayerStyles(): void {}
+
+  // ------------------------------------------------------------------ picking
+
+  /** Empty until the globe can map a picked primitive back to a feature id. */
+  identifyFeatures(_lngLat: [number, number], _layerId?: string): IdentifiedFeature[] {
+    return [];
+  }
+
+  highlightFeature(
+    _layer: GeoLibreLayer | undefined,
+    _featureId: string | string[] | null,
+    _options: { fit?: boolean } = {},
+  ): void {}
+
+  clearFeatureHighlight(): void {}
+
+  /** Places nothing and returns a no-op teardown; see `onMapDrawing`. */
+  startManualPlacement(_lngLat: [number, number], _options: ManualPlacementOptions): () => void {
+    return () => {};
+  }
+
+  // ----------------------------------------------------------------- controls
+
+  /**
+   * `false`: the globe has nowhere to mount an `IControl` yet. Callers already
+   * read a `false` return as "not available" (it is what a `MapController`
+   * returns before `init`), so plugins fail their activation honestly rather
+   * than reporting success and drawing nothing. The control host is issue #2263.
+   */
+  addControl(_control: maplibregl.IControl, _position?: maplibregl.ControlPosition): boolean {
+    return false;
+  }
+
+  removeControl(_control: maplibregl.IControl): void {}
+
+  setBuiltInControlVisible(_control: BuiltInMapControl, _visible: boolean): boolean {
+    return false;
+  }
+
+  getBuiltInControlPosition(_control: BuiltInMapControl): maplibregl.ControlPosition {
+    return "top-right";
+  }
+
+  setBuiltInControlPosition(
+    _control: BuiltInMapControl,
+    _position: maplibregl.ControlPosition,
+  ): boolean {
+    return false;
+  }
+
+  setCompassLabel(_label: string): void {}
+
+  setBackgroundLabel(_label: string): void {}
+
+  // ------------------------------------------------------------------ terrain
+
+  isTerrainEnabled(): boolean {
+    return this.terrainEnabled;
+  }
+
+  /**
+   * Toggle Cesium World Terrain. Unlike MapLibre — where terrain is a raster-DEM
+   * source added to the style — this swaps the globe's terrain provider, so the
+   * relief is real geometry rather than a displacement of the basemap.
+   *
+   * Returns whether the toggle was accepted; the provider itself loads
+   * asynchronously and is best-effort, matching how `CesiumCanvas` adds terrain
+   * at mount.
+   */
+  setTerrainEnabled(enabled: boolean): boolean {
+    const viewer = this.live();
+    if (!viewer) return false;
+    if (!enabled) {
+      this.terrainEnabled = false;
+      viewer.terrainProvider = new this.Cesium.EllipsoidTerrainProvider();
+      return true;
+    }
+    void this.enableWorldTerrain();
+    return true;
+  }
+
+  /**
+   * Await-able form of `setTerrainEnabled(true)`, for the mount path.
+   *
+   * `CesiumCanvas` adds world terrain *before* it seeds the camera, because
+   * ground height is what turns MapLibre's zoom into a camera distance — seeding
+   * first would place the first frame against the ellipsoid and rely on the
+   * terrain correction to fix it. The interface form cannot express that (it
+   * returns `boolean`), so the mount path calls this and the interface delegates
+   * to it fire-and-forget.
+   */
+  async enableWorldTerrain(): Promise<void> {
+    this.terrainEnabled = true;
+    try {
+      const provider = await this.Cesium.createWorldTerrainAsync();
+      const viewer = this.live();
+      // The toggle may have been reversed, or the viewer destroyed, while the
+      // provider loaded; applying it then would resurrect terrain the user just
+      // turned off.
+      if (viewer && this.terrainEnabled) viewer.terrainProvider = provider;
+    } catch {
+      // Terrain is best-effort; the globe still renders without it.
+    }
+  }
+
+  getTerrainExaggeration(): number {
+    return this.terrainExaggeration;
+  }
+
+  setTerrainExaggeration(exaggeration: number): void {
+    const viewer = this.live();
+    this.terrainExaggeration = exaggeration;
+    if (viewer) viewer.scene.verticalExaggeration = exaggeration;
+  }
+
+  /** Cesium World Terrain is the only source the globe offers today. */
+  getTerrainCogSource(): string | null {
+    return null;
+  }
+
+  hasCustomTerrainSource(): boolean {
+    return false;
+  }
+
+  setTerrainCogSource(_source: string | Blob | null, _band = 1): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  setTerrainLabel(_label: string): void {}
+
+  // ------------------------------------------------------------------- escape
+
+  /** Always `null`: there is no MapLibre map behind the globe. */
+  getMap(): maplibregl.Map | null {
+    return null;
+  }
+
+  // ------------------------------------------------------------------ internal
+
+  /**
+   * Flag the camera move that follows as user-driven, so the `moveEnd` handler
+   * marks the project dirty.
+   *
+   * Cesium's `moveEnd` cannot tell a menu click from a terrain settle, and the
+   * only signal the canvas ever had was raw pointer/wheel/touch input. A caller
+   * that drives the camera through this engine — View → Zoom in, a shortcut, a
+   * panel's "fly to" — *is* the user, so it has to raise the same flag their
+   * scroll wheel would. Without this, menu-driven camera changes would sync to
+   * the store but silently leave the project clean.
+   */
+  private markUserDriven(): void {
+    this.userMoved = true;
+    this.userOwnsCamera = true;
+  }
+
+  /** Animate the camera to `view`, defaulting to a user-driven, dirtying move. */
+  private animateTo(
+    view: MapViewState,
+    options: { userDriven?: boolean; seconds?: number } = {},
+  ): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    if (options.userDriven ?? true) this.markUserDriven();
+    // Cesium has no "ease to a MapLibre view" primitive, so the flight is
+    // expressed the same way applyView expresses a placement — a lookAt in the
+    // target's local frame — with `flyTo`'s duration doing the animating.
+    const [lng, lat] = view.center;
+    const ground = groundHeightAt(this.Cesium, viewer, lng, lat);
+    const range = Math.max(
+      zoomToRange(view.zoom, lat, canvasHeight(viewer), cameraFovy(viewer)),
+      1,
+    );
+    viewer.camera.flyToBoundingSphere(
+      new this.Cesium.BoundingSphere(
+        this.Cesium.Cartesian3.fromDegrees(lng, lat, ground),
+        // A zero-radius sphere makes `offset.range` the whole distance, so the
+        // arrival matches what applyView would have produced for this zoom.
+        0,
+      ),
+      {
+        // Same conversions applyMapViewToCamera uses, so an animated arrival and
+        // an instant apply of the same view land in identical orientations.
+        offset: new this.Cesium.HeadingPitchRange(
+          this.Cesium.Math.toRadians(normalizeBearing(view.bearing)),
+          this.Cesium.Math.toRadians(mapLibrePitchToCesiumDeg(view.pitch)),
+          range,
+        ),
+        duration: options.seconds ?? CAMERA_FLIGHT_SECONDS,
+      },
+    );
+  }
+
+  /**
+   * Flag genuine camera-moving input on the globe so the `moveEnd` handler can
+   * tell a real move from an autonomous settle. Only motion events count:
+   * Cesium's `moveEnd` fires solely on actual camera movement, so a plain
+   * click/tap that doesn't move the camera must NOT arm the flag — otherwise a
+   * later autonomous settle (terrain, resize) would consume that stale flag and
+   * dirty the project. A hover isn't a move either, so `pointermove` only counts
+   * while a button is down.
+   */
+  private installInputTracking(): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    const canvas = viewer.canvas;
+    const markMove = () => this.markUserDriven();
+    const markDrag = (event: PointerEvent) => {
+      if (event.buttons !== 0) this.markUserDriven();
+    };
+    const opts: AddEventListenerOptions = { passive: true };
+    canvas.addEventListener("pointermove", markDrag, opts);
+    canvas.addEventListener("wheel", markMove, opts);
+    canvas.addEventListener("touchmove", markMove, opts);
+    this.disposers.push(() => {
+      canvas.removeEventListener("pointermove", markDrag, opts);
+      canvas.removeEventListener("wheel", markMove, opts);
+      canvas.removeEventListener("touchmove", markMove, opts);
+    });
+  }
+
+  /**
+   * Re-apply the last placement once terrain settles at a different height.
+   *
+   * Terrain arrives after the camera is placed, and the ground height is what
+   * turns MapLibre's zoom into a camera distance. Until the tiles for the view
+   * land, `groundHeightAt` reports 0 and the camera is positioned against the
+   * ellipsoid — over Las Vegas that renders ~2x too close at zoom 15. The guard
+   * makes this a no-op without terrain (height stays 0) and stops it recursing:
+   * the re-apply's own load settles at the same height.
+   *
+   * It corrects a *programmatic* placement only. Navigating loads finer terrain,
+   * which drains the queue at a new height mid-gesture; without the
+   * `userOwnsCamera` guard that re-applied the last settled view and yanked the
+   * camera back, so a wheel zoom over terrain snapped straight back to where it
+   * started and the store never saw the move (the yank's own `moveEnd` read as
+   * the suppressed echo). Once the user is driving, their camera is
+   * authoritative and Cesium's own navigation already keeps it above terrain.
+   */
+  private installTerrainCorrection(): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    const onTileLoad = (queued: number) => {
+      const live = this.live();
+      const view = this.lastApplied;
+      if (queued > 0 || !live || !view) return;
+      if (this.userOwnsCamera) return;
+      const height = groundHeightAt(this.Cesium, live, view.center[0], view.center[1]);
+      if (Math.abs(height - this.lastGroundHeight) < 1) return;
+      this.applyView(view);
+    };
+    viewer.scene.globe.tileLoadProgressEvent.addEventListener(onTileLoad);
+    this.disposers.push(() => {
+      const live = this.live();
+      live?.scene.globe?.tileLoadProgressEvent.removeEventListener(onTileLoad);
+    });
+  }
+
+  /**
+   * Mirror the globe's camera back into the shared store. Echoes of our own
+   * {@link applyView} are filtered by the `isSameView` guard.
+   */
+  private installCameraPublisher(): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    const onMoveEnd = () => {
+      const live = this.live();
+      if (!live) return;
+      // Nothing to publish until the camera has been seeded. A fresh
+      // CesiumWidget starts on its own default camera and settles onto it, which
+      // fires moveEnd before `CesiumCanvas` has applied the project's view —
+      // with no `lastApplied` to recognize it by, that settle would look like a
+      // real move and overwrite the stored camera with Cesium's default. The
+      // listener is armed in the constructor (so it cannot miss a move) rather
+      // than after the seed, so the guard lives here.
+      if (!this.lastApplied) return;
+      const view = readMapViewFromCamera(this.Cesium, live);
+      if (isSameView(view, this.lastApplied)) return;
+      this.lastApplied = view;
+      // Only the moves that follow real user input dirty the project; an
+      // autonomous settle still syncs the camera (markDirty=false) so the panes
+      // stay in step without flipping isDirty on a freshly opened project.
+      const userDriven = this.userMoved;
+      this.userMoved = false;
+      const store = useAppStore.getState();
+      // Write only when the view actually differs from the stored camera:
+      // `setMapView` has no same-camera guard in the store, and
+      // `setSecondaryMapView`'s guard uses exact equality (which Cesium's lossy
+      // readback never hits), so both are gated here with isSameView.
+      if (this.isPrimary) {
+        // The primary globe owns `mapView` outright (there is no pane record to
+        // mirror into), so it writes regardless of the `syncView` toggle — that
+        // toggle governs the secondary panes, and the primary map is the camera
+        // they follow.
+        if (!isSameView(view, store.mapView)) store.setMapView(view, userDriven);
+        return;
+      }
+      if (store.mapLayout.syncView && !isSameView(view, store.mapView)) {
+        store.setMapView(view, userDriven);
+      }
+      const paneId = this.viewId;
+      if (paneId === undefined) return;
+      const paneView = store.secondaryMapViews.find((pane) => pane.id === paneId)?.view;
+      if (!paneView || !isSameView(view, paneView)) {
+        store.setSecondaryMapView(paneId, view, userDriven);
+      }
+    };
+    viewer.camera.moveEnd.addEventListener(onMoveEnd);
+    this.disposers.push(() => {
+      const live = this.live();
+      live?.camera.moveEnd.removeEventListener(onMoveEnd);
+    });
+  }
+
+  /**
+   * The view last pushed into or read from the camera, for the canvas's own echo
+   * guard. `CesiumCanvas` compares a store change against this before applying
+   * it, so a view the globe itself just published is not re-applied.
+   */
+  getLastAppliedView(): MapViewState | null {
+    return this.lastApplied;
+  }
+}

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -67,6 +67,15 @@ export const CESIUM_CAPABILITIES: MapEngineCapabilities = Object.freeze({
   domControls: false,
 });
 
+/**
+ * Coerce a preference zoom into MapLibre's [0, 24] range, falling back to
+ * `fallback` for a non-finite value. Mirrors `clampNumber` in `map-controller.ts`.
+ */
+function clampZoom(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(24, Math.max(0, value));
+}
+
 /** Seconds a menu-driven camera move takes on the globe. */
 const CAMERA_FLIGHT_SECONDS = 0.5;
 /** Zoom floor when framing a point-sized extent; matches MapController.fitBounds. */
@@ -136,6 +145,21 @@ export class CesiumEngine implements MapEngine {
    * terrain correction from fighting live navigation.
    */
   private userOwnsCamera = false;
+
+  /**
+   * Zoom bounds from the project's `MapPreferences`, in MapLibre zoom levels.
+   *
+   * MapLibre enforces these for free: `setMinZoom`/`setMaxZoom` clamp every
+   * camera operation, so `MapController.zoomIn()` cannot walk past the
+   * project's `maxZoom`. Cesium has no equivalent — its
+   * `screenSpaceCameraController` distance limits govern interactive navigation
+   * only, not a programmatic `flyToBoundingSphere` — so the engine has to clamp
+   * the target zoom itself or the two renderers disagree on the same click
+   * (#2265 review). Defaults span MapLibre's full range until preferences
+   * arrive.
+   */
+  private minZoom = 0;
+  private maxZoom = 24;
 
   private terrainEnabled = false;
   private terrainExaggeration = 1;
@@ -235,7 +259,7 @@ export class CesiumEngine implements MapEngine {
 
   zoomOut(): void {
     const view = this.readView();
-    this.animateTo({ ...view, zoom: Math.max(view.zoom - 1, 0) });
+    this.animateTo({ ...view, zoom: view.zoom - 1 });
   }
 
   resetNorth(): void {
@@ -314,6 +338,12 @@ export class CesiumEngine implements MapEngine {
     const latDeg = this.Cesium.Math.toDegrees(latitude);
     const height = canvasHeight(viewer);
     const fovy = cameraFovy(viewer);
+    // Remember the bounds so programmatic moves clamp to them the way
+    // MapLibre's setMinZoom/setMaxZoom clamp its own camera API. Same coercion
+    // as MapController.applyMapPreferences, including maxZoom never falling
+    // below minZoom.
+    this.minZoom = clampZoom(preferences.minZoom, 0);
+    this.maxZoom = Math.max(this.minZoom, clampZoom(preferences.maxZoom, 24));
     const controller = viewer.scene.screenSpaceCameraController;
     if (Number.isFinite(preferences.maxZoom)) {
       controller.minimumZoomDistance = Math.max(
@@ -568,10 +598,11 @@ export class CesiumEngine implements MapEngine {
     // target's local frame — with `flyTo`'s duration doing the animating.
     const [lng, lat] = view.center;
     const ground = groundHeightAt(this.Cesium, viewer, lng, lat);
-    const range = Math.max(
-      zoomToRange(view.zoom, lat, canvasHeight(viewer), cameraFovy(viewer)),
-      1,
-    );
+    // Every programmatic camera move funnels through here, so this is where the
+    // project's zoom bounds are enforced — the counterpart to MapLibre clamping
+    // inside its own camera API.
+    const zoom = Math.min(this.maxZoom, Math.max(this.minZoom, view.zoom));
+    const range = Math.max(zoomToRange(zoom, lat, canvasHeight(viewer), cameraFovy(viewer)), 1);
     viewer.camera.flyToBoundingSphere(
       new this.Cesium.BoundingSphere(
         this.Cesium.Cartesian3.fromDegrees(lng, lat, ground),

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -18,8 +18,11 @@ export { PANEL_RESIZE_END_EVENT, PANEL_RESIZE_START_EVENT } from "./map-resize";
 export { SecondaryMapCanvas, type SecondaryMapCanvasProps } from "./SecondaryMapCanvas";
 export { CesiumCanvas, type CesiumCanvasProps } from "./CesiumCanvas";
 export { isCesiumSupportedLayerType } from "./cesium-layer-sync";
+export { CESIUM_CAPABILITIES, CesiumEngine, type CesiumEngineOptions } from "./cesium-engine";
 export {
   applyMapViewToCamera,
+  cameraFovy,
+  canvasHeight,
   cesiumPitchToMapLibreDeg,
   groundResolution,
   isSameView,

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -110,6 +110,10 @@ function makeEvent() {
  * wheel, and touch input the engine listens for.
  */
 function makeViewer(groundHeight = 0) {
+  // Mutable so a test can make terrain *arrive* — a fixed height means the
+  // correction's own guard exits before re-applying and the assertion passes
+  // whether or not it ran.
+  let height = groundHeight;
   const moveEnd = makeEvent();
   const tileLoadProgressEvent = makeEvent();
   const canvasListeners = new Map<string, Set<(event: unknown) => void>>();
@@ -127,6 +131,7 @@ function makeViewer(groundHeight = 0) {
     },
   };
   const state = { lng: 0, lat: 0, range: 1000, heading: 0, pitch: -Math.PI / 2 };
+  const lookAtCount = { n: 0 };
   const viewer = {
     isDestroyed: () => false,
     canvas,
@@ -148,6 +153,7 @@ function makeViewer(groundHeight = 0) {
       moveEnd,
       // applyMapViewToCamera drives these; the fake records the resulting view.
       lookAt: (target: { x: number; y: number; z: number }, hpr: HprLike) => {
+        lookAtCount.n++;
         state.lng = target.x;
         state.lat = target.y;
         state.range = hpr.range;
@@ -181,7 +187,7 @@ function makeViewer(groundHeight = 0) {
       globe: {
         ellipsoid: { name: "wgs84" },
         tileLoadProgressEvent,
-        getHeight: () => groundHeight,
+        getHeight: () => height,
         pick: () => ({ x: state.lng, y: state.lat, z: 0 }),
       },
     },
@@ -213,6 +219,14 @@ function makeViewer(groundHeight = 0) {
     },
     fireCanvas(type: string, event: unknown = {}) {
       for (const fn of canvasListeners.get(type) ?? []) fn(event);
+    },
+    /** Simulate terrain tiles arriving and raising the ground. */
+    setGroundHeight(next: number) {
+      height = next;
+    },
+    /** How many times the camera has been placed by applyMapViewToCamera. */
+    get placements() {
+      return lookAtCount.n;
     },
   };
 }
@@ -321,18 +335,18 @@ describe("CesiumEngine camera publishing", () => {
     engine.destroy();
   });
 
-  it("marks a menu-driven camera move dirty, like the user's own scroll", () => {
-    // The reason the state machine had to move out of the component: a caller
-    // driving the camera through the engine *is* the user, so View → Zoom in has
-    // to dirty the project. Before the extraction there was no way to say so and
-    // the move would have synced but left the project clean.
+  it("syncs a menu-driven camera move without dirtying, matching the 2D map", () => {
+    // MapController drives MapLibre's own camera API with no `eventData`, so the
+    // resulting moveend has no `originalEvent` and MapCanvas publishes it with
+    // markDirty=false. The globe has to agree: identical clicks must not behave
+    // differently depending on which renderer is drawing (#2265 review).
     const fakes = makeViewer();
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     engine.applyView(VIEW);
     engine.zoomIn();
     fakes.moveEnd.emit();
-    assert.equal(writes.length, 1);
-    assert.equal(writes[0]?.markDirty, true);
+    assert.equal(writes.length, 1, "the camera still syncs");
+    assert.equal(writes[0]?.markDirty, false, "but it must not flag unsaved changes");
     engine.destroy();
   });
 
@@ -398,26 +412,32 @@ describe("CesiumEngine terrain correction", () => {
   it("re-applies the placement once terrain settles at a different height", () => {
     // The camera was placed against the ellipsoid because terrain had not
     // loaded; when it does, the same view has to be re-applied against the real
-    // ground or the globe renders too close.
-    const fakes = makeViewer(1200);
+    // ground or the globe renders too close. The ground must actually *change*
+    // for this to mean anything — with a fixed height the correction's own guard
+    // exits first and the test passes vacuously (#2265 review).
+    const fakes = makeViewer(0);
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     engine.applyView({ ...VIEW, center: [10, 20] });
-    const before = engine.getLastAppliedView();
+    const placementsAfterSeed = fakes.placements;
+    const seeded = engine.getLastAppliedView();
+    // Terrain tiles arrive and raise the ground under the view.
+    fakes.setGroundHeight(1200);
     fakes.nudge(40);
     // queued === 0: the tile queue has drained.
     fakes.tileLoadProgressEvent.emit(0);
-    assert.deepEqual(engine.getLastAppliedView(), before, "must re-apply the same view");
+    assert.equal(fakes.placements, placementsAfterSeed + 1, "the camera must be re-placed");
+    assert.deepEqual(engine.getLastAppliedView(), seeded, "re-applied as the same view");
     engine.destroy();
   });
 
   it("leaves the camera alone while tiles are still loading", () => {
-    const fakes = makeViewer(1200);
+    const fakes = makeViewer(0);
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     engine.applyView(VIEW);
-    fakes.nudge(40);
-    const moved = engine.readView();
+    const placements = fakes.placements;
+    fakes.setGroundHeight(1200);
     fakes.tileLoadProgressEvent.emit(7);
-    assert.deepEqual(engine.readView(), moved, "a non-empty queue must not re-apply");
+    assert.equal(fakes.placements, placements, "a non-empty queue must not re-apply");
     engine.destroy();
   });
 
@@ -425,14 +445,15 @@ describe("CesiumEngine terrain correction", () => {
     // A wheel zoom over terrain loads finer tiles mid-gesture. Re-applying the
     // last settled view there would snap the camera back to where the gesture
     // started, and the store would never see the move.
-    const fakes = makeViewer(1200);
+    const fakes = makeViewer(0);
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     engine.applyView(VIEW);
+    const placements = fakes.placements;
     fakes.fireCanvas("wheel");
+    fakes.setGroundHeight(1200);
     fakes.nudge(40);
-    const userView = engine.readView();
     fakes.tileLoadProgressEvent.emit(0);
-    assert.deepEqual(engine.readView(), userView, "the user's camera is authoritative");
+    assert.equal(fakes.placements, placements, "the user's camera is authoritative");
     engine.destroy();
   });
 
@@ -507,6 +528,24 @@ describe("CesiumEngine framing", () => {
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     engine.fitBounds([Number.NaN, 0, 10, 5]);
     assert.equal(fakes.flights.length, 0);
+    engine.destroy();
+  });
+
+  it("flies to the point for a degenerate, point-sized extent", () => {
+    // getLayerBounds on a single-point layer returns a zero-area box. Handing
+    // that to Cesium as a Rectangle has no "zoom to fit" and yields a
+    // nonsensical camera distance, so it takes the point path instead — the same
+    // workaround MapController.fitBounds uses (#2265 review).
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.fitBounds([12, 34, 12, 34]);
+    assert.equal(fakes.flights.length, 1);
+    const flight = fakes.flights[0] as {
+      destination?: unknown;
+      sphere?: { center: { x: number } };
+    };
+    assert.equal(flight.destination, undefined, "must not fly to a zero-area rectangle");
+    assert.equal(flight.sphere?.center.x, 12, "flies to the point itself");
     engine.destroy();
   });
 

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -550,6 +550,54 @@ describe("CesiumEngine zoom bounds", () => {
   });
 });
 
+describe("CesiumEngine animation durations", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      setMapView: (() => {}) as never,
+    } as never);
+  });
+
+  const durationOf = (flight: unknown) => (flight as { duration?: number }).duration;
+
+  it("matches the 2D map's 1s orientation resets", () => {
+    // MapLibre's resetNorth/resetNorthPitch animate over 1s and
+    // MapController.resetPitch sets 1000ms explicitly to match them. A 500ms
+    // globe would run the same click at double speed (#2265 review).
+    for (const reset of ["resetNorth", "resetNorthPitch", "resetPitch"] as const) {
+      const fakes = makeViewer();
+      const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+      engine[reset]();
+      assert.equal(durationOf(fakes.flights[0]), 1, `${reset} must animate over 1s`);
+      engine.destroy();
+    }
+  });
+
+  it("matches MapController.flyTo's 800ms default when no duration is given", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.flyTo({ center: [10, 20] });
+    assert.equal(durationOf(fakes.flights[0]), 0.8);
+    engine.destroy();
+  });
+
+  it("honours an explicit duration, converting ms to seconds", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.flyTo({ center: [10, 20], duration: 2500 });
+    assert.equal(durationOf(fakes.flights[0]), 2.5);
+    engine.destroy();
+  });
+
+  it("uses MapLibre's 500ms easeTo default for zoom steps", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.zoomIn();
+    assert.equal(durationOf(fakes.flights[0]), 0.5);
+    engine.destroy();
+  });
+});
+
 describe("CesiumEngine framing", () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -1,0 +1,538 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import { useAppStore } from "../packages/core/src/store";
+import type { MapViewState } from "../packages/core/src/types";
+import { CesiumEngine, CESIUM_CAPABILITIES } from "../packages/map/src/cesium-engine";
+
+// The globe's camera state machine, which moved out of CesiumCanvas's mount
+// effect and into CesiumEngine (issue #2260). It had no coverage while it lived
+// in the component — a React effect full of refs — and it is the part that has
+// to stay exactly right: it decides which camera moves reach the store, which
+// of them mark the project dirty, and when a terrain load may reposition the
+// camera. All three are invisible when they break.
+//
+// The real Cesium engine never loads here (its import in the module under test
+// is type-only), so the namespace and widget are faked. The camera *maths* is
+// real: readMapViewFromCamera and applyMapViewToCamera run against these fakes,
+// so an echo is suppressed by the same tolerance the app uses.
+
+/** A minimal Cesium namespace: just what the camera path touches. */
+function makeCesium() {
+  class Cartesian2 {
+    constructor(
+      public x: number,
+      public y: number,
+    ) {}
+  }
+  class Cartesian3 {
+    constructor(
+      public x: number,
+      public y: number,
+      public z: number,
+    ) {}
+    static fromDegrees(lng: number, lat: number, height = 0) {
+      // Not a real geodetic conversion — just an invertible encoding, so
+      // fromDegrees → fromCartesian round-trips through the fake.
+      return new Cartesian3(lng, lat, height);
+    }
+    static distance(a: { z?: number }, b: { z?: number }) {
+      return Math.abs((a.z ?? 0) - (b.z ?? 0));
+    }
+  }
+  class Cartographic {
+    constructor(
+      public longitude: number,
+      public latitude: number,
+      public height: number,
+    ) {}
+    static fromDegrees(lng: number, lat: number, height = 0) {
+      return new Cartographic(toRad(lng), toRad(lat), height);
+    }
+    static fromCartesian(c: { x: number; y: number; z: number }) {
+      return new Cartographic(toRad(c.x), toRad(c.y), c.z);
+    }
+  }
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  class HeadingPitchRange {
+    constructor(
+      public heading: number,
+      public pitch: number,
+      public range: number,
+    ) {}
+  }
+  class BoundingSphere {
+    constructor(
+      public center: unknown,
+      public radius: number,
+    ) {}
+  }
+  return {
+    Cartesian2,
+    Cartesian3,
+    Cartographic,
+    HeadingPitchRange,
+    BoundingSphere,
+    Ellipsoid: { WGS84: { name: "wgs84" } },
+    Matrix4: { IDENTITY: "identity" },
+    Rectangle: {
+      fromDegrees: (w: number, s: number, e: number, n: number) => ({ w, s, e, n }),
+    },
+    EllipsoidTerrainProvider: class {
+      readonly kind = "ellipsoid";
+    },
+    Math: {
+      toRadians: toRad,
+      toDegrees: (rad: number) => (rad * 180) / Math.PI,
+    },
+    createWorldTerrainAsync: () => Promise.resolve({ kind: "world-terrain" }),
+  } as unknown as typeof import("@cesium/engine");
+}
+
+/** A tiny stand-in for Cesium's Event (addEventListener/removeEventListener). */
+function makeEvent() {
+  const listeners = new Set<(...args: never[]) => void>();
+  return {
+    addEventListener: (fn: (...args: never[]) => void) => listeners.add(fn),
+    removeEventListener: (fn: (...args: never[]) => void) => listeners.delete(fn),
+    emit: (...args: unknown[]) => {
+      for (const fn of [...listeners]) (fn as (...a: unknown[]) => void)(...args);
+    },
+    get size() {
+      return listeners.size;
+    },
+  };
+}
+
+/**
+ * A fake CesiumWidget whose camera can be moved directly. `nudge` is how a test
+ * says "the camera is somewhere else now", standing in for whatever Cesium's own
+ * navigation would have done, and `fireCanvas` stands in for the raw pointer,
+ * wheel, and touch input the engine listens for.
+ */
+function makeViewer(groundHeight = 0) {
+  const moveEnd = makeEvent();
+  const tileLoadProgressEvent = makeEvent();
+  const canvasListeners = new Map<string, Set<(event: unknown) => void>>();
+  const canvas = {
+    clientWidth: 800,
+    clientHeight: 600,
+    width: 800,
+    height: 600,
+    addEventListener: (type: string, fn: (event: unknown) => void) => {
+      if (!canvasListeners.has(type)) canvasListeners.set(type, new Set());
+      canvasListeners.get(type)?.add(fn);
+    },
+    removeEventListener: (type: string, fn: (event: unknown) => void) => {
+      canvasListeners.get(type)?.delete(fn);
+    },
+  };
+  const state = { lng: 0, lat: 0, range: 1000, heading: 0, pitch: -Math.PI / 2 };
+  const viewer = {
+    isDestroyed: () => false,
+    canvas,
+    terrainProvider: { kind: "initial" } as unknown,
+    camera: {
+      get positionWC() {
+        return { x: state.lng, y: state.lat, z: state.range };
+      },
+      get positionCartographic() {
+        return { longitude: 0, latitude: 0, height: state.range };
+      },
+      get heading() {
+        return state.heading;
+      },
+      get pitch() {
+        return state.pitch;
+      },
+      frustum: { fovy: Math.PI / 3 },
+      moveEnd,
+      // applyMapViewToCamera drives these; the fake records the resulting view.
+      lookAt: (target: { x: number; y: number; z: number }, hpr: HprLike) => {
+        state.lng = target.x;
+        state.lat = target.y;
+        state.range = hpr.range;
+        state.heading = hpr.heading;
+        state.pitch = hpr.pitch;
+      },
+      lookAtTransform: () => {},
+      flyTo: (options: { destination?: unknown; duration?: number }) => {
+        flights.push(options);
+      },
+      flyToBoundingSphere: (sphere: { center: CenterLike }, options: FlightOptions) => {
+        flights.push({ sphere, ...options });
+        // Cesium lands the camera at the requested pose; the fake does it
+        // instantly so a following moveEnd reads the destination back.
+        state.lng = sphere.center.x;
+        state.lat = sphere.center.y;
+        state.range = options.offset.range;
+        state.heading = options.offset.heading;
+        state.pitch = options.offset.pitch;
+      },
+      getPickRay: () => ({ ray: true }),
+      pickEllipsoid: () => ({ x: state.lng, y: state.lat, z: 0 }),
+    },
+    scene: {
+      canvas,
+      verticalExaggeration: 1,
+      screenSpaceCameraController: {
+        minimumZoomDistance: 0,
+        maximumZoomDistance: Infinity,
+      },
+      globe: {
+        ellipsoid: { name: "wgs84" },
+        tileLoadProgressEvent,
+        getHeight: () => groundHeight,
+        pick: () => ({ x: state.lng, y: state.lat, z: 0 }),
+      },
+    },
+  };
+  const flights: unknown[] = [];
+  interface HprLike {
+    heading: number;
+    pitch: number;
+    range: number;
+  }
+  interface CenterLike {
+    x: number;
+    y: number;
+    z: number;
+  }
+  interface FlightOptions {
+    offset: HprLike;
+    duration?: number;
+  }
+  return {
+    viewer: viewer as never,
+    moveEnd,
+    tileLoadProgressEvent,
+    flights,
+    canvasListeners,
+    /** Nudge the camera as if the user had navigated there. */
+    nudge(deltaLng: number) {
+      state.lng += deltaLng;
+    },
+    fireCanvas(type: string, event: unknown = {}) {
+      for (const fn of canvasListeners.get(type) ?? []) fn(event);
+    },
+  };
+}
+
+const VIEW: MapViewState = { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 };
+
+describe("CesiumEngine capabilities", () => {
+  it("declares the globe's real surface, and freezes it", () => {
+    assert.equal(CESIUM_CAPABILITIES.terrain, true);
+    assert.equal(CESIUM_CAPABILITIES.styleSpec, false);
+    assert.equal(CESIUM_CAPABILITIES.nativeMapInstance, false);
+    assert.ok(Object.isFrozen(CESIUM_CAPABILITIES));
+  });
+
+  it("reports no MapLibre map and refuses controls, rather than pretending", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    assert.equal(engine.getMap(), null);
+    // `false` is what callers already read as "not available" — a `true` here
+    // would let a plugin activate and silently draw nothing.
+    assert.equal(engine.addControl({} as never), false);
+    assert.equal(engine.kind, "cesium");
+    engine.destroy();
+  });
+});
+
+describe("CesiumEngine camera publishing", () => {
+  let writes: Array<{ view: MapViewState; markDirty: boolean }>;
+
+  beforeEach(() => {
+    writes = [];
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      setMapView: ((view: MapViewState, markDirty = false) => {
+        writes.push({ view, markDirty });
+      }) as never,
+    } as never);
+  });
+
+  it("suppresses the echo of its own applyView", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    // Applying a view is what fires Cesium's moveEnd in the real engine.
+    fakes.moveEnd.emit();
+    assert.equal(writes.length, 0, "an applied view must not be published back");
+    engine.destroy();
+  });
+
+  it("does not publish the widget's startup camera before the view is seeded", () => {
+    // Regression: a fresh CesiumWidget settles onto its own default camera and
+    // fires moveEnd before CesiumCanvas applies the project's view. Publishing
+    // that overwrites the stored camera with Cesium's default — the project
+    // opens somewhere the user never chose, and switching 2D→3D→2D loses the
+    // view. Caught by driving the real app, not by the suite.
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    // No applyView yet: this is the window between construction and the seed.
+    fakes.nudge(25);
+    fakes.moveEnd.emit();
+    assert.equal(writes.length, 0, "an unseeded globe must not publish a camera");
+    // Once seeded, publishing resumes normally.
+    engine.applyView(VIEW);
+    fakes.fireCanvas("wheel");
+    fakes.nudge(25);
+    fakes.moveEnd.emit();
+    assert.equal(writes.length, 1);
+    engine.destroy();
+  });
+
+  it("publishes a user's own navigation and marks the project dirty", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    fakes.fireCanvas("wheel");
+    fakes.nudge(25);
+    fakes.moveEnd.emit();
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0]?.markDirty, true);
+    engine.destroy();
+  });
+
+  it("publishes an autonomous settle without dirtying the project", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    // No input event: a container resize or a terrain settle moved the camera.
+    fakes.nudge(25);
+    fakes.moveEnd.emit();
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0]?.markDirty, false);
+    engine.destroy();
+  });
+
+  it("ignores a hover, which is not a camera move", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    // buttons === 0: the pointer is moving but nothing is being dragged. Arming
+    // the flag here would let a later autonomous settle consume it and dirty the
+    // project.
+    fakes.fireCanvas("pointermove", { buttons: 0 });
+    fakes.nudge(25);
+    fakes.moveEnd.emit();
+    assert.equal(writes[0]?.markDirty, false);
+    engine.destroy();
+  });
+
+  it("marks a menu-driven camera move dirty, like the user's own scroll", () => {
+    // The reason the state machine had to move out of the component: a caller
+    // driving the camera through the engine *is* the user, so View → Zoom in has
+    // to dirty the project. Before the extraction there was no way to say so and
+    // the move would have synced but left the project clean.
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    engine.zoomIn();
+    fakes.moveEnd.emit();
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0]?.markDirty, true);
+    engine.destroy();
+  });
+
+  it("does not dirty the project for a scripted story camera", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    engine.applyStoryChapterCamera({ center: [30, 10], zoom: 8, bearing: 0, pitch: 0 });
+    fakes.moveEnd.emit();
+    assert.equal(writes.at(-1)?.markDirty, false);
+    engine.destroy();
+  });
+
+  it("stops publishing once destroyed", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    engine.destroy();
+    assert.equal(fakes.moveEnd.size, 0, "moveEnd listener must be removed");
+    fakes.nudge(25);
+    fakes.moveEnd.emit();
+    assert.equal(writes.length, 0);
+  });
+});
+
+describe("CesiumEngine pane publishing", () => {
+  it("writes a pane's own camera rather than the shared one", () => {
+    const paneWrites: Array<{ id: string; markDirty: boolean }> = [];
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      mapLayout: { rows: 1, cols: 2, syncView: false },
+      secondaryMapViews: [
+        { id: "pane-1", view: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 } },
+      ],
+      setMapView: (() => assert.fail("an unsynced pane must not write mapView")) as never,
+      setSecondaryMapView: ((id: string, _view: MapViewState, markDirty = false) => {
+        paneWrites.push({ id, markDirty });
+      }) as never,
+    } as never);
+
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer, { viewId: "pane-1" });
+    engine.applyView(VIEW);
+    fakes.fireCanvas("wheel");
+    fakes.nudge(25);
+    fakes.moveEnd.emit();
+
+    assert.equal(paneWrites.length, 1);
+    assert.equal(paneWrites[0]?.id, "pane-1");
+    assert.equal(paneWrites[0]?.markDirty, true);
+    engine.destroy();
+  });
+});
+
+describe("CesiumEngine terrain correction", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      setMapView: (() => {}) as never,
+    } as never);
+  });
+
+  it("re-applies the placement once terrain settles at a different height", () => {
+    // The camera was placed against the ellipsoid because terrain had not
+    // loaded; when it does, the same view has to be re-applied against the real
+    // ground or the globe renders too close.
+    const fakes = makeViewer(1200);
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView({ ...VIEW, center: [10, 20] });
+    const before = engine.getLastAppliedView();
+    fakes.nudge(40);
+    // queued === 0: the tile queue has drained.
+    fakes.tileLoadProgressEvent.emit(0);
+    assert.deepEqual(engine.getLastAppliedView(), before, "must re-apply the same view");
+    engine.destroy();
+  });
+
+  it("leaves the camera alone while tiles are still loading", () => {
+    const fakes = makeViewer(1200);
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    fakes.nudge(40);
+    const moved = engine.readView();
+    fakes.tileLoadProgressEvent.emit(7);
+    assert.deepEqual(engine.readView(), moved, "a non-empty queue must not re-apply");
+    engine.destroy();
+  });
+
+  it("never yanks a camera the user is driving", () => {
+    // A wheel zoom over terrain loads finer tiles mid-gesture. Re-applying the
+    // last settled view there would snap the camera back to where the gesture
+    // started, and the store would never see the move.
+    const fakes = makeViewer(1200);
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    fakes.fireCanvas("wheel");
+    fakes.nudge(40);
+    const userView = engine.readView();
+    fakes.tileLoadProgressEvent.emit(0);
+    assert.deepEqual(engine.readView(), userView, "the user's camera is authoritative");
+    engine.destroy();
+  });
+
+  it("drops the tile listener on destroy", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.destroy();
+    assert.equal(fakes.tileLoadProgressEvent.size, 0);
+  });
+});
+
+describe("CesiumEngine terrain", () => {
+  it("swaps in world terrain and reports it enabled", async () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    assert.equal(engine.isTerrainEnabled(), false);
+    await engine.enableWorldTerrain();
+    assert.equal(engine.isTerrainEnabled(), true);
+    assert.deepEqual(fakes.viewer.terrainProvider, { kind: "world-terrain" });
+    engine.destroy();
+  });
+
+  it("does not resurrect terrain the user turned off mid-load", async () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    const pending = engine.enableWorldTerrain();
+    engine.setTerrainEnabled(false);
+    await pending;
+    assert.equal(engine.isTerrainEnabled(), false);
+    assert.equal(
+      (fakes.viewer.terrainProvider as { kind?: string }).kind,
+      "ellipsoid",
+      "the disable must win over the in-flight load",
+    );
+    engine.destroy();
+  });
+
+  it("applies vertical exaggeration to the scene", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.setTerrainExaggeration(2.5);
+    assert.equal(engine.getTerrainExaggeration(), 2.5);
+    assert.equal(fakes.viewer.scene.verticalExaggeration, 2.5);
+    engine.destroy();
+  });
+});
+
+describe("CesiumEngine framing", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      setMapView: (() => {}) as never,
+    } as never);
+  });
+
+  it("flies to a rectangle for fitBounds", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.fitBounds([-10, -5, 10, 5]);
+    assert.equal(fakes.flights.length, 1);
+    assert.deepEqual((fakes.flights[0] as { destination: unknown }).destination, {
+      w: -10,
+      s: -5,
+      e: 10,
+      n: 5,
+    });
+    engine.destroy();
+  });
+
+  it("ignores a non-finite extent instead of flying to NaN", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.fitBounds([Number.NaN, 0, 10, 5]);
+    assert.equal(fakes.flights.length, 0);
+    engine.destroy();
+  });
+
+  it("frames a layer's own extent", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.fitLayer({
+      id: "l1",
+      name: "pts",
+      type: "geojson",
+      visible: true,
+      opacity: 1,
+      source: {},
+      metadata: {},
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [4, 8] },
+          },
+        ],
+      },
+    } as never);
+    assert.equal(fakes.flights.length, 1);
+    engine.destroy();
+  });
+});

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -501,6 +501,55 @@ describe("CesiumEngine terrain", () => {
   });
 });
 
+describe("CesiumEngine zoom bounds", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      setMapView: (() => {}) as never,
+    } as never);
+  });
+
+  const prefs = (minZoom: number, maxZoom: number) =>
+    ({ minZoom, maxZoom, maxPitch: 85, renderWorldCopies: true }) as never;
+
+  it("does not zoom past the project's maxZoom", () => {
+    // MapLibre gets this for free: setMaxZoom clamps its whole camera API, so
+    // MapController.zoomIn() cannot walk past the preference. Cesium's
+    // screenSpaceCameraController limits govern interactive navigation only, so
+    // the engine has to clamp the target itself or the same click behaves
+    // differently per renderer (#2265 review).
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyMapPreferences(prefs(0, 6));
+    engine.applyView({ ...VIEW, zoom: 6 });
+    engine.zoomIn();
+    assert.ok(engine.readView().zoom <= 6.001, `zoom ran past maxZoom: ${engine.readView().zoom}`);
+    engine.destroy();
+  });
+
+  it("does not zoom below the project's minZoom", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyMapPreferences(prefs(3, 24));
+    engine.applyView({ ...VIEW, zoom: 3 });
+    engine.zoomOut();
+    assert.ok(
+      engine.readView().zoom >= 2.999,
+      `zoom fell below minZoom: ${engine.readView().zoom}`,
+    );
+    engine.destroy();
+  });
+
+  it("keeps MapLibre's full range until preferences arrive", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView({ ...VIEW, zoom: 4 });
+    engine.zoomIn();
+    assert.ok(engine.readView().zoom > 4.5, "an unconfigured project must still zoom");
+    engine.destroy();
+  });
+});
+
 describe("CesiumEngine framing", () => {
   beforeEach(() => {
     useAppStore.setState({


### PR DESCRIPTION
Second step of #2260, on top of the `MapEngine` interface extracted in #2264. Part of #2259.

## What's here

`CesiumEngine implements MapEngine` over an existing `CesiumWidget`, and the globe's **camera state machine moves out of `CesiumCanvas`'s mount effect into it**.

That move is the point of the change, not a tidy-up. A caller running `zoomIn()` has to land in the same echo-suppression, terrain-correction, and publishing logic as a user's own scroll. Cesium's `moveEnd` carries no user-driven flag (unlike MapLibre's `moveend.originalEvent`), so a second, independent camera owner would have fought the canvas's state machine — re-applying stale views mid-gesture and mis-attributing autonomous settles.

`CesiumCanvas` keeps the widget's async lifecycle (lazy `import()`, the cancellation dance, the container) and delegates the rest. Same split as `MapCanvas`/`MapController`, minus `init` — construction is the one thing the engines legitimately do differently, which is why `MapEngine` doesn't declare it.

Net effect on the component: **-148 lines**, and the four hand-rolled refs (`lastAppliedRef`, `lastGroundHeightRef`, `userMovedRef`, `userOwnsCameraRef`) are gone.

## Capabilities, declared honestly

`terrain: true` — native on the globe, and better than MapLibre's raster-DEM displacement. The old `primaryRenderer === "cesium"` gates disabled it anyway.

`styleSpec`, `nativeMapInstance`, `customLayers`, `picking`, `onMapDrawing`, `domControls` are `false`, and the module documents why each is a **real absence** rather than unfinished work. In particular `picking` stays false because `identifyFeatures` needs a mapping from a picked primitive back to a layer/feature id that `CesiumLayerSync` doesn't record — claiming it early would make Identify report "no features here" instead of "not available". `addControl` returns `false` so a plugin fails activation honestly rather than reporting success and drawing nothing (the control host is #2263).

## A bug the browser caught that the suite didn't

Driving the real app surfaced a regression this PR introduced. Moving the listeners into the constructor arms `moveEnd` **before** `CesiumCanvas` seeds the camera — and a fresh `CesiumWidget` settles onto its own default camera first. With no `lastApplied` to recognise it by, that settle looked like a real move and published Cesium's default over the project's stored view: switching 2D→3D→2D lost the camera.

Fixed by bailing out of the publisher while `lastApplied` is null, with a regression test. The listener stays armed in the constructor (so it cannot miss a move) and the guard lives in the handler.

## Verification

Unit: **21 new tests** covering the state machine, which had **no coverage** while it lived in a React effect — echo suppression, user-driven vs. autonomous settles, the hover that is not a move, menu-driven dirtying, scripted story cameras, pane vs. primary publishing, listener teardown, the terrain correction's three branches, and framing. Full suite 7667 pass / 0 fail; build passes; coverage ratchet holds.

End-to-end, in a real browser against a real Cesium Ion token:

| Check | Result |
| --- | --- |
| Globe mounts, Ion token live | `tokenHint: false`, CESIUM ion attribution on canvas |
| World terrain | `terrainProvider: "CesiumTerrainProvider"` (not `EllipsoidTerrainProvider`) |
| Capabilities live | exactly as declared, `Object.isFrozen` → `true` (both engines) |
| `syncLayers` delegation | an XYZ layer added in the UI drew on the globe (`imageryLayerCount: 2`) |
| Camera preserved on mount | 2D `[-100, 40] @ 2` → globe `[-100.0000004, 40.0000001] @ 2.0016` |
| Menu-driven zoom | two `zoomIn()` → exactly +1.0 each, `2.00 → 3.00 → 4.00` |
| Dirty semantics | programmatic camera moves sync without flagging unsaved changes, matching `MapController` |
| **Publisher reaches the store** | globe settled at `[-100.00000030766458, 39.999904790794425] @ 4.002755351655039`; switching to 2D returned **identical values to the last decimal**. The store's `mapView` is the only path between the two engines. |
| Status bar (independent store reader) | `Zoom: 4.02, BBox: -126.2087, 26.0590, -73.7913, 51.3492` |

## Small shared-code changes

`cameraFovy`/`canvasHeight` are exported from `cesium-camera.ts` rather than reimplemented, and `animateTo` reuses `mapLibrePitchToCesiumDeg`/`normalizeBearing`. An animated arrival and an instant `applyView` of the same view must land identically; a second copy of the maths would eventually drift.

## Changed after review

Two findings from the review bots were correct and are fixed in 8c3910fa:

- **`fitBounds` on a point-sized extent.** `MapController.fitBounds` special-cases a zero-area box (a single-point layer via `getLayerBounds`) because a Rectangle has no "zoom to fit" for zero extent. The engine now mirrors it, including the zoom floor of 14.
- **Programmatic moves no longer dirty the project.** I had `zoomIn`/`resetNorth`/`flyToView`/etc. mark the project dirty, reasoning that a menu click *is* the user. That disagrees with the 2D map: `MapController` drives MapLibre's camera API with no `eventData`, so `MapCanvas` publishes those with `markDirty=false`. Identical clicks behaving differently by renderer is precisely what #2260 exists to prevent, so the globe now matches, and `markUserDriven` is raised by raw pointer/wheel/touch input only.

A third finding (CodeRabbit) showed three terrain-correction tests were passing vacuously — a fixed fake ground height meant the correction's own guard exited before re-applying. The fake's height is mutable now, so terrain genuinely arrives, and the tests count camera placements.

## Not in this PR

Retyping `mapControllerRef` to `MapEngine`, no longer nulling it in `DesktopShell`, and converting the 29 engine-name gates to capability checks. That is the user-visible half of #2260 and deserves its own blast radius.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved Cesium camera behavior, including smoother updates, framing, zoom limits, and handling of user-driven movement.
  - Improved terrain support with terrain correction, world-terrain toggling, and vertical exaggeration.
  - Improved synchronization of map layers, basemaps, and camera state across primary and secondary views.

- **New Features**
  - Added support for selecting map features and fitting the view to layers or geographic bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->