### PR TITLE
fix(map): support maplibre controls and Search Places on Cesium

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -18,6 +18,9 @@ import {
   useAppStore,
 } from "@geolibre/core";
 import { getPrimaryCesiumControlHost, type MapController } from "@geolibre/map";
+// Type-only: the Cesium engine itself is imported lazily, inside the globe
+// branch of handleSelect, so it stays off this panel's load path.
+import type { PointPrimitive, PointPrimitiveCollection, Primitive } from "@cesium/engine";
 import { Input } from "@geolibre/ui";
 import { Hexagon, Loader2, LocateFixed, MapPin, Search, Table2, X } from "lucide-react";
 import { formatLatLon, parseLatLon } from "../../lib/coordinates";
@@ -107,8 +110,19 @@ export function LayerPanelPlaceSearch({
   const [activeIndex, setActiveIndex] = useState(-1);
   const abortRef = useRef<AbortController | null>(null);
   const markerRef = useRef<maplibregl.Marker | null>(null);
-  const cesiumMarkerRef = useRef<any>(null);
-  const cesiumH3EntitiesRef = useRef<any[]>([]);
+  const cesiumMarkerRef = useRef<{
+    collection: PointPrimitiveCollection;
+    point: PointPrimitive;
+  } | null>(null);
+  const cesiumH3EntitiesRef = useRef<Primitive[]>([]);
+  /**
+   * Bumped on every selection, so an in-flight globe branch can tell it has
+   * been superseded. Two rapid picks both await the Cesium import; without this
+   * the later continuation overwrites `cesiumMarkerRef`, and cleanup then
+   * removes only the collection still in the ref — leaving the earlier one in
+   * the scene forever.
+   */
+  const selectionGeneration = useRef(0);
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // `open` read by the local scan's gate. It is a ref rather than a dependency
@@ -419,10 +433,13 @@ export function LayerPanelPlaceSearch({
           for (const position of row.cell.boundary) bounds.extend(position);
           map.fitBounds(bounds, { padding: 60 });
         } else {
-          const store = useAppStore.getState();
-          store.setMapView({
+          // Animated, not `setMapView`: the store path lands in
+          // `MapController.applyView`, which is a `jumpTo` — an instant snap.
+          // Routing the 2D case through the store for cross-engine tidiness
+          // would silently drop the fly-to this box has always had.
+          map.flyTo({
             center: [row.match.lon, row.match.lat],
-            zoom: Math.max(store.mapView.zoom, 12),
+            zoom: Math.max(map.getZoom(), 12),
           });
           markerRef.current = new maplibregl.Marker({ color: H3_HIGHLIGHT_COLOR })
             .setLngLat([row.match.lon, row.match.lat])
@@ -431,69 +448,87 @@ export function LayerPanelPlaceSearch({
       } else {
         const host = getPrimaryCesiumControlHost();
         if (host && !host.viewer.isDestroyed()) {
-          const Cesium = await import("@cesium/engine");
-          if (row.kind === "h3") {
-            const hierarchy = new Cesium.PolygonHierarchy(
-              row.cell.boundary.map((pos) => Cesium.Cartesian3.fromDegrees(pos[0], pos[1])),
-            );
-            // Use primitives since CesiumWidget has no entities
-            const instance = new Cesium.GeometryInstance({
-              geometry: new Cesium.PolygonGeometry({
-                polygonHierarchy: hierarchy,
-                perPositionHeight: true,
-              }),
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR).withAlpha(0.15),
-                ),
-              },
-            });
-            const polylineInstance = new Cesium.GeometryInstance({
-              geometry: new Cesium.PolylineGeometry({
-                positions: hierarchy.positions,
-                width: 2,
-              }),
-              attributes: {
-                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR),
-                ),
-              },
-            });
-            const primitive = new Cesium.Primitive({
-              geometryInstances: instance,
-              appearance: new Cesium.PerInstanceColorAppearance({
-                flat: true,
-                translucent: true,
-                closed: true,
-              }),
-            });
-            const polylinePrimitive = new Cesium.Primitive({
-              geometryInstances: polylineInstance,
-              appearance: new Cesium.PolylineColorAppearance({
-                translucent: true,
-              }),
-            });
-            host.viewer.scene.primitives.add(primitive);
-            host.viewer.scene.primitives.add(polylinePrimitive);
-            cesiumH3EntitiesRef.current.push(primitive, polylinePrimitive);
-            const boundingSphere = Cesium.BoundingSphere.fromPoints(hierarchy.positions);
-            host.viewer.camera.flyToBoundingSphere(boundingSphere, { duration: 1.5 });
-          } else {
-            const store = useAppStore.getState();
-            store.setMapView({
-              center: [row.match.lon, row.match.lat],
-              zoom: Math.max(store.mapView.zoom, 12),
-            });
-            const points = new Cesium.PointPrimitiveCollection();
-            host.viewer.scene.primitives.add(points);
-            const p = points.add({
-              position: Cesium.Cartesian3.fromDegrees(row.match.lon, row.match.lat),
-              color: Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR),
-              pixelSize: 12,
-              outlineColor: Cesium.Color.WHITE,
-              outlineWidth: 2,
-            });
-            cesiumMarkerRef.current = { collection: points, point: p };
+          // This selection's ticket. A later pick bumps the counter, so the
+          // checks after each await can tell they have been superseded.
+          const generation = ++selectionGeneration.current;
+          try {
+            const Cesium = await import("@cesium/engine");
+            // The globe can be unmounted (engine switch, panel closed) while the
+            // chunk loads. Cesium throws on any use of a destroyed viewer, so
+            // re-check after the await the way CesiumCanvas does — the import is
+            // usually cached, which narrows the window without closing it.
+            if (host.viewer.isDestroyed() || generation !== selectionGeneration.current) {
+              settle(row.match.displayName);
+              return;
+            }
+            if (row.kind === "h3") {
+              const hierarchy = new Cesium.PolygonHierarchy(
+                row.cell.boundary.map((pos) => Cesium.Cartesian3.fromDegrees(pos[0], pos[1])),
+              );
+              // Use primitives since CesiumWidget has no entities
+              const instance = new Cesium.GeometryInstance({
+                geometry: new Cesium.PolygonGeometry({
+                  polygonHierarchy: hierarchy,
+                  perPositionHeight: true,
+                }),
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR).withAlpha(0.15),
+                  ),
+                },
+              });
+              const polylineInstance = new Cesium.GeometryInstance({
+                geometry: new Cesium.PolylineGeometry({
+                  positions: hierarchy.positions,
+                  width: 2,
+                }),
+                attributes: {
+                  color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                    Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR),
+                  ),
+                },
+              });
+              const primitive = new Cesium.Primitive({
+                geometryInstances: instance,
+                appearance: new Cesium.PerInstanceColorAppearance({
+                  flat: true,
+                  translucent: true,
+                  closed: true,
+                }),
+              });
+              const polylinePrimitive = new Cesium.Primitive({
+                geometryInstances: polylineInstance,
+                appearance: new Cesium.PolylineColorAppearance({
+                  translucent: true,
+                }),
+              });
+              host.viewer.scene.primitives.add(primitive);
+              host.viewer.scene.primitives.add(polylinePrimitive);
+              cesiumH3EntitiesRef.current.push(primitive, polylinePrimitive);
+              const boundingSphere = Cesium.BoundingSphere.fromPoints(hierarchy.positions);
+              host.viewer.camera.flyToBoundingSphere(boundingSphere, { duration: 1.5 });
+            } else {
+              const store = useAppStore.getState();
+              store.setMapView({
+                center: [row.match.lon, row.match.lat],
+                zoom: Math.max(store.mapView.zoom, 12),
+              });
+              const points = new Cesium.PointPrimitiveCollection();
+              host.viewer.scene.primitives.add(points);
+              const p = points.add({
+                position: Cesium.Cartesian3.fromDegrees(row.match.lon, row.match.lat),
+                color: Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR),
+                pixelSize: 12,
+                outlineColor: Cesium.Color.WHITE,
+                outlineWidth: 2,
+              });
+              cesiumMarkerRef.current = { collection: points, point: p };
+            }
+          } catch (error) {
+            // A failed import or primitive build must not leave the dropdown
+            // open on a stale query with the old highlight already cleared —
+            // settle below runs either way.
+            console.warn("[GeoLibre] place search could not draw on the globe", error);
           }
         }
       }

--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -152,22 +152,35 @@ export function LayerPanelPlaceSearch({
       if (map.getSource(H3_SOURCE_ID)) map.removeSource(H3_SOURCE_ID);
     }
     const host = getPrimaryCesiumControlHost();
-    if (host) {
+    if (host && !host.viewer.isDestroyed()) {
       for (const prim of cesiumH3EntitiesRef.current) {
         host.viewer.scene.primitives.remove(prim);
       }
-      cesiumH3EntitiesRef.current = [];
     }
+    cesiumH3EntitiesRef.current = [];
   }, [mapControllerRef]);
+
+  const clearMarkers = useCallback(() => {
+    markerRef.current?.remove();
+    markerRef.current = null;
+    if (cesiumMarkerRef.current) {
+      const host = getPrimaryCesiumControlHost();
+      if (host && !host.viewer.isDestroyed()) {
+        cesiumMarkerRef.current.collection.remove(cesiumMarkerRef.current.point);
+        host.viewer.scene.primitives.remove(cesiumMarkerRef.current.collection);
+      }
+      cesiumMarkerRef.current = null;
+    }
+  }, []);
 
   useEffect(
     () => () => {
       abortRef.current?.abort();
-      markerRef.current?.remove();
+      clearMarkers();
       clearH3Highlight();
       if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
     },
-    [clearH3Highlight],
+    [clearH3Highlight, clearMarkers],
   );
 
   const runSearch = useCallback(
@@ -343,15 +356,7 @@ export function LayerPanelPlaceSearch({
       // Drop the previous marker and cell outline unconditionally so neither is
       // ever orphaned when the map is briefly unavailable (mount/teardown/
       // headless) or when the next result is of a different kind.
-      markerRef.current?.remove();
-      markerRef.current = null;
-      if (cesiumMarkerRef.current) {
-        cesiumMarkerRef.current.collection.remove(cesiumMarkerRef.current.point);
-        getPrimaryCesiumControlHost()?.viewer.scene.primitives.remove(
-          cesiumMarkerRef.current.collection,
-        );
-        cesiumMarkerRef.current = null;
-      }
+      clearMarkers();
       clearH3Highlight();
 
       // A place, a coordinate, or a cell takes the box's attention off the
@@ -425,7 +430,7 @@ export function LayerPanelPlaceSearch({
         }
       } else {
         const host = getPrimaryCesiumControlHost();
-        if (host) {
+        if (host && !host.viewer.isDestroyed()) {
           const Cesium = await import("@cesium/engine");
           if (row.kind === "h3") {
             const hierarchy = new Cesium.PolygonHierarchy(
@@ -455,14 +460,23 @@ export function LayerPanelPlaceSearch({
               },
             });
             const primitive = new Cesium.Primitive({
-              geometryInstances: [instance, polylineInstance],
+              geometryInstances: instance,
               appearance: new Cesium.PerInstanceColorAppearance({
                 flat: true,
                 translucent: true,
+                closed: true,
+              }),
+            });
+            const polylinePrimitive = new Cesium.Primitive({
+              geometryInstances: polylineInstance,
+              appearance: new Cesium.PolylineColorAppearance({
+                translucent: true,
+                closed: true,
               }),
             });
             host.viewer.scene.primitives.add(primitive);
-            cesiumH3EntitiesRef.current.push(primitive);
+            host.viewer.scene.primitives.add(polylinePrimitive);
+            cesiumH3EntitiesRef.current.push(primitive, polylinePrimitive);
             const boundingSphere = Cesium.BoundingSphere.fromPoints(hierarchy.positions);
             host.viewer.camera.flyToBoundingSphere(boundingSphere, { duration: 1.5 });
           } else {
@@ -491,8 +505,7 @@ export function LayerPanelPlaceSearch({
 
   const handleClear = useCallback(() => {
     abortRef.current?.abort();
-    markerRef.current?.remove();
-    markerRef.current = null;
+    clearMarkers();
     clearH3Highlight();
     // Clearing the box clears what the box put on the map, and a picked feature
     // row leaves a live selection behind. Dropping it here takes the highlight

--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -123,6 +123,15 @@ export function LayerPanelPlaceSearch({
    * the scene forever.
    */
   const selectionGeneration = useRef(0);
+  /**
+   * False once this panel has unmounted. The generation and `isDestroyed`
+   * checks below cover a superseded pick and a torn-down globe, but not a
+   * torn-down *panel*: the unmount cleanup runs against whatever is in the refs
+   * at that moment, so a pick still awaiting the Cesium import would resume
+   * afterwards and add primitives to a live globe under refs nobody will read
+   * again — orphaning them in the scene for as long as the globe lives.
+   */
+  const mountedRef = useRef(true);
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // `open` read by the local scan's gate. It is a ref rather than a dependency
@@ -187,15 +196,16 @@ export function LayerPanelPlaceSearch({
     }
   }, []);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
       abortRef.current?.abort();
       clearMarkers();
       clearH3Highlight();
       if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
-    },
-    [clearH3Highlight, clearMarkers],
-  );
+    };
+  }, [clearH3Highlight, clearMarkers]);
 
   const runSearch = useCallback(
     async (text: string) => {
@@ -457,7 +467,11 @@ export function LayerPanelPlaceSearch({
             // chunk loads. Cesium throws on any use of a destroyed viewer, so
             // re-check after the await the way CesiumCanvas does — the import is
             // usually cached, which narrows the window without closing it.
-            if (host.viewer.isDestroyed() || generation !== selectionGeneration.current) {
+            if (
+              !mountedRef.current ||
+              host.viewer.isDestroyed() ||
+              generation !== selectionGeneration.current
+            ) {
               // Do not settle: a superseded selection has already been settled
               // by whichever pick superseded it, and re-settling here would
               // rewrite the box (and settledQuery) back to this stale row's

--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -17,7 +17,7 @@ import {
   resolveGeocoderConfig,
   useAppStore,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import { getPrimaryCesiumControlHost, type MapController } from "@geolibre/map";
 import { Input } from "@geolibre/ui";
 import { Hexagon, Loader2, LocateFixed, MapPin, Search, Table2, X } from "lucide-react";
 import { formatLatLon, parseLatLon } from "../../lib/coordinates";
@@ -107,6 +107,8 @@ export function LayerPanelPlaceSearch({
   const [activeIndex, setActiveIndex] = useState(-1);
   const abortRef = useRef<AbortController | null>(null);
   const markerRef = useRef<maplibregl.Marker | null>(null);
+  const cesiumMarkerRef = useRef<any>(null);
+  const cesiumH3EntitiesRef = useRef<any[]>([]);
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // `open` read by the local scan's gate. It is a ref rather than a dependency
@@ -143,11 +145,19 @@ export function LayerPanelPlaceSearch({
    */
   const clearH3Highlight = useCallback(() => {
     const map = mapControllerRef.current?.getMap();
-    if (!map) return;
-    for (const layerId of [H3_FILL_LAYER_ID, H3_LINE_LAYER_ID]) {
-      if (map.getLayer(layerId)) map.removeLayer(layerId);
+    if (map) {
+      for (const layerId of [H3_FILL_LAYER_ID, H3_LINE_LAYER_ID]) {
+        if (map.getLayer(layerId)) map.removeLayer(layerId);
+      }
+      if (map.getSource(H3_SOURCE_ID)) map.removeSource(H3_SOURCE_ID);
     }
-    if (map.getSource(H3_SOURCE_ID)) map.removeSource(H3_SOURCE_ID);
+    const host = getPrimaryCesiumControlHost();
+    if (host) {
+      for (const prim of cesiumH3EntitiesRef.current) {
+        host.viewer.scene.primitives.remove(prim);
+      }
+      cesiumH3EntitiesRef.current = [];
+    }
   }, [mapControllerRef]);
 
   useEffect(
@@ -328,13 +338,18 @@ export function LayerPanelPlaceSearch({
   }, []);
 
   const handleSelect = useCallback(
-    (row: SearchRow) => {
+    async (row: SearchRow) => {
       const map = mapControllerRef.current?.getMap();
       // Drop the previous marker and cell outline unconditionally so neither is
       // ever orphaned when the map is briefly unavailable (mount/teardown/
       // headless) or when the next result is of a different kind.
       markerRef.current?.remove();
       markerRef.current = null;
+      if (cesiumMarkerRef.current) {
+        cesiumMarkerRef.current.collection.remove(cesiumMarkerRef.current.point);
+        getPrimaryCesiumControlHost()?.viewer.scene.primitives.remove(cesiumMarkerRef.current.collection);
+        cesiumMarkerRef.current = null;
+      }
       clearH3Highlight();
 
       // A place, a coordinate, or a cell takes the box's attention off the
@@ -371,41 +386,101 @@ export function LayerPanelPlaceSearch({
         return;
       }
 
-      if (map && row.kind === "h3") {
-        // An H3 cell spans anything from a continent (resolution 0) to under a
-        // square meter (resolution 15), so frame the cell itself rather than
-        // flying to a fixed zoom, and outline it so the match is visible.
-        map.addSource(H3_SOURCE_ID, {
-          type: "geojson",
-          data: {
-            type: "Feature",
-            properties: { h3: row.cell.cell, resolution: row.cell.resolution },
-            geometry: { type: "Polygon", coordinates: [row.cell.boundary] },
-          },
-        });
-        map.addLayer({
-          id: H3_FILL_LAYER_ID,
-          type: "fill",
-          source: H3_SOURCE_ID,
-          paint: { "fill-color": H3_HIGHLIGHT_COLOR, "fill-opacity": 0.15 },
-        });
-        map.addLayer({
-          id: H3_LINE_LAYER_ID,
-          type: "line",
-          source: H3_SOURCE_ID,
-          paint: { "line-color": H3_HIGHLIGHT_COLOR, "line-width": 2 },
-        });
-        const bounds = new maplibregl.LngLatBounds();
-        for (const position of row.cell.boundary) bounds.extend(position);
-        map.fitBounds(bounds, { padding: 60 });
-      } else if (map) {
-        map.flyTo({
-          center: [row.match.lon, row.match.lat],
-          zoom: Math.max(map.getZoom(), 12),
-        });
-        markerRef.current = new maplibregl.Marker({ color: H3_HIGHLIGHT_COLOR })
-          .setLngLat([row.match.lon, row.match.lat])
-          .addTo(map);
+      if (map) {
+        if (row.kind === "h3") {
+          map.addSource(H3_SOURCE_ID, {
+            type: "geojson",
+            data: {
+              type: "Feature",
+              properties: { h3: row.cell.cell, resolution: row.cell.resolution },
+              geometry: { type: "Polygon", coordinates: [row.cell.boundary] },
+            },
+          });
+          map.addLayer({
+            id: H3_FILL_LAYER_ID,
+            type: "fill",
+            source: H3_SOURCE_ID,
+            paint: { "fill-color": H3_HIGHLIGHT_COLOR, "fill-opacity": 0.15 },
+          });
+          map.addLayer({
+            id: H3_LINE_LAYER_ID,
+            type: "line",
+            source: H3_SOURCE_ID,
+            paint: { "line-color": H3_HIGHLIGHT_COLOR, "line-width": 2 },
+          });
+          const bounds = new maplibregl.LngLatBounds();
+          for (const position of row.cell.boundary) bounds.extend(position);
+          map.fitBounds(bounds, { padding: 60 });
+        } else {
+          const store = useAppStore.getState();
+          store.setMapView({
+            center: [row.match.lon, row.match.lat],
+            zoom: Math.max(store.mapView.zoom, 12),
+          });
+          markerRef.current = new maplibregl.Marker({ color: H3_HIGHLIGHT_COLOR })
+            .setLngLat([row.match.lon, row.match.lat])
+            .addTo(map);
+        }
+      } else {
+        const host = getPrimaryCesiumControlHost();
+        if (host) {
+          const Cesium = await import("@cesium/engine");
+          if (row.kind === "h3") {
+            const hierarchy = new Cesium.PolygonHierarchy(
+              row.cell.boundary.map((pos) => Cesium.Cartesian3.fromDegrees(pos[0], pos[1]))
+            );
+            // Use primitives since CesiumWidget has no entities
+            const instance = new Cesium.GeometryInstance({
+              geometry: new Cesium.PolygonGeometry({
+                polygonHierarchy: hierarchy,
+                perPositionHeight: true,
+              }),
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR).withAlpha(0.15)
+                ),
+              },
+            });
+            const polylineInstance = new Cesium.GeometryInstance({
+              geometry: new Cesium.PolylineGeometry({
+                positions: hierarchy.positions,
+                width: 2,
+              }),
+              attributes: {
+                color: Cesium.ColorGeometryInstanceAttribute.fromColor(
+                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR)
+                ),
+              },
+            });
+            const primitive = new Cesium.Primitive({
+              geometryInstances: [instance, polylineInstance],
+              appearance: new Cesium.PerInstanceColorAppearance({
+                flat: true,
+                translucent: true,
+              }),
+            });
+            host.viewer.scene.primitives.add(primitive);
+            cesiumH3EntitiesRef.current.push(primitive);
+            const boundingSphere = Cesium.BoundingSphere.fromPoints(hierarchy.positions);
+            host.viewer.camera.flyToBoundingSphere(boundingSphere, { duration: 1.5 });
+          } else {
+            const store = useAppStore.getState();
+            store.setMapView({
+              center: [row.match.lon, row.match.lat],
+              zoom: Math.max(store.mapView.zoom, 12),
+            });
+            const points = new Cesium.PointPrimitiveCollection();
+            host.viewer.scene.primitives.add(points);
+            const p = points.add({
+              position: Cesium.Cartesian3.fromDegrees(row.match.lon, row.match.lat),
+              color: Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR),
+              pixelSize: 12,
+              outlineColor: Cesium.Color.WHITE,
+              outlineWidth: 2,
+            });
+            cesiumMarkerRef.current = { collection: points, point: p };
+          }
+        }
       }
       settle(row.match.displayName);
     },

--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -471,7 +471,6 @@ export function LayerPanelPlaceSearch({
               geometryInstances: polylineInstance,
               appearance: new Cesium.PolylineColorAppearance({
                 translucent: true,
-                closed: true,
               }),
             });
             host.viewer.scene.primitives.add(primitive);

--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -458,7 +458,10 @@ export function LayerPanelPlaceSearch({
             // re-check after the await the way CesiumCanvas does — the import is
             // usually cached, which narrows the window without closing it.
             if (host.viewer.isDestroyed() || generation !== selectionGeneration.current) {
-              settle(row.match.displayName);
+              // Do not settle: a superseded selection has already been settled
+              // by whichever pick superseded it, and re-settling here would
+              // rewrite the box (and settledQuery) back to this stale row's
+              // label after the newer one had won.
               return;
             }
             if (row.kind === "h3") {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -347,7 +347,9 @@ export function LayerPanelPlaceSearch({
       markerRef.current = null;
       if (cesiumMarkerRef.current) {
         cesiumMarkerRef.current.collection.remove(cesiumMarkerRef.current.point);
-        getPrimaryCesiumControlHost()?.viewer.scene.primitives.remove(cesiumMarkerRef.current.collection);
+        getPrimaryCesiumControlHost()?.viewer.scene.primitives.remove(
+          cesiumMarkerRef.current.collection,
+        );
         cesiumMarkerRef.current = null;
       }
       clearH3Highlight();
@@ -427,7 +429,7 @@ export function LayerPanelPlaceSearch({
           const Cesium = await import("@cesium/engine");
           if (row.kind === "h3") {
             const hierarchy = new Cesium.PolygonHierarchy(
-              row.cell.boundary.map((pos) => Cesium.Cartesian3.fromDegrees(pos[0], pos[1]))
+              row.cell.boundary.map((pos) => Cesium.Cartesian3.fromDegrees(pos[0], pos[1])),
             );
             // Use primitives since CesiumWidget has no entities
             const instance = new Cesium.GeometryInstance({
@@ -437,7 +439,7 @@ export function LayerPanelPlaceSearch({
               }),
               attributes: {
                 color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR).withAlpha(0.15)
+                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR).withAlpha(0.15),
                 ),
               },
             });
@@ -448,7 +450,7 @@ export function LayerPanelPlaceSearch({
               }),
               attributes: {
                 color: Cesium.ColorGeometryInstanceAttribute.fromColor(
-                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR)
+                  Cesium.Color.fromCssColorString(H3_HIGHLIGHT_COLOR),
                 ),
               },
             });

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -94,7 +94,7 @@ import {
   closeFloatingPanel,
   getOpenFloatingPanels,
 } from "@geolibre/plugins";
-import type { MapController } from "@geolibre/map";
+import { getPrimaryCesiumControlHost, type MapController } from "@geolibre/map";
 import type {
   GeoLibreCogLayerOptions,
   GeoLibreCogRenderEngine,
@@ -1198,9 +1198,17 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     addMapControl: (
       control: Parameters<MapController["addControl"]>[0],
       position?: Parameters<MapController["addControl"]>[1],
-    ) => mapControllerRef?.current?.addControl(control, position) ?? false,
-    removeMapControl: (control: Parameters<MapController["removeControl"]>[0]) =>
-      mapControllerRef?.current?.removeControl(control),
+    ) =>
+      mapControllerRef?.current?.addControl(control, position) ??
+      getPrimaryCesiumControlHost()?.addControl(control, position) ??
+      false,
+    removeMapControl: (control: Parameters<MapController["removeControl"]>[0]) => {
+      if (mapControllerRef?.current) {
+        mapControllerRef.current.removeControl(control);
+      } else {
+        getPrimaryCesiumControlHost()?.removeControl(control);
+      }
+    },
     setBuiltInMapControlVisible: (
       control: Parameters<MapController["setBuiltInControlVisible"]>[0],
       visible: boolean,

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -102,6 +102,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   const viewerRef = useRef<CesiumWidget | null>(null);
   const cesiumRef = useRef<typeof import("@cesium/engine") | null>(null);
   const engineRef = useRef<CesiumEngine | null>(null);
+  const controlHostRef = useRef<CesiumControlHost | null>(null);
   // The imagery layers currently drawing the project basemap, at the bottom of
   // the stack. Tracked so a basemap change replaces exactly these and leaves
   // the data layers above them alone.
@@ -279,12 +280,6 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         cesiumRef.current = Cesium;
         viewerRef.current = viewer;
 
-        let controlHost: CesiumControlHost | null = null;
-        if (viewId === undefined) {
-          controlHost = new CesiumControlHost(viewer, container);
-          setPrimaryCesiumControlHost(controlHost);
-        }
-
         // Note for anyone reintroducing `Viewer`: it installs a double-click
         // "track entity" gesture that flies to and camera-locks a picked
         // feature, which fights the store-driven camera sync and isn't wired to
@@ -312,6 +307,11 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         // the seed/sync/moveEnd below would run against a dead viewer and leave a
         // moveEnd listener that cleanupInput never removes.
         if (cancelled || viewer.isDestroyed()) return;
+
+        if (viewId === undefined) {
+          controlHostRef.current = new CesiumControlHost(viewer, container);
+          setPrimaryCesiumControlHost(controlHostRef.current);
+        }
 
         // Seed the camera from the shared store camera before the first frame.
         // The primary globe always seeds from `mapView`, which is what carries
@@ -351,6 +351,10 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
       baseImageryLayersRef.current = [];
       appliedImageryRef.current = null;
       if (viewId === undefined) {
+        if (controlHostRef.current) {
+          controlHostRef.current.destroy();
+          controlHostRef.current = null;
+        }
         setPrimaryCesiumControlHost(null);
       }
       const viewer = viewerRef.current;

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -12,6 +12,7 @@ import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { applyBasemapAppearance, applyBasemapImagery } from "./cesium-basemap";
 import { isSameView } from "./cesium-camera";
 import { CesiumEngine } from "./cesium-engine";
+import { CesiumControlHost, setPrimaryCesiumControlHost } from "./cesium-control-host";
 
 // The Cesium 3D-globe view (see private/cesium-view-plan.md). M1 wired the
 // build, token, and split-pane mount; M2 synced the camera with the shared store
@@ -278,6 +279,12 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         cesiumRef.current = Cesium;
         viewerRef.current = viewer;
 
+        let controlHost: CesiumControlHost | null = null;
+        if (viewId === undefined) {
+          controlHost = new CesiumControlHost(viewer, container);
+          setPrimaryCesiumControlHost(controlHost);
+        }
+
         // Note for anyone reintroducing `Viewer`: it installs a double-click
         // "track entity" gesture that flies to and camera-locks a picked
         // feature, which fights the store-driven camera sync and isn't wired to
@@ -343,6 +350,9 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
       // the handles so a remount starts from an empty stack and redraws.
       baseImageryLayersRef.current = [];
       appliedImageryRef.current = null;
+      if (viewId === undefined) {
+        setPrimaryCesiumControlHost(null);
+      }
       const viewer = viewerRef.current;
       if (viewer && !viewer.isDestroyed()) viewer.destroy();
       viewerRef.current = null;

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -210,7 +210,19 @@ export class CesiumControlHost {
       el.parentElement.removeChild(el);
     }
 
-    control.onRemove(this.facade as unknown as maplibregl.Map);
+    // Guarded for the same reason `addControl` guards `onAdd`, and it matters
+    // more here: `destroy()` calls this in a loop, and `CesiumCanvas`'s unmount
+    // effect calls `destroy()` with no try/catch of its own. A control whose
+    // `onRemove` trips one of the facade's deliberate throws would otherwise
+    // escape the cleanup — leaving the remaining controls mounted, the
+    // container attached, the primary-host registration stale, and the Cesium
+    // viewer never destroyed. The control is dropped from the registry either
+    // way: it is already detached from the DOM by this point.
+    try {
+      control.onRemove(this.facade as unknown as maplibregl.Map);
+    } catch (error) {
+      console.warn("[GeoLibre] control failed to unmount cleanly from the globe", error);
+    }
     this.controls.delete(control);
   }
 }

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -28,7 +28,13 @@ class CesiumMapFacade extends maplibregl.Evented {
   setStyle(style: any, options?: any) {
     if (typeof style === "string") {
       useAppStore.getState().setBasemapStyleUrl(style);
-      // Wait a tick for state propagation then emit style.load
+      // Best-effort `style.load`, not a real readiness signal. The store update
+      // reaches the globe through CesiumCanvas's own effect, whose imagery
+      // providers and tile requests are asynchronous and not bounded by one
+      // macrotask — so a control that reacts to this by reading style state may
+      // still run before the imagery has actually switched. It exists because
+      // controls wait for it before finishing a basemap swap (they would hang
+      // otherwise); it does not promise the pixels have changed.
       setTimeout(() => {
         this.fire(new maplibregl.Event("style.load"));
       }, 0);
@@ -101,10 +107,10 @@ class CesiumMapFacade extends maplibregl.Evented {
     return useAppStore.getState().mapView.zoom;
   }
   getBearing() {
-    return 0; // Cesium camera mapping handles actual bearing, but keeping shim simple
+    return useAppStore.getState().mapView.bearing;
   }
   getPitch() {
-    return 0;
+    return useAppStore.getState().mapView.pitch;
   }
   getBounds() {
     throw new Error("CesiumControlHost: getBounds not implemented");
@@ -170,7 +176,21 @@ export class CesiumControlHost {
   addControl(control: maplibregl.IControl, position: maplibregl.ControlPosition = "top-right") {
     if (this.controls.has(control)) return false;
 
-    const el = control.onAdd(this.facade as unknown as maplibregl.Map);
+    // The facade throws for the style-spec methods it cannot honour, which is
+    // deliberate — but `addMapControl` is a boolean-returning API that plugins
+    // are written against (`if (!app.addMapControl(...))`), and at least one
+    // caller activates plugins without a try/catch (PluginManager's
+    // project-restore loop). Letting the throw escape would abort restoring the
+    // remaining plugins instead of degrading like any other failed control, so
+    // a control whose onAdd trips the facade reports "not added" rather than
+    // taking the caller down with it.
+    let el: HTMLElement;
+    try {
+      el = control.onAdd(this.facade as unknown as maplibregl.Map);
+    } catch (error) {
+      console.warn("[GeoLibre] control could not mount on the globe", error);
+      return false;
+    }
     el.style.pointerEvents = "auto";
 
     const corner = this.corners[position];

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -155,7 +155,7 @@ export class CesiumControlHost {
   }
 
   destroy() {
-    for (const control of Array.from(this.controls)) {
+    for (const control of Array.from(this.controls.keys())) {
       this.removeControl(control);
     }
     if (this.container.parentElement) {

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -51,12 +51,10 @@ class CesiumMapFacade extends maplibregl.Evented {
 
   flyTo(options: maplibregl.FlyToOptions) {
     return this.jumpTo(options as any);
-    
   }
 
   easeTo(options: maplibregl.EaseToOptions) {
     return this.jumpTo(options as any);
-    
   }
 
   addSource(id: string, source: any) {
@@ -166,24 +164,24 @@ export class CesiumControlHost {
 
     const el = control.onAdd(this.facade as unknown as maplibregl.Map);
     el.style.pointerEvents = "auto";
-    
+
     const corner = this.corners[position];
     if (corner) {
       corner.appendChild(el);
     }
-    
+
     this.controls.set(control, el);
     return true;
   }
 
   removeControl(control: maplibregl.IControl) {
     if (!this.controls.has(control)) return;
-    
+
     const el = this.controls.get(control)!;
     if (el.parentElement) {
       el.parentElement.removeChild(el);
     }
-    
+
     control.onRemove(this.facade as unknown as maplibregl.Map);
     this.controls.delete(control);
   }

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -1,0 +1,198 @@
+import * as maplibregl from "maplibre-gl";
+import type { CesiumWidget } from "@cesium/engine";
+import { useAppStore } from "@geolibre/core";
+
+class CesiumMapFacade extends maplibregl.Evented {
+  private sources = new Map<string, any>();
+  private layers = new Map<string, any>();
+
+  constructor(
+    private host: CesiumControlHost,
+    private viewer: any,
+  ) {
+    super();
+  }
+
+  getContainer() {
+    return this.host.getContainer();
+  }
+
+  getCanvas() {
+    return this.viewer.canvas;
+  }
+
+  isStyleLoaded() {
+    return true;
+  }
+
+  setStyle(style: any, options?: any) {
+    if (typeof style === "string") {
+      useAppStore.getState().setBasemapStyleUrl(style);
+      // Wait a tick for state propagation then emit style.load
+      setTimeout(() => {
+        this.fire(new maplibregl.Event("style.load"));
+      }, 0);
+    } else {
+      throw new Error("CesiumControlHost: setStyle with an object is not supported.");
+    }
+    return this;
+  }
+
+  jumpTo(options: maplibregl.JumpToOptions) {
+    if (options.center) {
+      const center = maplibregl.LngLat.convert(options.center);
+      useAppStore.getState().setMapView({
+        center: [center.lng, center.lat],
+        zoom: options.zoom ?? useAppStore.getState().mapView.zoom,
+      });
+    }
+    return this;
+  }
+
+  flyTo(options: maplibregl.FlyToOptions) {
+    return this.jumpTo(options as any);
+    
+  }
+
+  easeTo(options: maplibregl.EaseToOptions) {
+    return this.jumpTo(options as any);
+    
+  }
+
+  addSource(id: string, source: any) {
+    this.sources.set(id, source);
+    return this;
+  }
+
+  getSource(id: string) {
+    return this.sources.get(id);
+  }
+
+  removeSource(id: string) {
+    this.sources.delete(id);
+    return this;
+  }
+
+  addLayer(layer: any, beforeId?: string) {
+    throw new Error("CesiumControlHost: addLayer is not supported on the globe.");
+  }
+
+  removeLayer(id: string) {
+    this.layers.delete(id);
+    useAppStore.getState().removeLayer(id);
+    return this;
+  }
+
+  // Not implemented but required by IControl type definition/plugins in fallback
+  project(lnglat: maplibregl.LngLatLike) {
+    throw new Error("CesiumControlHost: project not implemented");
+  }
+  unproject(point: maplibregl.PointLike) {
+    throw new Error("CesiumControlHost: unproject not implemented");
+  }
+  getCenter() {
+    const view = useAppStore.getState().mapView;
+    return new maplibregl.LngLat(view.center[0], view.center[1]);
+  }
+  getZoom() {
+    return useAppStore.getState().mapView.zoom;
+  }
+  getBearing() {
+    return 0; // Cesium camera mapping handles actual bearing, but keeping shim simple
+  }
+  getPitch() {
+    return 0;
+  }
+  getBounds() {
+    throw new Error("CesiumControlHost: getBounds not implemented");
+  }
+
+  // Throw explicitly for style-spec mutations
+  setPaintProperty() {
+    throw new Error("CesiumControlHost: setPaintProperty is not supported on the globe.");
+  }
+  setLayoutProperty() {
+    throw new Error("CesiumControlHost: setLayoutProperty is not supported on the globe.");
+  }
+  getStyle() {
+    throw new Error("CesiumControlHost: getStyle is not supported on the globe.");
+  }
+}
+
+export class CesiumControlHost {
+  private container: HTMLDivElement;
+  private corners: Record<string, HTMLDivElement>;
+  private controls = new Map<maplibregl.IControl, HTMLElement>();
+  private facade: CesiumMapFacade;
+
+  constructor(
+    public viewer: CesiumWidget,
+    containerParent: HTMLElement,
+  ) {
+    this.container = document.createElement("div");
+    this.container.className = "maplibregl-control-container";
+
+    this.corners = {
+      "top-left": document.createElement("div"),
+      "top-right": document.createElement("div"),
+      "bottom-left": document.createElement("div"),
+      "bottom-right": document.createElement("div"),
+    };
+
+    for (const [pos, el] of Object.entries(this.corners)) {
+      el.className = `maplibregl-ctrl-${pos}`;
+      el.style.position = "absolute";
+      el.style.pointerEvents = "none";
+      el.style.zIndex = "2";
+      this.container.appendChild(el);
+    }
+
+    containerParent.appendChild(this.container);
+    this.facade = new CesiumMapFacade(this, viewer);
+  }
+
+  destroy() {
+    if (this.container.parentElement) {
+      this.container.parentElement.removeChild(this.container);
+    }
+  }
+
+  getContainer() {
+    return this.container;
+  }
+
+  addControl(control: maplibregl.IControl, position: maplibregl.ControlPosition = "top-right") {
+    if (this.controls.has(control)) return false;
+
+    const el = control.onAdd(this.facade as unknown as maplibregl.Map);
+    el.style.pointerEvents = "auto";
+    
+    const corner = this.corners[position];
+    if (corner) {
+      corner.appendChild(el);
+    }
+    
+    this.controls.set(control, el);
+    return true;
+  }
+
+  removeControl(control: maplibregl.IControl) {
+    if (!this.controls.has(control)) return;
+    
+    const el = this.controls.get(control)!;
+    if (el.parentElement) {
+      el.parentElement.removeChild(el);
+    }
+    
+    control.onRemove(this.facade as unknown as maplibregl.Map);
+    this.controls.delete(control);
+  }
+}
+
+let primaryCesiumControlHost: CesiumControlHost | null = null;
+export function getPrimaryCesiumControlHost() {
+  return primaryCesiumControlHost;
+}
+export function setPrimaryCesiumControlHost(host: CesiumControlHost | null) {
+  primaryCesiumControlHost = host;
+}

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -39,12 +39,18 @@ class CesiumMapFacade extends maplibregl.Evented {
   }
 
   jumpTo(options: maplibregl.JumpToOptions) {
+    const currentView = useAppStore.getState().mapView;
+    const update: any = {};
     if (options.center) {
       const center = maplibregl.LngLat.convert(options.center);
-      useAppStore.getState().setMapView({
-        center: [center.lng, center.lat],
-        zoom: options.zoom ?? useAppStore.getState().mapView.zoom,
-      });
+      update.center = [center.lng, center.lat];
+    }
+    if (options.zoom !== undefined) update.zoom = options.zoom;
+    if (options.bearing !== undefined) update.bearing = options.bearing;
+    if (options.pitch !== undefined) update.pitch = options.pitch;
+
+    if (Object.keys(update).length > 0) {
+      useAppStore.getState().setMapView({ ...currentView, ...update });
     }
     return this;
   }
@@ -77,7 +83,6 @@ class CesiumMapFacade extends maplibregl.Evented {
 
   removeLayer(id: string) {
     this.layers.delete(id);
-    useAppStore.getState().removeLayer(id);
     return this;
   }
 
@@ -150,6 +155,9 @@ export class CesiumControlHost {
   }
 
   destroy() {
+    for (const control of Array.from(this.controls)) {
+      this.removeControl(control);
+    }
     if (this.container.parentElement) {
       this.container.parentElement.removeChild(this.container);
     }

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -69,6 +69,19 @@ export const CESIUM_CAPABILITIES: MapEngineCapabilities = Object.freeze({
 });
 
 /**
+ * Capabilities of a globe rendered as a **grid pane** rather than the primary
+ * map area.
+ *
+ * Identical to {@link CESIUM_CAPABILITIES} except for `domControls`: the
+ * control host is a singleton owned by the primary globe, so a pane has nowhere
+ * to mount an `IControl`.
+ */
+export const CESIUM_PANE_CAPABILITIES: MapEngineCapabilities = Object.freeze({
+  ...CESIUM_CAPABILITIES,
+  domControls: false,
+});
+
+/**
  * Coerce a preference zoom into MapLibre's [0, 24] range, falling back to
  * `fallback` for a non-finite value. Mirrors `clampNumber` in `map-controller.ts`.
  */
@@ -125,7 +138,15 @@ export interface CesiumEngineOptions {
  */
 export class CesiumEngine implements MapEngine {
   readonly kind = "cesium" as const;
-  readonly capabilities: MapEngineCapabilities = CESIUM_CAPABILITIES;
+  /**
+   * Per-instance, because `domControls` is not true of every globe: the control
+   * host is a singleton belonging to the primary map area, so a grid pane has
+   * nowhere to mount an `IControl`. A flag that claimed otherwise while
+   * {@link addControl} returned `false` would be the exact failure the
+   * capability flags exist to prevent — UI gating on a capability the engine
+   * does not actually honour.
+   */
+  readonly capabilities: MapEngineCapabilities;
 
   private readonly Cesium: CesiumNs;
   private viewer: CesiumWidget | null;
@@ -184,6 +205,8 @@ export class CesiumEngine implements MapEngine {
     this.Cesium = Cesium;
     this.viewer = viewer;
     this.viewId = options.viewId;
+    this.capabilities =
+      options.viewId === undefined ? CESIUM_CAPABILITIES : CESIUM_PANE_CAPABILITIES;
     this.layerSync = new CesiumLayerSync(Cesium, viewer);
     this.terrainExaggeration = viewer.scene.verticalExaggeration ?? 1;
     this.installInputTracking();
@@ -479,16 +502,26 @@ export class CesiumEngine implements MapEngine {
   // ----------------------------------------------------------------- controls
 
   /**
-   * `true`: the globe mounts `IControl`s using the control host.
+   * Mount a control on the globe's control host.
+   *
+   * Only the **primary** globe has one. The host is a module-level singleton
+   * keyed to whichever globe owns the primary map area, so delegating from a
+   * grid pane's engine would mount the pane's control onto a different viewer
+   * — or onto nothing at all when the primary renderer is MapLibre. A pane
+   * reports `false`, the same answer every caller already reads as "this engine
+   * has nowhere to host it".
    */
   addControl(control: maplibregl.IControl, position?: maplibregl.ControlPosition): boolean {
+    if (!this.isPrimary) return false;
     // Return the host's own result: it answers `false` for a control that is
     // already mounted, and a caller that reads `true` there would double-count
     // its registration.
     return getPrimaryCesiumControlHost()?.addControl(control, position) ?? false;
   }
 
+  /** No-op for a grid pane, which never mounted a control. See {@link addControl}. */
   removeControl(control: maplibregl.IControl): void {
+    if (!this.isPrimary) return;
     getPrimaryCesiumControlHost()?.removeControl(control);
   }
 

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -21,6 +21,7 @@ import {
   readMapViewFromCamera,
   zoomToRange,
 } from "./cesium-camera";
+import { getPrimaryCesiumControlHost } from "./cesium-control-host";
 import { CesiumLayerSync } from "./cesium-layer-sync";
 import { getLayerBounds } from "./geojson-loader";
 import type {
@@ -64,7 +65,7 @@ export const CESIUM_CAPABILITIES: MapEngineCapabilities = Object.freeze({
   terrain: true,
   picking: false,
   onMapDrawing: false,
-  domControls: false,
+  domControls: true,
 });
 
 /**
@@ -478,16 +479,20 @@ export class CesiumEngine implements MapEngine {
   // ----------------------------------------------------------------- controls
 
   /**
-   * `false`: the globe has nowhere to mount an `IControl` yet. Callers already
-   * read a `false` return as "not available" (it is what a `MapController`
-   * returns before `init`), so plugins fail their activation honestly rather
-   * than reporting success and drawing nothing. The control host is issue #2263.
+   * `true`: the globe mounts `IControl`s using the control host.
    */
-  addControl(_control: maplibregl.IControl, _position?: maplibregl.ControlPosition): boolean {
+  addControl(control: maplibregl.IControl, position?: maplibregl.ControlPosition): boolean {
+    const host = getPrimaryCesiumControlHost();
+    if (host) {
+      host.addControl(control, position);
+      return true;
+    }
     return false;
   }
 
-  removeControl(_control: maplibregl.IControl): void {}
+  removeControl(control: maplibregl.IControl): void {
+    getPrimaryCesiumControlHost()?.removeControl(control);
+  }
 
   setBuiltInControlVisible(_control: BuiltInMapControl, _visible: boolean): boolean {
     return false;

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -482,12 +482,10 @@ export class CesiumEngine implements MapEngine {
    * `true`: the globe mounts `IControl`s using the control host.
    */
   addControl(control: maplibregl.IControl, position?: maplibregl.ControlPosition): boolean {
-    const host = getPrimaryCesiumControlHost();
-    if (host) {
-      host.addControl(control, position);
-      return true;
-    }
-    return false;
+    // Return the host's own result: it answers `false` for a control that is
+    // already mounted, and a caller that reads `true` there would double-count
+    // its registration.
+    return getPrimaryCesiumControlHost()?.addControl(control, position) ?? false;
   }
 
   removeControl(control: maplibregl.IControl): void {

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -19,7 +19,12 @@ export { SecondaryMapCanvas, type SecondaryMapCanvasProps } from "./SecondaryMap
 export { CesiumCanvas, type CesiumCanvasProps } from "./CesiumCanvas";
 export { getPrimaryCesiumControlHost } from "./cesium-control-host";
 export { isCesiumSupportedLayerType } from "./cesium-layer-sync";
-export { CESIUM_CAPABILITIES, CesiumEngine, type CesiumEngineOptions } from "./cesium-engine";
+export {
+  CESIUM_CAPABILITIES,
+  CESIUM_PANE_CAPABILITIES,
+  CesiumEngine,
+  type CesiumEngineOptions,
+} from "./cesium-engine";
 export {
   applyMapViewToCamera,
   cameraFovy,

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -17,6 +17,7 @@ export {
 export { PANEL_RESIZE_END_EVENT, PANEL_RESIZE_START_EVENT } from "./map-resize";
 export { SecondaryMapCanvas, type SecondaryMapCanvasProps } from "./SecondaryMapCanvas";
 export { CesiumCanvas, type CesiumCanvasProps } from "./CesiumCanvas";
+export { getPrimaryCesiumControlHost } from "./cesium-control-host";
 export { isCesiumSupportedLayerType } from "./cesium-layer-sync";
 export { CESIUM_CAPABILITIES, CesiumEngine, type CesiumEngineOptions } from "./cesium-engine";
 export {

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -241,12 +241,25 @@ describe("CesiumEngine capabilities", () => {
     assert.ok(Object.isFrozen(CESIUM_CAPABILITIES));
   });
 
+  it("does not let a grid pane mount controls on the primary globe's host", () => {
+    // The control host is a singleton owned by the primary map area, so
+    // delegating from a pane would mount its control onto a different viewer —
+    // or onto nothing when the primary renderer is MapLibre (#2266 review).
+    const fakes = makeViewer();
+    const pane = new CesiumEngine(makeCesium(), fakes.viewer, { viewId: "pane-1" });
+    assert.equal(pane.addControl({} as never), false);
+    // ...and the capability says so, rather than advertising one it refuses.
+    assert.equal(pane.capabilities.domControls, false);
+    assert.equal(CESIUM_CAPABILITIES.domControls, true, "the primary globe still hosts controls");
+    pane.destroy();
+  });
+
   it("reports no MapLibre map and refuses controls, rather than pretending", () => {
     const fakes = makeViewer();
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     assert.equal(engine.getMap(), null);
-    // `false` is what callers already read as "not available" — a `true` here
-    // would let a plugin activate and silently draw nothing.
+    // No control host registered in this test, so there is nowhere to mount:
+    // `false` is what callers already read as "not available".
     assert.equal(engine.addControl({} as never), false);
     assert.equal(engine.kind, "cesium");
     engine.destroy();

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, it } from "node:test";
 import { useAppStore } from "../packages/core/src/store";
 import type { MapViewState } from "../packages/core/src/types";
 import { CesiumEngine, CESIUM_CAPABILITIES } from "../packages/map/src/cesium-engine";
+import {
+  setPrimaryCesiumControlHost,
+  type CesiumControlHost,
+} from "../packages/map/src/cesium-control-host";
 
 // The globe's camera state machine, which moved out of CesiumCanvas's mount
 // effect and into CesiumEngine (issue #2260). It had no coverage while it lived
@@ -245,13 +249,43 @@ describe("CesiumEngine capabilities", () => {
     // The control host is a singleton owned by the primary map area, so
     // delegating from a pane would mount its control onto a different viewer —
     // or onto nothing when the primary renderer is MapLibre (#2266 review).
-    const fakes = makeViewer();
-    const pane = new CesiumEngine(makeCesium(), fakes.viewer, { viewId: "pane-1" });
-    assert.equal(pane.addControl({} as never), false);
-    // ...and the capability says so, rather than advertising one it refuses.
-    assert.equal(pane.capabilities.domControls, false);
+    //
+    // A registered host is what makes this test mean anything: without one an
+    // unguarded addControl would answer `false` too, and the assertion would
+    // pass whether or not the guard exists.
+    const calls = { added: 0, removed: 0 };
+    const host = {
+      addControl: () => {
+        calls.added++;
+        return true;
+      },
+      removeControl: () => {
+        calls.removed++;
+      },
+    } as unknown as CesiumControlHost;
+    setPrimaryCesiumControlHost(host);
+    try {
+      const fakes = makeViewer();
+      const pane = new CesiumEngine(makeCesium(), fakes.viewer, { viewId: "pane-1" });
+      assert.equal(pane.addControl({} as never), false);
+      pane.removeControl({} as never);
+      assert.equal(calls.added, 0, "a pane must not reach the primary host");
+      assert.equal(calls.removed, 0, "nor unmount a control it never added");
+      // ...and the capability says so, rather than advertising one it refuses.
+      assert.equal(pane.capabilities.domControls, false);
+      pane.destroy();
+
+      // The primary globe, by contrast, does delegate to the host.
+      const primaryFakes = makeViewer();
+      const primary = new CesiumEngine(makeCesium(), primaryFakes.viewer);
+      assert.equal(primary.addControl({} as never), true);
+      assert.equal(calls.added, 1);
+      assert.equal(primary.capabilities.domControls, true);
+      primary.destroy();
+    } finally {
+      setPrimaryCesiumControlHost(null);
+    }
     assert.equal(CESIUM_CAPABILITIES.domControls, true, "the primary globe still hosts controls");
-    pane.destroy();
   });
 
   it("reports no MapLibre map and refuses controls, rather than pretending", () => {


### PR DESCRIPTION
Fixes #2263

### Description
This PR resolves the issue where MapLibre controls (such as the Basemaps plugin) and the Search Places fly-to functionality would break when the 3D globe (Cesium) was active.

### Changes Made
1. **CesiumControlHost**: Implemented a MapLibre-shaped \CesiumControlHost\ over \CesiumWidget\. This acts as a facade, allowing \createAppAPI\ to register MapLibre controls (like the Basemaps control) onto the globe canvas. The facade intentionally fails loudly on unsupported style-spec methods rather than silently no-opping.
2. **CesiumCanvas Integration**: Integrated the new \CesiumControlHost\ into \CesiumCanvas\ so it is globally available as the primary host when in 3D mode.
3. **Search Places Panel**: Updated \LayerPanelPlaceSearch\ to handle Cesium mode:
   - Routes fly-to commands through the store's \setMapView\ (which natively handles both engines).
   - Draws the Cesium marker (using \PointPrimitiveCollection\) and H3 outlines (using \Primitive\ geometry instances) directly on the Cesium scene primitives collection when the 2D map controller is absent.

### Validation
- Tested compiling with \
pm run typecheck\, confirming typings correctly map \CesiumWidget\ primitives.
- Ensured unsupported methods throw exceptions instead of silently swallowing requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying search-result markers and H3 highlights on the 3D globe.
  * Search selections can update the shared map view and move the globe camera to the selected area.
  * Map controls now work when the 3D globe is active, including adding and removing compatible controls.

* **Bug Fixes**
  * Improved cleanup of search highlights and markers when changing or clearing selections.
  * Improved handling of rapidly changing selections, globe initialization errors, and unavailable map views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->