### PR TITLE
feat(map): drive the app through MapEngine, gate UI on capabilities

### DIFF
--- a/apps/geolibre-desktop/src/components/comments/CommentMapOverlay.tsx
+++ b/apps/geolibre-desktop/src/components/comments/CommentMapOverlay.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useAppStore, type ProjectComment } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import * as maplibreGl from "maplibre-gl";
 
 interface CommentMapOverlayProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   onSelectComment?: (commentId: string) => void;
   showResolved?: boolean;
 }

--- a/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
+++ b/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
@@ -227,12 +227,16 @@ export function CommentsPanel({
   };
 
   const handleZoomTo = (comment: ProjectComment) => {
-    const map = mapControllerRef.current?.getMap() ?? null;
-    if (!map) return;
-    const coords = resolveCommentCoordinates(comment, map);
-    if (coords) {
-      map.flyTo({ center: coords, zoom: Math.max(map.getZoom(), 15), duration: 800 });
-    }
+    const engine = mapControllerRef.current;
+    if (!engine) return;
+    // The map is only needed to resolve a *feature*-anchored comment, and
+    // `resolveCommentCoordinates` already answers a direct `lngLat` without one
+    // — so a comment with its own coordinates zooms on any engine. The flight
+    // goes through `engine.flyTo`, which the globe implements too; using
+    // `map.flyTo` would have made this silently do nothing there (#2268 review).
+    const coords = resolveCommentCoordinates(comment, engine.getMap());
+    if (!coords) return;
+    engine.flyTo({ center: coords, zoom: Math.max(engine.readView().zoom, 15), duration: 800 });
   };
 
   const unresolvedComments = comments.filter((c) => !c.resolved);

--- a/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
+++ b/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useAppStore, type ProjectComment, type CommentReply } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button, Input, ScrollArea, cn } from "@geolibre/ui";
 import {
   MessageSquare,
@@ -45,7 +45,7 @@ function saveStoredName(name: string): void {
 }
 
 interface CommentsPanelProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   collaboration?: CollaborationApi;
   onActivateCommentTool?: () => void;
   isCommentToolActive?: boolean;

--- a/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
+++ b/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
@@ -31,7 +31,12 @@ export function useCommentTool({ mapControllerRef, collaboration }: UseCommentTo
    * without a native map must not let the tool arm (#2268 review).
    */
   const canPlaceComments = useCallback(
-    () => mapControllerRef.current?.capabilities.nativeMapInstance !== false,
+    // `=== true`, not `!== false`: a null ref (no engine published yet) must not
+    // arm the tool either. The effect below only attaches its click listener
+    // when `isActive` flips, and mutating the ref does not re-run it — so a tool
+    // armed before the map was ready would stay armed and dead until the user
+    // toggled it off and on again (#2268 review).
+    () => mapControllerRef.current?.capabilities.nativeMapInstance === true,
     [mapControllerRef],
   );
 

--- a/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
+++ b/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
@@ -2,13 +2,13 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type React from "react";
 import { useAppStore, type CommentAnchor, type ProjectComment } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { v4 as uuidv4 } from "uuid";
 import type { CollaborationApi } from "../../hooks/useCollaboration";
 import type * as maplibreGl from "maplibre-gl";
 
 interface UseCommentToolOptions {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   collaboration?: CollaborationApi;
 }
 

--- a/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
+++ b/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
@@ -132,10 +132,15 @@ export function useCommentTool({
     const map = mapControllerRef.current?.getMap();
     if (!isActive) return;
     if (!map) {
-      // The engine that just published cannot place comments. Disarm rather than
-      // leave the tool looking active over a map that will never receive its
-      // click.
-      if (mapControllerRef.current) setIsActive(false);
+      // Armed with no map to click: disarm rather than leave the tool looking
+      // active. Unconditional, including when the ref is momentarily null — the
+      // hand-off bumps the generation before the incoming engine publishes, and
+      // waiting for a non-null ref left the tool stuck armed if that engine
+      // never arrived (a Cesium or WebGL failure means no second bump) (#2268
+      // review). There is no initial-mount case to protect: `canPlaceComments`
+      // requires `nativeMapInstance === true`, so `isActive` cannot be true
+      // before an engine has published.
+      setIsActive(false);
       return;
     }
 

--- a/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
+++ b/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
@@ -98,6 +98,11 @@ export function useCommentTool({ mapControllerRef, collaboration }: UseCommentTo
   }, []);
 
   useEffect(() => {
+    // Placing a comment needs a map click plus feature picking, so it is
+    // MapLibre-only for now. The guard used to be implicit — the ref was null on
+    // the globe — but it now holds a `CesiumEngine` whose `getMap()` is null, so
+    // without saying so the tool could read as armed while no click ever lands
+    // (#2268 review). `activateTool`/`toggleTool` refuse to arm without it.
     const map = mapControllerRef.current?.getMap();
     if (!map || !isActive) return;
 

--- a/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
+++ b/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
@@ -10,6 +10,12 @@ import type * as maplibreGl from "maplibre-gl";
 interface UseCommentToolOptions {
   mapControllerRef: React.RefObject<MapEngine | null>;
   collaboration?: CollaborationApi;
+  /**
+   * Bumped whenever a canvas publishes an engine, and on an engine hand-off.
+   * The ref has stable identity, so this is what re-runs the click-listener
+   * effect when the map underneath changes (#2268 review).
+   */
+  mapReadyGeneration: number;
 }
 
 export interface PendingCommentState {
@@ -17,7 +23,11 @@ export interface PendingCommentState {
   point: { x: number; y: number };
 }
 
-export function useCommentTool({ mapControllerRef, collaboration }: UseCommentToolOptions) {
+export function useCommentTool({
+  mapControllerRef,
+  collaboration,
+  mapReadyGeneration,
+}: UseCommentToolOptions) {
   const { t } = useTranslation();
   const [isActive, setIsActive] = useState(false);
   const [pendingComment, setPendingComment] = useState<PendingCommentState | null>(null);
@@ -120,7 +130,14 @@ export function useCommentTool({ mapControllerRef, collaboration }: UseCommentTo
     // without saying so the tool could read as armed while no click ever lands
     // (#2268 review). `activateTool`/`toggleTool` refuse to arm without it.
     const map = mapControllerRef.current?.getMap();
-    if (!map || !isActive) return;
+    if (!isActive) return;
+    if (!map) {
+      // The engine that just published cannot place comments. Disarm rather than
+      // leave the tool looking active over a map that will never receive its
+      // click.
+      if (mapControllerRef.current) setIsActive(false);
+      return;
+    }
 
     map.getCanvas().style.cursor = "crosshair";
 
@@ -179,7 +196,11 @@ export function useCommentTool({ mapControllerRef, collaboration }: UseCommentTo
       map.getCanvas().style.cursor = "";
       map.off("click", handleMapClick);
     };
-  }, [isActive, mapControllerRef]);
+    // `mapReadyGeneration` is what makes this re-run on an engine hand-off: the
+    // ref has stable identity, so without it a tool armed on the 2D map would
+    // stay armed across a switch and never attach to the replacement map
+    // (#2268 review).
+  }, [isActive, mapControllerRef, mapReadyGeneration]);
 
   return {
     isActive,

--- a/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
+++ b/apps/geolibre-desktop/src/components/comments/useCommentTool.ts
@@ -25,10 +25,21 @@ export function useCommentTool({ mapControllerRef, collaboration }: UseCommentTo
   const addComment = useAppStore((s) => s.addComment);
   const collab = useAppStore((s) => s.collaboration);
 
+  /**
+   * Whether the current engine can host the tool at all. Placing a comment needs
+   * a map click and feature picking, both MapLibre-only today, so an engine
+   * without a native map must not let the tool arm (#2268 review).
+   */
+  const canPlaceComments = useCallback(
+    () => mapControllerRef.current?.capabilities.nativeMapInstance !== false,
+    [mapControllerRef],
+  );
+
   const activateTool = useCallback(() => {
+    if (!canPlaceComments()) return;
     setIsActive(true);
     setPendingComment(null);
-  }, []);
+  }, [canPlaceComments]);
 
   const deactivateTool = useCallback(() => {
     setIsActive(false);
@@ -36,9 +47,9 @@ export function useCommentTool({ mapControllerRef, collaboration }: UseCommentTo
   }, []);
 
   const toggleTool = useCallback(() => {
-    setIsActive((prev) => !prev);
+    setIsActive((prev) => (prev ? false : canPlaceComments()));
     setPendingComment(null);
-  }, []);
+  }, [canPlaceComments]);
 
   const submitComment = useCallback(
     (body: string, authorName?: string) => {

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@geolibre/ui";
 import { Database } from "lucide-react";
 import { useCallback, useMemo, useState, type RefObject } from "react";
@@ -34,7 +34,7 @@ export type { AddDataKind } from "./add-data/types";
 
 interface AddDataDialogProps {
   kind: AddDataKind | null;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   onOpenChange: (open: boolean) => void;
   /**
    * Deck.gl Layer kind to pre-select when the dialog opens as `deckgl-viz`

--- a/apps/geolibre-desktop/src/components/layout/BasemapExtractPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BasemapExtractPanel.tsx
@@ -4,7 +4,6 @@ import {
   createPMTilesStoreLayer,
   evictOfflineBasemapStyle,
   hasPMTilesArchive,
-  type MapController,
   OFFLINE_BASEMAP_SENTINEL_PREFIX,
   PROTOMAPS_FLAVORS,
   type ProtomapsFlavor,
@@ -12,6 +11,7 @@ import {
   registerOfflineBasemapStyle,
   registerPMTilesArchive,
   unregisterPMTilesArchive,
+  type MapEngine,
 } from "@geolibre/map";
 import { extractPmtiles, type PmtilesExtractProgress } from "@geolibre/processing";
 import { Button, Input, Label, Select } from "@geolibre/ui";
@@ -111,7 +111,7 @@ const EMPTY_COORDS: CoordFields = { west: "", south: "", east: "", north: "" };
 interface BasemapExtractPanelProps {
   open: boolean;
   onClose: () => void;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /** Round a coordinate to a readable-but-precise 6 decimal places. */

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -1,6 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import { Button, Input } from "@geolibre/ui";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { ChevronUp, MapPin, Send, Settings2, Users, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,7 +15,7 @@ interface Announcement {
 
 interface CollaborationStatusBadgeProps {
   api: CollaborationApi;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 // How long a join/leave announcement stays on screen before auto-dismissing.

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1388,6 +1388,16 @@ export function DesktopShell({
   // after they meant to dismiss it (#2217 review).
   useEffect(() => {
     if (!cesiumPrimary) return;
+    // Bump the readiness generation on the hand-off. It is no longer *reset*
+    // (that is what left every consumer pointing at nothing on the globe), but
+    // the reset did do one useful thing: it forced the generation-gated effects
+    // — viewport history, the embed/notebook/command bridges — to re-run and
+    // detach their listeners from the outgoing MapLibre map. Without a bump
+    // they would not re-run until a new engine published, so a globe that never
+    // becomes ready would leave those closures holding a destroyed map for the
+    // session (#2268 review). Incrementing keeps that cleanup timing while the
+    // ref itself stays live.
+    setMapReadyGeneration((generation) => generation + 1);
     setRasterSubsetLayer(null);
     setBasemapExtractOpen(false);
     setObjectDetectionOpen(false);

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,7 +1,7 @@
 // @refresh reset
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
-import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
+import type { MapDiagnosticEvent, MapEngine } from "@geolibre/map";
 import { getLayerBounds, MapCanvas, setExternalDeckLayerOrderHandler } from "@geolibre/map";
 import { useTranslation } from "react-i18next";
 import {
@@ -657,7 +657,7 @@ export function DesktopShell({
   // mid-drag still detaches the global listeners and restores document.body.
   const activeResizeCleanupRef = useRef<(() => void) | null>(null);
   useEffect(() => () => activeResizeCleanupRef.current?.(), []);
-  const mapControllerRef = useRef<MapController | null>(null);
+  const mapControllerRef = useRef<MapEngine | null>(null);
 
   // Frame layers a `?data=` deep link added. Single non-GeoJSON datasets move
   // the camera in their format-specific loader; a repeated `data` batch lists
@@ -1367,20 +1367,20 @@ export function DesktopShell({
   );
   const setObjectDetectionOpen = useAppStore((s) => s.setObjectDetectionOpen);
   const setSegmentEverythingOpen = useAppStore((s) => s.setSegmentEverythingOpen);
-  // Switching to the globe destroys the MapLibre map, which would otherwise
-  // leave `mapControllerRef` pointing at a removed map and `mapReadyGeneration`
-  // claiming one is live. Reset both to the boot state — the "no map yet" case
-  // every consumer already handles — so nothing calls into a dead map. Switching
-  // back remounts MapCanvas, which fires onControllerReady and re-arms them.
+  // Switching engines swaps which engine the shared ref points at: MapCanvas
+  // unmounts and clears it, then PrimaryCesiumCanvas publishes its CesiumEngine
+  // (and the reverse on the way back). The ref is no longer nulled wholesale
+  // here — that was necessary while only MapLibre implemented the surface, and
+  // it is what left every menu, panel, and shortcut pointing at nothing on the
+  // globe (#2260). Each canvas owns clearing its own engine on unmount, so the
+  // ref is never left aimed at a destroyed map.
   //
-  // The four MapLibre-only panels below unmount with the map, so any that were
-  // open are closed here too. Without this their open flags survive on the
+  // The MapLibre-only panels below still unmount with the 2D map, so any that
+  // were open are closed here. Without this their open flags survive on the
   // globe and the panel springs back the moment the user returns to 2D, long
   // after they meant to dismiss it (#2217 review).
   useEffect(() => {
     if (!cesiumPrimary) return;
-    mapControllerRef.current = null;
-    setMapReadyGeneration(0);
     setRasterSubsetLayer(null);
     setBasemapExtractOpen(false);
     setObjectDetectionOpen(false);
@@ -2596,7 +2596,10 @@ export function DesktopShell({
                   neutral, store-driven overlays sit outside the branch and are
                   available under either engine. */}
               {cesiumPrimary ? (
-                <PrimaryCesiumCanvas />
+                <PrimaryCesiumCanvas
+                  engineRef={mapControllerRef}
+                  onEngineReady={handleMapControllerReady}
+                />
               ) : (
                 <>
                   <MapCanvas

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -933,7 +933,7 @@ export function DesktopShell({
   // the Collaborate dialog and the on-canvas status badge share one socket, and
   // so the dialog stays mounted in toolbar-hidden layouts.
   const collaboration = useCollaboration(mapControllerRef);
-  const commentTool = useCommentTool({ mapControllerRef, collaboration });
+  const commentTool = useCommentTool({ mapControllerRef, collaboration, mapReadyGeneration });
   const [showResolvedComments, setShowResolvedComments] = useState(false);
   const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null);
   const collaborateDialogOpen = useAppStore((s) => s.ui.collaborateDialogOpen);

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -956,7 +956,7 @@ export function DesktopShell({
   // Runtime postMessage API for a third-party host page that frames the app
   // (fly to a record, highlight it, open a tool; selection/view/tool events back
   // out). Off unless the deployment configured GEOLIBRE_EMBED_ORIGINS.
-  useEmbedApi(mapControllerRef, mapAppAPI);
+  useEmbedApi(mapControllerRef, mapAppAPI, mapReadyGeneration);
   // Same scripting surface, reached over the desktop Jupyter server's relay, so
   // a kernel driven from an EXTERNAL client (VS Code's Jupyter extension) can
   // control the map too. Inert until that server is running.

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -952,7 +952,7 @@ export function DesktopShell({
   useEmbedBridge(mapControllerRef);
   // Request/reply + event channel backing the Python scripting API (live
   // queries, processing, map events). Also inert when not embedded.
-  useCommandBridge(mapControllerRef);
+  useCommandBridge(mapControllerRef, mapReadyGeneration);
   // Runtime postMessage API for a third-party host page that frames the app
   // (fly to a record, highlight it, open a tool; selection/view/tool events back
   // out). Off unless the deployment configured GEOLIBRE_EMBED_ORIGINS.
@@ -1255,7 +1255,14 @@ export function DesktopShell({
     // or the map is reinitialised (mapReadyGeneration), not on every
     // incremental plugin write-back. projectPlugins is read from the store
     // snapshot at call time so it is always current without being a dependency.
-    if (!externalPluginsReady || !mapReadyGeneration || !mapControllerRef.current) return;
+    // Every restore below re-binds a MapLibre control or source, so they need a
+    // native map. This used to be implied: the ref was null on the globe, so the
+    // effect never ran there. Now it holds a `CesiumEngine`, and the guard has to
+    // be stated (#2268 review). Making these restores engine-neutral is
+    // follow-up work, not a silent behaviour change here.
+    const engine = mapControllerRef.current;
+    if (!externalPluginsReady || !mapReadyGeneration || !engine) return;
+    if (!engine.capabilities.nativeMapInstance) return;
     const appAPI = createAppAPI(mapControllerRef);
     const pluginManager = getPluginManager();
     pluginManager.restoreProjectState(useAppStore.getState().projectPlugins, appAPI);
@@ -2865,6 +2872,7 @@ export function DesktopShell({
               <NotebookPanel
                 onResizeStart={startNotebookPanelResize}
                 mapControllerRef={mapControllerRef}
+                mapReadyGeneration={mapReadyGeneration}
                 themeMode={themeMode}
               />
             </Suspense>

--- a/apps/geolibre-desktop/src/components/layout/FieldCollectionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/FieldCollectionDialog.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import * as maplibregl from "maplibre-gl";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   currentEditorIdentity,
   editorTrackingFieldNames,
@@ -72,7 +72,7 @@ import { releaseBodyPointerEvents } from "../../lib/radix-compat";
 interface FieldCollectionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   /** Bumped by the shell whenever the map controller (re)initialises. */
   mapReadyGeneration: number;
 }

--- a/apps/geolibre-desktop/src/components/layout/GeoreferencerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GeoreferencerDialog.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type * as maplibregl from "maplibre-gl";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, useAppStore } from "@geolibre/core";
 import {
   Button,
@@ -48,7 +48,7 @@ import { releaseBodyPointerEvents } from "../../lib/radix-compat";
 interface GeoreferencerDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 interface LoadedImage {

--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { Feature, FeatureCollection } from "geojson";
 import * as maplibregl from "maplibre-gl";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { useAppStore } from "@geolibre/core";
 import {
   Button,
@@ -75,7 +75,7 @@ import { saveTextFileWithFallback } from "../../lib/tauri-io";
 interface GpsTrackingDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /** Transient map sources for the live position overlays (not store layers, so

--- a/apps/geolibre-desktop/src/components/layout/LoadFeaturesIntoEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/LoadFeaturesIntoEditorDialog.tsx
@@ -1,6 +1,6 @@
 import { Button, cn, Input, Label, Select } from "@geolibre/ui";
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   buildEditorSaveCollection,
   getGeoEditorFeatureCount,
@@ -35,7 +35,7 @@ import { exportVectorLayer } from "../../lib/vector-export";
 interface LoadFeaturesIntoEditorDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   /** Store layer to preselect (set when opened from a layer's context menu). */
   initialLayerId: string | null;
 }

--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -1,5 +1,5 @@
 import { isAllowedPluginManifestUrl } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   Button,
   Dialog,
@@ -90,7 +90,7 @@ const ManagePluginsTrans = Trans as ComponentType<ManagePluginsTransProps>;
 interface ManagePluginsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 export function ManagePluginsDialog({

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useAppStore, FEET_PER_METER, METERS_PER_MILE } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -105,7 +105,7 @@ export function MapContextMenu({
   mapReadyGeneration,
   onExplorePlace,
 }: {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   mapReadyGeneration: number;
   /** Open a Wikipedia knowledge card for the clicked coordinate. */
   onExplorePlace?: (lat: number, lng: number) => void;

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -9,7 +9,7 @@ import {
   REVERSE_GEOCODE_PLUGIN_ID,
   subscribeDirectionsState,
 } from "@geolibre/plugins";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Clock, MapPin, Navigation, Route, Trash2, Undo2, X } from "lucide-react";
 import { type RefObject, useSyncExternalStore } from "react";
 import type { TFunction } from "i18next";
@@ -18,7 +18,7 @@ import { Button } from "@geolibre/ui";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 
 interface MapModeBannerProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 function formatDistance(meters: number, locale: string, t: TFunction): string {

--- a/apps/geolibre-desktop/src/components/layout/NetcdfCubeSetupDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfCubeSetupDialog.tsx
@@ -1,4 +1,4 @@
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { LocalNetcdfAxis } from "@geolibre/plugins";
 import {
   Button,
@@ -32,7 +32,7 @@ import { clearPrintExtent, drawPrintExtent } from "../../lib/print-extent";
 
 interface NetcdfCubeSetupDialogProps {
   /** The live map, for "use the current view" and for drawing an extent. */
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/layout/NetcdfCubeWindow.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfCubeWindow.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { gridPixelAt, type LocalNetcdfGrid, type LocalNetcdfWindow } from "@geolibre/plugins";
 import { Button, ColorRampSelect, Label } from "@geolibre/ui";
 import { Boxes, GripVertical, Settings2, X } from "lucide-react";
@@ -57,7 +57,7 @@ const DEFAULT_Z_SCALE = 1;
 
 interface NetcdfCubeWindowProps {
   /** The live map, for reading the view to window the cube against. */
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /**
@@ -544,7 +544,7 @@ function formatBand(value: number): string {
  * @returns The window to read every band plane with.
  */
 function cubeWindow(
-  controller: MapController | null,
+  controller: MapEngine | null,
   grid: LocalNetcdfGrid,
   settings: NetcdfCubeSettings,
 ): LocalNetcdfWindow {
@@ -557,7 +557,7 @@ function cubeWindow(
 
 /** The cells under the chosen extent, or null for the whole grid. */
 function extentRect(
-  controller: MapController | null,
+  controller: MapEngine | null,
   grid: LocalNetcdfGrid,
   settings: NetcdfCubeSettings,
 ): CellRect | null {

--- a/apps/geolibre-desktop/src/components/layout/NetcdfSampleMarkers.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfSampleMarkers.tsx
@@ -1,6 +1,6 @@
 import * as maplibregl from "maplibre-gl";
 import { type RefObject, useEffect, useSyncExternalStore } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { netcdfSeriesColor } from "../../lib/netcdf-profile-series";
 import {
   getNetcdfProfileSamples,
@@ -56,7 +56,7 @@ export function NetcdfSampleMarkers({
   mapControllerRef,
   mapReadyGeneration,
 }: {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   mapReadyGeneration: number;
 }) {
   const samples = useSyncExternalStore(

--- a/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
@@ -14,7 +14,7 @@ import { Crosshair, Download, GripVertical, LineChart, Loader2, Trash2, X } from
 import { type RefObject, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as maplibregl from "maplibre-gl";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { type ChartDomain, resolveChartDomain } from "../../lib/chart-domain";
 import { useFloatingPanelRect } from "../../hooks/useFloatingPanelRect";
 import { usePluginRegistry } from "../../hooks/usePlugins";
@@ -51,7 +51,7 @@ const SERIES_COLORS = [
 const SOURCE_DASHES: (string | undefined)[] = [undefined, "4 3", "2 2", "8 3"];
 
 interface PixelTimeSeriesControlProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
@@ -1,6 +1,19 @@
-import { CesiumCanvas } from "@geolibre/map";
+import { CesiumCanvas, type MapEngine } from "@geolibre/map";
+import type { RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useCesiumIonToken } from "../../hooks/useCesiumIonToken";
+
+export interface PrimaryCesiumCanvasProps {
+  /**
+   * The shared engine ref the rest of the app drives the map through. The globe
+   * publishes its `CesiumEngine` into it exactly as `MapCanvas` publishes its
+   * `MapController`, so menus, panels, and shortcuts act on whichever renderer
+   * is live (issue #2260).
+   */
+  engineRef: RefObject<MapEngine | null>;
+  /** Called once the engine is live, to re-arm anything keyed to map readiness. */
+  onEngineReady: () => void;
+}
 
 /**
  * The primary map area drawn by the CesiumJS globe (issue #2217).
@@ -10,11 +23,14 @@ import { useCesiumIonToken } from "../../hooks/useCesiumIonToken";
  * basemap, layers, groups, visibility, opacity — so switching engines changes
  * only what draws the project, never the project itself.
  *
- * It renders no `MapController`, so the MapLibre-only overlays (context menu,
- * legend, comments, story map, terrain, the ML panels) are not mounted beside
- * it, and the View menu greys out the items that drive one.
+ * It publishes a `CesiumEngine` into the shared engine ref rather than a
+ * `MapController`, so camera work, terrain, and layer sync all reach the globe
+ * through the same calls the 2D map answers. The MapLibre-only overlays
+ * (context menu, legend, comments, story map, the ML panels) are still not
+ * mounted beside it, and the menus gate those on `engine.capabilities` rather
+ * than on the renderer's name.
  */
-export function PrimaryCesiumCanvas() {
+export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumCanvasProps) {
   const { t } = useTranslation();
   const ionToken = useCesiumIonToken();
 
@@ -24,7 +40,12 @@ export function PrimaryCesiumCanvas() {
           the globe: `Cesium.Ion.defaultAccessToken` is applied once at viewer
           creation, so without a remount a swapped token would never take
           effect. Mirrors the globe panes in MapGrid. */}
-      <CesiumCanvas key={ionToken} ionToken={ionToken} />
+      <CesiumCanvas
+        key={ionToken}
+        ionToken={ionToken}
+        engineRef={engineRef}
+        onEngineReady={onEngineReady}
+      />
       {/* The globe works without an Ion token — it draws the project basemap —
           so say what a token would add rather than hiding the view. Bottom-end
           keeps it clear of Cesium's own credit display (bottom-left) and of the

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -7,7 +7,7 @@ import {
   VECTOR_COLOR_RAMPS,
   type PrintLayoutConfig,
 } from "@geolibre/core";
-import { loadMarkerSvgImage, type MapController } from "@geolibre/map";
+import { loadMarkerSvgImage, type MapEngine } from "@geolibre/map";
 import { GRATICULE_LABEL_LAYER_ID } from "@geolibre/plugins";
 import {
   Button,
@@ -119,7 +119,7 @@ import { clearAtlasFeatureMask, showAtlasFeatureMask } from "../../lib/print-atl
 interface PrintLayoutDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /** Common industry scale denominators offered as quick presets (GH #522). */
@@ -1414,7 +1414,7 @@ export function PrintLayoutDialog({
    * dialog and delay "idle" indefinitely (same failure mode as GH #743);
    * captureMapImage forces a redraw, so proceeding is safe. */
   const waitForAtlasSettle = useCallback(
-    (map: NonNullable<ReturnType<MapController["getMap"]>>) =>
+    (map: NonNullable<ReturnType<MapEngine["getMap"]>>) =>
       new Promise<void>((resolve) => {
         let done = false;
         let timer = 0;

--- a/apps/geolibre-desktop/src/components/layout/RasterSubsetPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RasterSubsetPanel.tsx
@@ -1,5 +1,5 @@
 import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button, Input, Label, Textarea } from "@geolibre/ui";
 import {
   ChevronDown,
@@ -59,7 +59,7 @@ interface RasterSubsetPanelProps {
   /** The layer being extracted, or `null` when the panel is closed. */
   layer: GeoLibreLayer | null;
   onClose: () => void;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /** Round a coordinate to a readable-but-precise 6 decimal places. */

--- a/apps/geolibre-desktop/src/components/layout/RecordTourDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RecordTourDialog.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button, cn, Input, Label, Select } from "@geolibre/ui";
 import {
   ArrowDown,
@@ -50,7 +50,7 @@ import {
 interface RecordTourDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 // "ready" holds a finished recording in memory so saving is a deliberate second

--- a/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
@@ -1,4 +1,4 @@
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button, cn, Input, Label, Select } from "@geolibre/ui";
 import {
   Circle,
@@ -33,7 +33,7 @@ import { RegionSelectOverlay } from "./RegionSelectOverlay";
 interface RecordVideoDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 // "ready" holds a finished recording in memory so saving is a deliberate second

--- a/apps/geolibre-desktop/src/components/layout/RegionSelectOverlay.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RegionSelectOverlay.tsx
@@ -1,9 +1,9 @@
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { useEffect, useRef, useState } from "react";
 import { MIN_REGION_SIZE, type RecordRegion } from "../../lib/map-recorder";
 
 interface RegionSelectOverlayProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   /**
    * - `select`: drag a new rectangle (crosshair, captures pointer events).
    * - `frame`: show the chosen rectangle as a fixed frame; pointer events pass

--- a/apps/geolibre-desktop/src/components/layout/RemoteCursorsOverlay.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RemoteCursorsOverlay.tsx
@@ -2,7 +2,7 @@ import { useAppStore, type CollaborationPresence } from "@geolibre/core";
 import * as maplibregl from "maplibre-gl";
 import { useEffect, useRef } from "react";
 import type { RefObject } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
 import type { Feature, FeatureCollection, Polygon } from "geojson";
 
@@ -23,7 +23,7 @@ const VIEWPORT_LAYER_ID = "__geolibre_collab_viewports_line";
 export function RemoteCursorsOverlay({
   mapControllerRef,
 }: {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }): null {
   const presence = useAppStore((s) => s.collaboration.presence);
   const isActive = useAppStore((s) => s.collaboration.isActive);

--- a/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
@@ -13,7 +13,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@geolibre/ui";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { ParseKeys } from "i18next";
 import { ChevronDown, ClipboardPaste, Info } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -31,7 +31,7 @@ import {
 interface SetViewDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -35,7 +35,7 @@ import {
   Select,
   cn,
 } from "@geolibre/ui";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   Bot,
   Braces,
@@ -197,7 +197,7 @@ interface SettingsDialogProps {
   buttonClassName?: string;
   buttonSize?: "default" | "sm" | "lg" | "icon" | null;
   iconClassName?: string;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   showLabels?: boolean;
   onOpenManagePlugins: () => void;
   /** Toggleable plugins for the Interface (UI profile) section (issue #500). */

--- a/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
@@ -5,7 +5,7 @@ import {
   TERRAIN_SETTINGS_CLOSE_EVENT,
   TERRAIN_SETTINGS_EVENT,
   type CogDemErrorCode,
-  type MapController,
+  type MapEngine,
 } from "@geolibre/map";
 import {
   Button,
@@ -43,7 +43,7 @@ const SOURCE_ERROR_KEYS = {
 } as const satisfies Record<CogDemErrorCode, string>;
 
 export interface TerrainSettingsDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -5,7 +5,8 @@ import {
   serializeProject,
   useAppStore,
 } from "@geolibre/core";
-import { DEFAULT_BUILT_IN_CONTROL_VISIBILITY, type MapController } from "@geolibre/map";
+import { DEFAULT_BUILT_IN_CONTROL_VISIBILITY, type MapEngine } from "@geolibre/map";
+import { useMapCapabilities } from "../../hooks/useMapCapabilities";
 import {
   closeDuckDBLayerPanel,
   closeEarthEnginePanel,
@@ -181,7 +182,7 @@ import {
 interface TopToolbarProps {
   compact?: boolean;
   diagnosticsErrorCount: number;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   mapReadyGeneration: number;
   showLabels?: boolean;
   showProjectInfo?: boolean;
@@ -1148,6 +1149,7 @@ export function TopToolbar({
   // The globe owns the primary map, so the MapLibre-only entries below are dead
   // while it is active and the View menu becomes the only way back to 2D (#2217).
   const cesiumPrimary = useAppStore((s) => s.primaryRenderer) === "cesium";
+  const capabilities = useMapCapabilities(mapControllerRef);
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
   const setLoadEditorFeaturesOpen = useAppStore((s) => s.setLoadEditorFeaturesOpen);
   const loadEditorFeaturesOpen = useAppStore((s) => s.ui.loadEditorFeaturesOpen);
@@ -1682,10 +1684,10 @@ export function TopToolbar({
             run: () => setSegmentationOpen(true),
           },
         ]),
-    // Both panels need the MapLibre canvas, which the globe replaces; the
-    // palette has no disabled state, so drop the commands rather than offer
-    // two that silently do nothing (#2217 review).
-    ...(cesiumPrimary
+    // Both panels read pixels off the MapLibre canvas; the palette has no
+    // disabled state, so drop the commands rather than offer two that silently
+    // do nothing (#2217 review). Gated on the capability, not the engine name.
+    ...(!capabilities.nativeMapInstance
       ? []
       : [
           {
@@ -1818,93 +1820,87 @@ export function TopToolbar({
       run: panels.viewState.toggle,
     },
     // View
-    // All eight drive the MapLibre `MapController`, which is null while the
-    // globe owns the primary map — and this array feeds the global shortcut
-    // layer and the cheat sheet as well as the palette, so leaving them in
-    // would keep "[", "]", "n", "u" and "r" firing into nothing and let
-    // Set View open a dialog that silently no-ops on submit. Dropping them
-    // matches the greyed-out ViewMenu items (#2217 review). `view.comments`
-    // below opens a panel from the store, so it stays.
-    ...(cesiumPrimary
-      ? []
-      : [
-          {
-            id: "view.zoom-in",
-            title: t("toolbar.command.zoomIn"),
-            group: t("toolbar.commandGroup.view"),
-            keywords: "zoom in closer magnify scale",
-            icon: ZoomIn,
-            run: () => mapControllerRef.current?.zoomIn(),
-          },
-          {
-            id: "view.zoom-out",
-            title: t("toolbar.command.zoomOut"),
-            group: t("toolbar.commandGroup.view"),
-            keywords: "zoom out farther wider scale",
-            icon: ZoomOut,
-            run: () => mapControllerRef.current?.zoomOut(),
-          },
-          {
-            id: "view.previous",
-            title: t("toolbar.command.previousView"),
-            group: t("toolbar.commandGroup.view"),
-            keywords: "back history viewport extent previous undo pan zoom",
-            icon: ArrowLeft,
-            // "[" / "]" step through viewport history (unbound by MapLibre).
-            shortcut: { key: "[" },
-            run: viewportHistory.goBack,
-          },
-          {
-            id: "view.next",
-            title: t("toolbar.command.nextView"),
-            group: t("toolbar.commandGroup.view"),
-            keywords: "forward history viewport extent next redo pan zoom",
-            icon: ArrowRight,
-            shortcut: { key: "]" },
-            run: viewportHistory.goForward,
-          },
-          {
-            id: "view.reset-north",
-            title: t("toolbar.command.resetNorth"),
-            group: t("toolbar.commandGroup.view"),
-            keywords: "north bearing rotation rotate compass orientation",
-            icon: Compass,
-            // Plain "N" (Google Earth Pro's north-up shortcut). No modifier, so it
-            // never clashes with ⌘/Ctrl+N (New project) and leaves MapLibre's own
-            // arrow/zoom keys untouched.
-            shortcut: { key: "n" },
-            run: () => mapControllerRef.current?.resetNorth(),
-          },
-          {
-            id: "view.reset-pitch",
-            title: t("toolbar.command.resetPitch"),
-            group: t("toolbar.commandGroup.view"),
-            keywords: "pitch tilt top down overhead flat level plan 2d reset",
-            icon: Grid2x2,
-            // Plain "U" resets pitch to a top-down view (Google Earth Pro's shortcut).
-            shortcut: { key: "u" },
-            run: () => mapControllerRef.current?.resetPitch(),
-          },
-          {
-            id: "view.reset-pitch-bearing",
-            title: t("toolbar.command.resetPitchBearing"),
-            group: t("toolbar.commandGroup.view"),
-            keywords: "pitch bearing tilt rotation north flat level 3d",
-            icon: Mountain,
-            // Plain "R" resets pitch and bearing (like Google Earth Pro's reset view).
-            shortcut: { key: "r" },
-            run: () => mapControllerRef.current?.resetNorthPitch(),
-          },
-          {
-            id: "view.set-view",
-            title: t("toolbar.command.setView"),
-            group: t("toolbar.commandGroup.view"),
-            keywords:
-              "set view go to coordinates center zoom pitch bearing camera location longitude latitude",
-            icon: Crosshair,
-            run: () => setSetViewOpen(true),
-          },
-        ]),
+    // All eight drive the shared engine's camera, which every engine
+    // implements — so they stay in the palette (and in the shortcut layer and
+    // cheat sheet this array also feeds) whichever renderer is live. They were
+    // dropped on the globe only because the ref was nulled there (#2217); it
+    // now points at the `CesiumEngine` (#2260).
+    {
+      id: "view.zoom-in",
+      title: t("toolbar.command.zoomIn"),
+      group: t("toolbar.commandGroup.view"),
+      keywords: "zoom in closer magnify scale",
+      icon: ZoomIn,
+      run: () => mapControllerRef.current?.zoomIn(),
+    },
+    {
+      id: "view.zoom-out",
+      title: t("toolbar.command.zoomOut"),
+      group: t("toolbar.commandGroup.view"),
+      keywords: "zoom out farther wider scale",
+      icon: ZoomOut,
+      run: () => mapControllerRef.current?.zoomOut(),
+    },
+    {
+      id: "view.previous",
+      title: t("toolbar.command.previousView"),
+      group: t("toolbar.commandGroup.view"),
+      keywords: "back history viewport extent previous undo pan zoom",
+      icon: ArrowLeft,
+      // "[" / "]" step through viewport history (unbound by MapLibre).
+      shortcut: { key: "[" },
+      run: viewportHistory.goBack,
+    },
+    {
+      id: "view.next",
+      title: t("toolbar.command.nextView"),
+      group: t("toolbar.commandGroup.view"),
+      keywords: "forward history viewport extent next redo pan zoom",
+      icon: ArrowRight,
+      shortcut: { key: "]" },
+      run: viewportHistory.goForward,
+    },
+    {
+      id: "view.reset-north",
+      title: t("toolbar.command.resetNorth"),
+      group: t("toolbar.commandGroup.view"),
+      keywords: "north bearing rotation rotate compass orientation",
+      icon: Compass,
+      // Plain "N" (Google Earth Pro's north-up shortcut). No modifier, so it
+      // never clashes with ⌘/Ctrl+N (New project) and leaves MapLibre's own
+      // arrow/zoom keys untouched.
+      shortcut: { key: "n" },
+      run: () => mapControllerRef.current?.resetNorth(),
+    },
+    {
+      id: "view.reset-pitch",
+      title: t("toolbar.command.resetPitch"),
+      group: t("toolbar.commandGroup.view"),
+      keywords: "pitch tilt top down overhead flat level plan 2d reset",
+      icon: Grid2x2,
+      // Plain "U" resets pitch to a top-down view (Google Earth Pro's shortcut).
+      shortcut: { key: "u" },
+      run: () => mapControllerRef.current?.resetPitch(),
+    },
+    {
+      id: "view.reset-pitch-bearing",
+      title: t("toolbar.command.resetPitchBearing"),
+      group: t("toolbar.commandGroup.view"),
+      keywords: "pitch bearing tilt rotation north flat level 3d",
+      icon: Mountain,
+      // Plain "R" resets pitch and bearing (like Google Earth Pro's reset view).
+      shortcut: { key: "r" },
+      run: () => mapControllerRef.current?.resetNorthPitch(),
+    },
+    {
+      id: "view.set-view",
+      title: t("toolbar.command.setView"),
+      group: t("toolbar.commandGroup.view"),
+      keywords:
+        "set view go to coordinates center zoom pitch bearing camera location longitude latitude",
+      icon: Crosshair,
+      run: () => setSetViewOpen(true),
+    },
     {
       id: "view.comments",
       title: t("toolbar.command.viewComments"),

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -2166,15 +2166,23 @@ export function TopToolbar({
           // `animateTo`. Reading them off the MapLibre map would report `null`
           // on the globe and leave Zoom In/Out never showing as "at limit".
           getCamera={() => {
-            const view = mapControllerRef.current?.readView();
+            const engine = mapControllerRef.current;
+            const view = engine?.readView();
             if (!view) return null;
+            // Prefer the limits the engine actually enforces: MapLibre's
+            // effective minZoom is raised above the raw preference when
+            // `restrictBounds` is set, so reading the preference alone would
+            // leave Zoom Out enabled at the true floor (#2268 review). The
+            // preference is the fallback for an engine with no native map,
+            // which clamps to it directly.
+            const map = engine?.getMap();
             const { map: mapPreferences } = useAppStore.getState().preferences;
             return {
               zoom: view.zoom,
               bearing: view.bearing,
               pitch: view.pitch,
-              minZoom: mapPreferences.minZoom,
-              maxZoom: mapPreferences.maxZoom,
+              minZoom: map ? map.getMinZoom() : mapPreferences.minZoom,
+              maxZoom: map ? map.getMaxZoom() : mapPreferences.maxZoom,
             };
           }}
           onResetNorth={() => mapControllerRef.current?.resetNorth()}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1508,13 +1508,20 @@ export function TopToolbar({
           },
         ]
       : []),
-    {
-      id: "project.print-layout",
-      title: t("toolbar.item.printLayoutEllipsis"),
-      group: t("toolbar.commandGroup.project"),
-      icon: Printer,
-      run: () => setPrintLayoutOpen(true),
-    },
+    // Print layout renders from the MapLibre canvas; the palette has no disabled
+    // state, so drop the command rather than offer one that opens a dialog which
+    // cannot produce a preview (#2268 review).
+    ...(capabilities.nativeMapInstance
+      ? [
+          {
+            id: "project.print-layout",
+            title: t("toolbar.item.printLayoutEllipsis"),
+            group: t("toolbar.commandGroup.project"),
+            icon: Printer,
+            run: () => setPrintLayoutOpen(true),
+          },
+        ]
+      : []),
     // Add Data
     {
       id: "add.vector",
@@ -2153,32 +2160,40 @@ export function TopToolbar({
         <ViewMenu
           chrome={chrome}
           history={viewportHistory}
+          // Engine-neutral: the camera comes from `readView()`, and the zoom
+          // limits from the project preferences both engines apply — MapLibre
+          // through `setMinZoom`/`setMaxZoom`, the globe by clamping in
+          // `animateTo`. Reading them off the MapLibre map would report `null`
+          // on the globe and leave Zoom In/Out never showing as "at limit".
           getCamera={() => {
-            const map = mapControllerRef.current?.getMap();
-            if (!map) return null;
+            const view = mapControllerRef.current?.readView();
+            if (!view) return null;
+            const { map: mapPreferences } = useAppStore.getState().preferences;
             return {
-              zoom: map.getZoom(),
-              bearing: map.getBearing(),
-              pitch: map.getPitch(),
-              minZoom: map.getMinZoom(),
-              maxZoom: map.getMaxZoom(),
+              zoom: view.zoom,
+              bearing: view.bearing,
+              pitch: view.pitch,
+              minZoom: mapPreferences.minZoom,
+              maxZoom: mapPreferences.maxZoom,
             };
           }}
           onResetNorth={() => mapControllerRef.current?.resetNorth()}
           onResetPitch={() => mapControllerRef.current?.resetPitch()}
           onResetPitchBearing={() => mapControllerRef.current?.resetNorthPitch()}
           onSetView={() => setSetViewOpen(true)}
+          // `readView()`, not `getMap()`: both hand-offs only need a camera, which
+          // every engine reports, and the MapLibre escape hatch is `null` on the
+          // globe — which would have made these silently do nothing now that the
+          // menu no longer greys them out (#2268 review).
           onViewInGoogleEarth={() => {
-            const map = mapControllerRef.current?.getMap();
-            if (!map) return;
-            const center = map.getCenter();
-            void openExternalLink(googleEarthUrl(center.lat, center.lng, map.getZoom()));
+            const view = mapControllerRef.current?.readView();
+            if (!view) return;
+            void openExternalLink(googleEarthUrl(view.center[1], view.center[0], view.zoom));
           }}
           onViewInGoogleMaps={() => {
-            const map = mapControllerRef.current?.getMap();
-            if (!map) return;
-            const center = map.getCenter();
-            void openExternalLink(googleMapsUrl(center.lat, center.lng, map.getZoom()));
+            const view = mapControllerRef.current?.readView();
+            if (!view) return;
+            void openExternalLink(googleMapsUrl(view.center[1], view.center[0], view.zoom));
           }}
           onZoomIn={() => mapControllerRef.current?.zoomIn()}
           onZoomOut={() => mapControllerRef.current?.zoomOut()}

--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -20,7 +20,7 @@
  */
 
 import type { GeoLibreLayer } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 // Type-only: erased at compile time, so importing it does not pull maplibre-gl
 // (which `xyz-url` imports at runtime) into the pure builder surface.
 import type { ArcGISLayerType, ArcGISSourceType } from "@geolibre/plugins";
@@ -425,7 +425,7 @@ export interface ApplyServiceDeps {
   /** Store action to add the built layer. */
   addLayer: (layer: GeoLibreLayer, beforeLayerId?: string | null) => void;
   /** Map controller ref, used for the ArcGIS plugin path and to fit new layers. */
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   /** Insert-before layer id, or null/undefined for the top of the stack. */
   beforeLayerId?: string | null;
 }

--- a/apps/geolibre-desktop/src/components/layout/add-data/context.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/context.tsx
@@ -6,12 +6,12 @@
  */
 
 import type { GeoLibreLayer } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { createContext, useContext, type RefObject } from "react";
 import type { MartinConnection } from "./useMartinConnection";
 
 export interface AddDataShellContextValue {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   addLayer: (layer: GeoLibreLayer, beforeLayerId?: string | null) => void;
   existingLayers: GeoLibreLayer[];
   isSubmitting: boolean;

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -376,7 +376,13 @@ export function ControlsMenu({
             </DropdownMenuItem>
           )}
           {show("controls.recordVideo") && (
-            <DropdownMenuItem onSelect={onOpenRecordVideo}>
+            // Same MapLibre-canvas dependency as Record Tour above:
+            // RecordVideoDialog builds its recording canvas from `getMap()` /
+            // `getContainer()` (#2268 review).
+            <DropdownMenuItem
+              onSelect={onOpenRecordVideo}
+              disabled={!capabilities.nativeMapInstance}
+            >
               <Clapperboard className="me-2 h-3.5 w-3.5" />
               {t("toolbar.item.recordVideo")}
             </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -49,6 +49,7 @@ import {
   type ToolbarChrome,
   type ToolbarMapControl,
 } from "./constants";
+import { useMapCapabilities } from "../../../hooks/useMapCapabilities";
 
 /**
  * Controls-menu entries that write to the project rather than only changing
@@ -116,6 +117,7 @@ export function ControlsMenu({
   onOpenRecordVideo,
 }: ControlsMenuProps) {
   const { t } = useTranslation();
+  const capabilities = useMapCapabilities();
   const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
   const show = (id: string) =>
     viewer && AUTHORING_CONTROL_ITEMS.includes(id) ? false : isMenuItemVisible(uiProfile, id);
@@ -362,7 +364,13 @@ export function ControlsMenu({
             </DropdownMenuItem>
           )}
           {show("controls.recordTour") && (
-            <DropdownMenuItem onSelect={onOpenRecordTour}>
+            // Tour recording captures frames from the MapLibre canvas, so without
+            // a native map the Record button would look enabled and do nothing
+            // (#2268 review).
+            <DropdownMenuItem
+              onSelect={onOpenRecordTour}
+              disabled={!capabilities.nativeMapInstance}
+            >
               <Video className="me-2 h-3.5 w-3.5" />
               {t("toolbar.item.recordTour")}
             </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
@@ -6,7 +6,7 @@ import {
   undo,
   useAppStore,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   Button,
   DropdownMenu,
@@ -44,7 +44,7 @@ import type { ToolbarChrome } from "./constants";
 
 interface EditMenuProps {
   chrome: ToolbarChrome;
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -78,9 +78,6 @@ export function ProcessingMenu({
   const setSegmentationOpen = useAppStore((s) => s.setSegmentationOpen);
   const setObjectDetectionOpen = useAppStore((s) => s.setObjectDetectionOpen);
   const setSegmentEverythingOpen = useAppStore((s) => s.setSegmentEverythingOpen);
-  // Both panels read the map canvas through a `MapController`, which does not
-  // exist while the globe owns the primary map — DesktopShell unmounts them
-  // there, so selecting either would do nothing at all (#2217 review).
   // Object detection and segment-everything read pixels off the MapLibre canvas
   // and drive the map directly, so they need a live native map instance — not
   // merely "not Cesium".

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -26,6 +26,7 @@ import { WHITEBOX_MENU_CATALOG } from "../../../lib/whitebox-menu-catalog";
 import { DOWNLOAD_GLOBAL_DEM_TOOL_ID } from "../../../lib/global-dem";
 import { CapabilityNotice, capabilityNoticeId, useCapabilityReason } from "./CapabilityNotice";
 import type { ToolbarChrome } from "./constants";
+import { useMapCapabilities } from "../../../hooks/useMapCapabilities";
 
 // aria-describedby targets for the "your role does not allow this" explanations.
 // One per privilege rather than one per item: several denied entries share a
@@ -80,7 +81,10 @@ export function ProcessingMenu({
   // Both panels read the map canvas through a `MapController`, which does not
   // exist while the globe owns the primary map — DesktopShell unmounts them
   // there, so selecting either would do nothing at all (#2217 review).
-  const cesiumPrimary = useAppStore((s) => s.primaryRenderer) === "cesium";
+  // Object detection and segment-everything read pixels off the MapLibre canvas
+  // and drive the map directly, so they need a live native map instance — not
+  // merely "not Cesium".
+  const capabilities = useMapCapabilities();
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
   const setPythonConsoleOpen = useAppStore((s) => s.setPythonConsoleOpen);
   const setNotebookOpen = useAppStore((s) => s.setNotebookOpen);
@@ -707,7 +711,7 @@ export function ProcessingMenu({
             so it stays available on mobile/web clients (no `!mobile` gate). */}
               {show("processing.objectDetection") && (
                 <DropdownMenuItem
-                  disabled={cesiumPrimary}
+                  disabled={!capabilities.nativeMapInstance}
                   onSelect={() => setObjectDetectionOpen(true)}
                 >
                   {t("toolbar.command.objectDetection")}
@@ -717,7 +721,7 @@ export function ProcessingMenu({
             so it stays available on mobile/web clients (no `!mobile` gate). */}
               {show("processing.segmentEverything") && (
                 <DropdownMenuItem
-                  disabled={cesiumPrimary}
+                  disabled={!capabilities.nativeMapInstance}
                   onSelect={() => setSegmentEverythingOpen(true)}
                 >
                   {t("toolbar.command.segmentEverything")}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -40,6 +40,7 @@ import { isMenuItemVisible } from "../../../lib/ui-profile";
 import type { ShareHostStatus } from "../../../lib/share-geolibre";
 import { CapabilityNotice, capabilityNoticeId } from "./CapabilityNotice";
 import { formatRecentProjectTime, type ToolbarChrome } from "./constants";
+import { useMapCapabilities } from "../../../hooks/useMapCapabilities";
 
 // aria-describedby targets for the "sharing server unavailable" explanation.
 const SHARE_UNAVAILABLE_ID = "project-menu-share-unavailable";
@@ -109,7 +110,9 @@ export function ProjectMenu({
   // The offline-region panel traces the extract area on the MapLibre canvas via
   // a `MapController`. The globe has none and DesktopShell unmounts the panel
   // there, so the entry would open nothing at all (#2217 review).
-  const cesiumPrimary = useAppStore((s) => s.primaryRenderer) === "cesium";
+  // The offline-region export walks the basemap's style document to collect the
+  // tiles it needs, so it depends on the Style Spec rather than on the renderer.
+  const capabilities = useMapCapabilities();
   const recentProjects = useAppStore((s) => s.recentProjects);
   const forgetRecentProject = useAppStore((s) => s.forgetRecentProject);
   const clearRecentProjects = useAppStore((s) => s.clearRecentProjects);
@@ -421,7 +424,7 @@ export function ProjectMenu({
         {show("project.offlineRegion") && (
           <DropdownMenuItem
             onSelect={onOpenOfflineBasemap}
-            disabled={cesiumPrimary || !exportDataCapability.granted}
+            disabled={!capabilities.styleSpec || !exportDataCapability.granted}
             aria-describedby={exportDataDeniedBy}
           >
             <HardDriveDownload className="me-2 h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -107,9 +107,6 @@ export function ProjectMenu({
 }: ProjectMenuProps) {
   const { t } = useTranslation();
   const projectPath = useAppStore((s) => s.projectPath);
-  // The offline-region panel traces the extract area on the MapLibre canvas via
-  // a `MapController`. The globe has none and DesktopShell unmounts the panel
-  // there, so the entry would open nothing at all (#2217 review).
   // The offline-region export walks the basemap's style document to collect the
   // tiles it needs, so it depends on the Style Spec rather than on the renderer.
   const capabilities = useMapCapabilities();
@@ -414,7 +411,10 @@ export function ProjectMenu({
         {show("project.printLayout") && (
           <DropdownMenuItem
             onSelect={onPrintLayout}
-            disabled={!exportImageCapability.granted}
+            // Print layout composes its preview and export from the MapLibre
+            // canvas, so it needs a native map instance rather than merely a
+            // camera (#2268 review).
+            disabled={!capabilities.nativeMapInstance || !exportImageCapability.granted}
             aria-describedby={exportImageDeniedBy}
           >
             <Printer className="me-2 h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
@@ -150,13 +150,12 @@ export function ViewMenu({
   // profile says: this submenu is the only way back to the 2D map, and hiding
   // it there would strand a user on a renderer whose tools are all disabled.
   const showRenderingEngine = show("view.renderingEngine") || primaryRenderer === "cesium";
-  // Every item in this menu except Split View and Rendering engine drives the
-  // MapLibre `MapController` — zoom, viewport history, orientation, Set View,
-  // and the Google Maps/Earth hand-offs all read or animate that map. The globe
-  // has no controller, so they would silently do nothing; grey them out so the
-  // menu shows they are unavailable rather than failing quietly (#2217). The
-  // Rendering engine submenu below stays enabled as the way back to 2D.
-  const noMapLibreMap = primaryRenderer === "cesium";
+  // Zoom, viewport history, orientation, Set View, and the Google Maps/Earth
+  // hand-offs read or animate the camera — which every engine has. They were
+  // greyed out on the globe only because there was no engine behind the ref to
+  // answer them (#2217); `CesiumEngine` answers all of them now, so the gate is
+  // gone (#2260). Items that need a capability the engine lacks say so through
+  // `capabilities` instead of naming the renderer.
   const showGoogleMaps = show("view.googleMaps");
   const showGoogleEarth = show("view.googleEarth");
   const showExternal = showGoogleMaps || showGoogleEarth;
@@ -197,32 +196,26 @@ export function ViewMenu({
         <DropdownMenuLabel>{t("toolbar.menu.view")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {show("view.zoomIn") && (
-          <DropdownMenuItem disabled={atMaxZoom || noMapLibreMap} onSelect={onZoomIn}>
+          <DropdownMenuItem disabled={atMaxZoom} onSelect={onZoomIn}>
             <ZoomIn className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.zoomIn")}</span>
           </DropdownMenuItem>
         )}
         {show("view.zoomOut") && (
-          <DropdownMenuItem disabled={atMinZoom || noMapLibreMap} onSelect={onZoomOut}>
+          <DropdownMenuItem disabled={atMinZoom} onSelect={onZoomOut}>
             <ZoomOut className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.zoomOut")}</span>
           </DropdownMenuItem>
         )}
         {showZoom && showNavigation && <DropdownMenuSeparator />}
         {show("view.previousView") && (
-          <DropdownMenuItem
-            disabled={!history.canGoBack || noMapLibreMap}
-            onSelect={history.goBack}
-          >
+          <DropdownMenuItem disabled={!history.canGoBack} onSelect={history.goBack}>
             <ArrowLeft className="me-2 h-3.5 w-3.5 shrink-0 rtl:rotate-180" />
             <span className="whitespace-nowrap">{t("toolbar.item.previousView")}</span>
           </DropdownMenuItem>
         )}
         {show("view.nextView") && (
-          <DropdownMenuItem
-            disabled={!history.canGoForward || noMapLibreMap}
-            onSelect={history.goForward}
-          >
+          <DropdownMenuItem disabled={!history.canGoForward} onSelect={history.goForward}>
             <ArrowRight className="me-2 h-3.5 w-3.5 shrink-0 rtl:rotate-180" />
             <span className="whitespace-nowrap">{t("toolbar.item.nextView")}</span>
           </DropdownMenuItem>
@@ -231,7 +224,7 @@ export function ViewMenu({
         {showReset && (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger
-              disabled={allResetDisabled || noMapLibreMap}
+              disabled={allResetDisabled}
               className="data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
             >
               <RotateCcw className="h-3.5 w-3.5 shrink-0" />
@@ -268,7 +261,7 @@ export function ViewMenu({
         )}
         {(showZoom || showNavigation || showReset) && showSetView && <DropdownMenuSeparator />}
         {showSetView && (
-          <DropdownMenuItem disabled={noMapLibreMap} onSelect={onSetView}>
+          <DropdownMenuItem onSelect={onSetView}>
             <Crosshair className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.setView")}</span>
           </DropdownMenuItem>
@@ -361,13 +354,13 @@ export function ViewMenu({
           showRenderingEngine) &&
           showExternal && <DropdownMenuSeparator />}
         {showGoogleMaps && (
-          <DropdownMenuItem disabled={noMapLibreMap} onSelect={onViewInGoogleMaps}>
+          <DropdownMenuItem onSelect={onViewInGoogleMaps}>
             <MapIcon className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.viewInGoogleMaps")}</span>
           </DropdownMenuItem>
         )}
         {showGoogleEarth && (
-          <DropdownMenuItem disabled={noMapLibreMap} onSelect={onViewInGoogleEarth}>
+          <DropdownMenuItem onSelect={onViewInGoogleEarth}>
             <Earth className="me-2 h-3.5 w-3.5 shrink-0" />
             <span className="whitespace-nowrap">{t("toolbar.item.viewInGoogleEarth")}</span>
           </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -1,5 +1,5 @@
 import type { ConversionToolKind, RasterToolKind, VectorToolKind } from "@geolibre/core";
-import { type BuiltInMapControl, type MapController, type MapEngine } from "@geolibre/map";
+import { type BuiltInMapControl, type MapEngine } from "@geolibre/map";
 import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
 import type { ParseKeys } from "i18next";
 import type { createAppAPI } from "../../../hooks/usePlugins";
@@ -8,7 +8,7 @@ import type { AddDataKind } from "../AddDataDialog";
 /** The live app API surface plugins and panels are driven through. */
 export type AppApi = ReturnType<typeof createAppAPI>;
 
-/** A ref to the live MapController, shared across the toolbar pieces. */
+/** A ref to the live map engine, shared across the toolbar pieces. */
 export type MapControllerRef = React.RefObject<MapEngine | null>;
 
 /** Built-in map controls that the Controls menu can toggle (all but the layer control). */

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -1,5 +1,5 @@
 import type { ConversionToolKind, RasterToolKind, VectorToolKind } from "@geolibre/core";
-import { type BuiltInMapControl, type MapController } from "@geolibre/map";
+import { type BuiltInMapControl, type MapController, type MapEngine } from "@geolibre/map";
 import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
 import type { ParseKeys } from "i18next";
 import type { createAppAPI } from "../../../hooks/usePlugins";
@@ -9,7 +9,7 @@ import type { AddDataKind } from "../AddDataDialog";
 export type AppApi = ReturnType<typeof createAppAPI>;
 
 /** A ref to the live MapController, shared across the toolbar pieces. */
-export type MapControllerRef = React.RefObject<MapController | null>;
+export type MapControllerRef = React.RefObject<MapEngine | null>;
 
 /** Built-in map controls that the Controls menu can toggle (all but the layer control). */
 export type ToolbarMapControl = Exclude<BuiltInMapControl, "layer-control">;

--- a/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
+++ b/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
@@ -17,7 +17,7 @@ import {
   type LegendCustomEntry,
   type LegendPanelPosition,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { colormapColors, warmColormapColors } from "@geolibre/plugins";
 import { cn } from "@geolibre/ui";
 import {
@@ -174,7 +174,7 @@ export function MapLegendPanel({
   mapControllerRef,
   mapReadyGeneration,
 }: {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   mapReadyGeneration: number;
 }) {
   const { t, i18n } = useTranslation();

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController, MapEngine } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button, Select, Textarea, cn } from "@geolibre/ui";
 import {
   AlertCircle,

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapController, MapEngine } from "@geolibre/map";
 import { Button, Select, Textarea, cn } from "@geolibre/ui";
 import {
   AlertCircle,
@@ -106,7 +106,7 @@ interface Turn {
 }
 
 interface AssistantPanelProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /** Short human-readable summary of a finished tool call. */

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -23,7 +23,7 @@ import {
   updateDuckDBLayerRows,
   type DuckDBAttributeRow,
 } from "@geolibre/plugins";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { GeoJSONSource } from "maplibre-gl";
 import {
   Button,
@@ -370,7 +370,7 @@ function applyDraftsToDuckDBRows(
 }
 
 interface AttributeTableProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 export function AttributeTable({ mapControllerRef }: AttributeTableProps) {

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -7,7 +7,7 @@ import {
   useAppStore,
   type GeoLibreLayer,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { fetchPostgisStatus, listPostgisTables } from "@geolibre/processing";
 import { Input, ScrollArea } from "@geolibre/ui";
 import { Search } from "lucide-react";
@@ -47,7 +47,7 @@ const CONNECTION_ID_PREFIX = "connection:";
 const FOLDER_ID_PREFIX = "folder:";
 
 interface BrowserPanelProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   /**
    * Open a recent project by path (shared with the toolbar's instance).
    * Resolves to an error message to show inline, or null on success.

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -66,11 +66,7 @@ import {
   type TimePropertyCandidate,
   type TimePropertyRecord,
 } from "@geolibre/plugins";
-import {
-  defaultBlankBackgroundColor,
-  startFeatureSelection,
-  type MapController,
-} from "@geolibre/map";
+import { defaultBlankBackgroundColor, startFeatureSelection, type MapEngine } from "@geolibre/map";
 import {
   applyMapboxStyleImport,
   applyQmlImport,
@@ -254,11 +250,12 @@ import { participantCanEditLayer } from "../../lib/collab-protocol";
 import type { CollaborationApi } from "../../hooks/useCollaboration";
 import { BasemapPickerDialog } from "./BasemapPickerDialog";
 import { LayerPanelPlaceSearch } from "./LayerPanelPlaceSearch";
+import { useMapCapabilities } from "../../hooks/useMapCapabilities";
 import { LayerSwatchIcon } from "./LayerSwatchIcon";
 
 interface LayerPanelProps {
   themeMode: ThemeMode;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   collaborationApi?: CollaborationApi;
   onResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
   /** Id of the layer currently in a geometry-edit session, or null. */
@@ -663,6 +660,9 @@ export function LayerPanel({
   // The 3D globe draws a subset of the layer kinds MapLibre does, so rows it
   // cannot render are flagged while it owns the primary map area (#2217).
   const cesiumPrimary = useAppStore((s) => s.primaryRenderer === "cesium");
+  // The subset panel draws its extract box on the map surface, so it needs an
+  // engine the user can draw on — not merely "not the globe".
+  const capabilities = useMapCapabilities(mapControllerRef);
   const addLayerGroup = useAppStore((s) => s.addLayerGroup);
   const removeLayerGroup = useAppStore((s) => s.removeLayerGroup);
   const renameLayerGroup = useAppStore((s) => s.renameLayerGroup);
@@ -3314,11 +3314,11 @@ export function LayerPanel({
             const canExportRaster = layerCaps.export && canExportRasterLayer(layer);
             // COG/WMS/XYZ layers can also export a bounding-box subset (a clip)
             // via the in-browser geolibre-wasm extractors, drawn on the map.
-            // `!cesiumPrimary`: the subset panel draws its extract box on the
-            // MapLibre canvas, which does not exist while the globe is primary
-            // (DesktopShell unmounts the panel there) — #2217 review.
+            // Gated on the engine's own drawing capability: the panel needs a
+            // surface the user can drag an extract box on, which the globe does
+            // not offer yet (#2260).
             const canExtractSubset =
-              layerCaps.export && !cesiumPrimary && canExtractRasterSubset(layer);
+              layerCaps.export && capabilities.onMapDrawing && canExtractRasterSubset(layer);
             // Rasters added through the floating Add Raster Layer panel are
             // styled there; offer a shortcut to reopen that panel since it is
             // dismissed (and its on-map icon removed) when closed.

--- a/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanelPlaceSearch.tsx
@@ -17,7 +17,7 @@ import {
   resolveGeocoderConfig,
   useAppStore,
 } from "@geolibre/core";
-import { getPrimaryCesiumControlHost, type MapController } from "@geolibre/map";
+import { getPrimaryCesiumControlHost, type MapEngine } from "@geolibre/map";
 // Type-only: the Cesium engine itself is imported lazily, inside the globe
 // branch of handleSelect, so it stays off this panel's load path.
 import type { PointPrimitive, PointPrimitiveCollection, Primitive } from "@cesium/engine";
@@ -35,7 +35,7 @@ import {
 } from "../../lib/feature-search";
 
 interface LayerPanelPlaceSearchProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /** Fast-UI minimum debounce before firing a forward-geocode while typing. */

--- a/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
@@ -17,7 +17,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
 import { useNotebookBridge } from "../../hooks/useNotebookBridge";
 import { useNotebookThemeSync } from "../../hooks/useNotebookThemeSync";
@@ -58,7 +58,7 @@ function externalClientUrl(server: JupyterServerInfo): string {
 
 interface NotebookPanelProps {
   onResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   themeMode: ThemeMode;
 }
 

--- a/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
@@ -59,6 +59,8 @@ function externalClientUrl(server: JupyterServerInfo): string {
 interface NotebookPanelProps {
   onResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
   mapControllerRef: RefObject<MapEngine | null>;
+  /** Bumped when a canvas publishes an engine; re-arms the notebook's map bridge. */
+  mapReadyGeneration: number;
   themeMode: ThemeMode;
 }
 
@@ -79,7 +81,12 @@ interface NotebookPanelProps {
  *   notebook scripting bridge so notebook cells can drive the map.
  * @param themeMode - The app's current theme, mirrored into the notebook.
  */
-export function NotebookPanel({ onResizeStart, mapControllerRef, themeMode }: NotebookPanelProps) {
+export function NotebookPanel({
+  onResizeStart,
+  mapControllerRef,
+  mapReadyGeneration,
+  themeMode,
+}: NotebookPanelProps) {
   const { t } = useTranslation();
   const setNotebookOpen = useAppStore((s) => s.setNotebookOpen);
   const [isCollapsed, setIsCollapsed] = useState(getIsMobileViewport);
@@ -91,7 +98,7 @@ export function NotebookPanel({ onResizeStart, mapControllerRef, themeMode }: No
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Let notebook cells drive the live map via the shared scripting protocol.
-  useNotebookBridge(iframeRef, mapControllerRef);
+  useNotebookBridge(iframeRef, mapControllerRef, mapReadyGeneration);
   // Mirror the app's light/dark theme into the embedded notebook.
   useNotebookThemeSync(iframeRef, themeMode, loaded);
 

--- a/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button, Textarea } from "@geolibre/ui";
 import {
   ChevronDown,
@@ -49,7 +49,7 @@ interface Entry {
 }
 
 interface PythonConsolePanelProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/panels/QuickFiltersSection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/QuickFiltersSection.tsx
@@ -4,7 +4,7 @@ import {
   type GeoLibreLayer,
   type LayerQuickFilter,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   Button,
   DropdownMenu,
@@ -21,7 +21,7 @@ import { QuickFilterControl } from "./QuickFilterControl";
 
 interface QuickFiltersSectionProps {
   layer: GeoLibreLayer;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   /** Bumped when the map (re)initializes; see {@link useQuickFilterProfiles}. */
   mapReadyGeneration?: number;
 }

--- a/apps/geolibre-desktop/src/components/panels/RouteAnimationPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RouteAnimationPanel.tsx
@@ -1,5 +1,5 @@
 import { geojsonHasZCoordinates, styleValue, useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   ROUTE_ANIM_SPEED_MAX,
   ROUTE_ANIM_SPEED_MIN,
@@ -78,7 +78,7 @@ interface LineLayerOption {
 }
 
 interface RouteAnimationPanelProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -57,7 +57,7 @@ import {
 import {
   layerBlendModesSupported,
   subscribeLayerBlendModeSupport,
-  type MapController,
+  type MapEngine,
 } from "@geolibre/map";
 import type { ParseKeys, TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
@@ -183,7 +183,7 @@ function labelOverrideInvalid(
 }
 
 interface StylePanelProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   /** Bumped when the map (re)initializes; see {@link useQuickFilterProfiles}. */
   mapReadyGeneration?: number;
   onResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;

--- a/apps/geolibre-desktop/src/components/panels/ViewerLayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/ViewerLayerPanel.tsx
@@ -1,6 +1,6 @@
 import { clearQuickFilterValues, hasActiveQuickFilter, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer, LayerGroup, LayerQuickFilter } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button } from "@geolibre/ui";
 import { Eye, EyeOff, Folder, Layers } from "lucide-react";
 import { Fragment, useMemo, type RefObject } from "react";
@@ -12,14 +12,14 @@ import { QuickFilterControl } from "./QuickFilterControl";
 const GROUP_INDENT_REM = 0.75;
 
 interface ViewerLayerPanelProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   /** Bumped when the map (re)initializes; see {@link useQuickFilterProfiles}. */
   mapReadyGeneration?: number;
 }
 
 interface ViewerQuickFiltersProps {
   layer: GeoLibreLayer;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
   mapReadyGeneration?: number;
   indentRem: number;
 }

--- a/apps/geolibre-desktop/src/components/processing/BatchToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/BatchToolsDialog.tsx
@@ -1,7 +1,7 @@
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
-import { detectGeometryProfile, type MapController } from "@geolibre/map";
+import { detectGeometryProfile, type MapEngine } from "@geolibre/map";
 import {
   VECTOR_TOOLS,
   runAlgorithmCapture,
@@ -33,7 +33,7 @@ import { Loader2, Play } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 
 interface BatchToolsDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /** The conventional id of a tool's primary input layer parameter. */
@@ -135,7 +135,7 @@ function useFieldsByLayer(layers: GeoLibreLayer[], enabled: boolean): Map<string
 
 /** Read the current map viewport as [west, south, east, north]. */
 function viewportBoundsReader(
-  mapControllerRef: React.RefObject<MapController | null>,
+  mapControllerRef: React.RefObject<MapEngine | null>,
 ): () => [number, number, number, number] | null {
   return () => {
     const map = mapControllerRef.current?.getMap();

--- a/apps/geolibre-desktop/src/components/processing/GeocodeDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/GeocodeDialog.tsx
@@ -12,7 +12,7 @@ import {
   rowCap,
   useAppStore,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   Button,
   Dialog,
@@ -33,7 +33,7 @@ import { sniffDelimiter } from "../../lib/deck-viz-input";
 import { openLocalDataFileWithFallback } from "../../lib/tauri-io";
 
 interface GeocodeDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 interface ParsedCsv {

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -1,5 +1,5 @@
 import { getRoutingConfig, useAppStore } from "@geolibre/core";
-import { detectGeometryProfile, type MapController } from "@geolibre/map";
+import { detectGeometryProfile, type MapEngine } from "@geolibre/map";
 import {
   NETWORK_TOOLS,
   getNetworkTool,
@@ -30,7 +30,7 @@ import {
 import { ParameterField } from "./ParameterField";
 
 interface NetworkToolsDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/processing/ObjectDetectionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ObjectDetectionDialog.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   detectObjects,
   isOrtAvailable,
@@ -44,7 +44,7 @@ import {
 import { openLocalDataFileWithFallback } from "../../lib/tauri-io";
 
 interface ObjectDetectionDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 const IMAGE_EXTENSIONS = ["tif", "tiff", ...DETECTION_PHOTO_EXTENSIONS];

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1,5 +1,5 @@
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
-import { getLayerBounds, type MapController } from "@geolibre/map";
+import { getLayerBounds, type MapEngine } from "@geolibre/map";
 import {
   clearRemoteWhiteboxCatalogSnapshotCache,
   fetchWhiteboxJob,
@@ -115,7 +115,7 @@ import {
 } from "../../lib/processing-tool-i18n";
 
 interface ProcessingDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   // Renders a raster tool output (a Cloud Optimized GeoTIFF, from the WASM
   // runner) as a new map layer. Wired by the desktop shell, which owns the
   // raster control / app API.

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -1,6 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { addRasterToMap } from "@geolibre/plugins";
 import {
   RASTER_TOOLS,
@@ -119,7 +119,7 @@ function toolDefaults(tool: RasterTool): Record<string, unknown> {
 }
 
 interface RasterToolsDialogProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps): ReactElement {

--- a/apps/geolibre-desktop/src/components/processing/SegmentEverythingPanel.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentEverythingPanel.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   isOrtAvailable,
   readRasterData,
@@ -39,7 +39,7 @@ import {
 } from "../../lib/segment-models";
 
 interface SegmentEverythingPanelProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 const IMAGE_FILTERS = [{ name: "Imagery", extensions: ["tif", "tiff"] }];

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { fetchMlStatus, mlSegment, type MlSegmentMode, type MlStatus } from "@geolibre/processing";
 import {
   Button,
@@ -33,7 +33,7 @@ import { UPDATE_URL } from "../../lib/updates";
 import { SidecarHelpBanner, SIDECAR_PORT, SIDECAR_URL } from "./SidecarHelpBanner";
 
 interface SegmentationDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 const IMAGE_FILTERS = [{ name: "Imagery", extensions: ["tif", "tiff", "png", "jpg", "jpeg"] }];

--- a/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import { detectGeometryProfile, type MapController } from "@geolibre/map";
+import { detectGeometryProfile, type MapEngine } from "@geolibre/map";
 import {
   STATISTICS_TOOLS,
   getStatisticsTool,
@@ -34,7 +34,7 @@ import {
 import { ParameterField } from "./ParameterField";
 
 interface StatisticsToolsDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import { detectGeometryProfile, type MapController } from "@geolibre/map";
+import { detectGeometryProfile, type MapEngine } from "@geolibre/map";
 import {
   VECTOR_TOOLS,
   getVectorTool,
@@ -43,7 +43,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { useTranslation } from "react-i18next";
 
 interface VectorToolsDialogProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
 }
 
 type Engine = "client" | "sidecar" | "pyodide";

--- a/apps/geolibre-desktop/src/components/processing/model-builder/ModelBuilderPanel.tsx
+++ b/apps/geolibre-desktop/src/components/processing/model-builder/ModelBuilderPanel.tsx
@@ -8,7 +8,7 @@ import {
   type ProcessingModel,
   type ProcessingModelGraph,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   VECTOR_TOOLS,
   fetchRemoteWhiteboxCatalogSnapshot,
@@ -254,7 +254,7 @@ function portPosition(
 }
 
 interface ModelBuilderPanelProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: React.RefObject<MapEngine | null>;
   /** Adds a raster result (COG bytes) to the map, when the host supports it. */
   onAddRaster?: (bytes: Uint8Array, name: string, fileName: string) => Promise<void> | void;
 }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
@@ -1,12 +1,12 @@
 import { type RefObject, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button } from "@geolibre/ui";
 import { Check, Frame, X } from "lucide-react";
 
 interface StoryMapComposeBarProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -2,7 +2,7 @@ import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } fro
 import * as maplibregl from "maplibre-gl";
 import { useTranslation } from "react-i18next";
 import type { StoryActiveSlideMode, StoryChapter, StoryMap } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   Button,
   Dialog,
@@ -34,7 +34,7 @@ interface StoryMapHandoutDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   story: StoryMap;
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /** One exportable screen: a chapter or an intro/outro slide. */

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -18,7 +18,7 @@ import {
   type StoryMap,
   type StorySlideMode,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   Button,
   ColorField,
@@ -60,7 +60,7 @@ import { buildStoryMapHtml } from "../../lib/storymap-export";
 import { StoryMapHandoutDialog } from "./StoryMapHandoutDialog";
 
 interface StoryMapPanelProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 function createId(): string {

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -17,7 +17,7 @@ import {
   type StoryChapter,
   type StoryMap,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { Button, cn } from "@geolibre/ui";
 import { GripVertical, List, X } from "lucide-react";
 import { sanitizeStoryHtml } from "../../lib/sanitize-html";
@@ -30,7 +30,7 @@ import {
 } from "../../lib/storymap-constants";
 
 interface StoryMapPresenterProps {
-  mapControllerRef: RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapEngine | null>;
 }
 
 /** One scroll step in the presentation: a chapter card or an intro/outro slide. */

--- a/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type * as maplibregl from "maplibre-gl";
 import { knownCogBandCount, readCogSpectralProfile } from "@geolibre/plugins/cog-spectral-profile";
 import { useTranslation } from "react-i18next";
@@ -30,7 +30,7 @@ import { fetchRemoteArrayBuffer } from "./usePlugins";
  * Mounted once at the app shell, alongside the other identify hooks.
  */
 export function useCogSpectralIdentify(
-  mapControllerRef: React.RefObject<MapController | null>,
+  mapControllerRef: React.RefObject<MapEngine | null>,
   mapReadyGeneration: number,
 ): void {
   const { t } = useTranslation();

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -10,7 +10,7 @@ import {
 } from "@geolibre/core";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { RefObject } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { Map as MapLibreMap, MapLibreEvent } from "maplibre-gl";
 import i18n from "../i18n";
 import {
@@ -64,9 +64,7 @@ export interface CollaborationApi {
   sendCommentMutation: (action: CommentMutationAction) => boolean;
 }
 
-export function useCollaboration(
-  mapControllerRef: RefObject<MapController | null>,
-): CollaborationApi {
+export function useCollaboration(mapControllerRef: RefObject<MapEngine | null>): CollaborationApi {
   const baseUrl = useMemo(() => resolveCollabBaseUrl(), []);
   const enabled = baseUrl !== null;
 

--- a/apps/geolibre-desktop/src/hooks/useCommandBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useCommandBridge.ts
@@ -37,7 +37,15 @@ interface CommandMessage {
  *   useEmbedBridge and MapCanvas share), used to read/drive the camera and query
  *   rendered features.
  */
-export function useCommandBridge(mapControllerRef: RefObject<MapEngine | null>): void {
+export function useCommandBridge(
+  mapControllerRef: RefObject<MapEngine | null>,
+  /**
+   * Bumped whenever a canvas publishes an engine. The ref itself is stable, so
+   * without this the effect would never re-run on an engine hand-off and the
+   * click listener would stay bound to the old map (#2268 review).
+   */
+  mapReadyGeneration: number,
+): void {
   useEffect(() => {
     if (!isEmbedded()) return;
     const hostChannel = getEmbedHost();
@@ -141,7 +149,15 @@ export function useCommandBridge(mapControllerRef: RefObject<MapEngine | null>):
     };
     let rafId: number | null = null;
     const attachClick = () => {
-      const map = controller()?.getMap();
+      const engine = controller();
+      // Stop polling for a map that will never arrive. The loop existed to wait
+      // out MapCanvas's mount, when a null ref meant "not ready yet"; the ref can
+      // now hold a `CesiumEngine`, whose `getMap()` is null forever — so without
+      // this the loop would schedule a frame every frame for the life of the
+      // globe (#2268 review). A later switch back to 2D re-runs this effect
+      // through `mapReadyGeneration`, which re-arms the attach.
+      if (engine && !engine.capabilities.nativeMapInstance) return;
+      const map = engine?.getMap();
       if (map) {
         clickMap = map;
         map.on("click", onMapClick);
@@ -157,6 +173,6 @@ export function useCommandBridge(mapControllerRef: RefObject<MapEngine | null>):
       if (rafId !== null) cancelAnimationFrame(rafId);
       clickMap?.off("click", onMapClick);
     };
-    // Mount-only: mapControllerRef is a stable ref read lazily inside handlers.
-  }, [mapControllerRef]);
+    // Re-runs on each engine hand-off; the ref itself is stable and read lazily.
+  }, [mapControllerRef, mapReadyGeneration]);
 }

--- a/apps/geolibre-desktop/src/hooks/useCommandBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useCommandBridge.ts
@@ -1,7 +1,7 @@
 import { useAppStore } from "@geolibre/core";
 import type * as maplibregl from "maplibre-gl";
 import { type RefObject, useEffect } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { getEmbedHost, isEmbedded } from "./embedHost";
 import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
 
@@ -37,7 +37,7 @@ interface CommandMessage {
  *   useEmbedBridge and MapCanvas share), used to read/drive the camera and query
  *   rendered features.
  */
-export function useCommandBridge(mapControllerRef: RefObject<MapController | null>): void {
+export function useCommandBridge(mapControllerRef: RefObject<MapEngine | null>): void {
   useEffect(() => {
     if (!isEmbedded()) return;
     const hostChannel = getEmbedHost();
@@ -131,7 +131,7 @@ export function useCommandBridge(mapControllerRef: RefObject<MapController | nul
     // Map click events. The controller (and its map) become available
     // asynchronously after the map loads, so poll on animation frames until the
     // map exists, then attach the listener.
-    let clickMap: ReturnType<MapController["getMap"]> | null = null;
+    let clickMap: ReturnType<MapEngine["getMap"]> | null = null;
     const onMapClick = (event: maplibregl.MapMouseEvent) => {
       const lngLat: [number, number] = [event.lngLat.lng, event.lngLat.lat];
       emit("click", {

--- a/apps/geolibre-desktop/src/hooks/useCommandBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useCommandBridge.ts
@@ -4,6 +4,7 @@ import { type RefObject, useEffect } from "react";
 import type { MapEngine } from "@geolibre/map";
 import { getEmbedHost, isEmbedded } from "./embedHost";
 import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
+import { shouldAwaitNativeMap } from "../lib/native-map-attach";
 
 // Request/reply + event channel that backs the Python scripting API. Where
 // useEmbedBridge syncs the whole project, this handles the things the project
@@ -150,13 +151,8 @@ export function useCommandBridge(
     let rafId: number | null = null;
     const attachClick = () => {
       const engine = controller();
-      // Stop polling for a map that will never arrive. The loop existed to wait
-      // out MapCanvas's mount, when a null ref meant "not ready yet"; the ref can
-      // now hold a `CesiumEngine`, whose `getMap()` is null forever — so without
-      // this the loop would schedule a frame every frame for the life of the
-      // globe (#2268 review). A later switch back to 2D re-runs this effect
-      // through `mapReadyGeneration`, which re-arms the attach.
-      if (engine && !engine.capabilities.nativeMapInstance) return;
+      // Stops the poll once a map can no longer arrive; see the helper.
+      if (!shouldAwaitNativeMap(engine)) return;
       const map = engine?.getMap();
       if (map) {
         clickMap = map;

--- a/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
@@ -1,6 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import { type RefObject, useEffect } from "react";
-import { getLayerBounds, type MapController } from "@geolibre/map";
+import { getLayerBounds, type MapEngine } from "@geolibre/map";
 import { captureMapImage } from "../lib/print-layout-export";
 import {
   buildEmbedEvent,
@@ -55,7 +55,7 @@ const VIEW_THROTTLE_MS = 250;
  *   MapCanvas and the other bridges), used to drive and read the camera.
  */
 export function useEmbedApi(
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
   mapAppAPI: ReturnType<typeof createAppAPI> | null,
 ): void {
   useEffect(() => {
@@ -369,7 +369,7 @@ export function useEmbedApi(
 
     // Camera events. The controller and its map appear asynchronously, so poll
     // animation frames until the map exists (same pattern as useCommandBridge).
-    let viewMap: ReturnType<MapController["getMap"]> | null = null;
+    let viewMap: ReturnType<MapEngine["getMap"]> | null = null;
     let lastViewAt = 0;
     let trailingTimer: number | null = null;
     const postView = () => {

--- a/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
@@ -57,6 +57,11 @@ const VIEW_THROTTLE_MS = 250;
 export function useEmbedApi(
   mapControllerRef: RefObject<MapEngine | null>,
   mapAppAPI: ReturnType<typeof createAppAPI> | null,
+  /**
+   * Bumped whenever a canvas publishes an engine, so the view-listener attach
+   * re-arms on a hand-off — the ref itself is stable (#2268 review).
+   */
+  mapReadyGeneration: number,
 ): void {
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -404,7 +409,14 @@ export function useEmbedApi(
     };
     let rafId: number | null = null;
     const attach = () => {
-      const map = controller()?.getMap();
+      const engine = controller();
+      // Same guard as useCommandBridge/useNotebookBridge: the loop was written to
+      // wait out MapCanvas's mount, when a null ref meant "not ready yet". The
+      // ref can now hold a `CesiumEngine`, whose `getMap()` is null forever — so
+      // without this it would schedule a frame every frame for the life of an
+      // embedded globe session (#2268 review).
+      if (engine && !engine.capabilities.nativeMapInstance) return;
+      const map = engine?.getMap();
       if (!map) {
         rafId = requestAnimationFrame(attach);
         return;
@@ -429,5 +441,5 @@ export function useEmbedApi(
       viewMap?.off("move", onMapMove);
       viewMap?.off("moveend", onMapMove);
     };
-  }, [mapControllerRef, mapAppAPI]);
+  }, [mapControllerRef, mapAppAPI, mapReadyGeneration]);
 }

--- a/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
@@ -18,6 +18,7 @@ import {
   type EmbedEventType,
 } from "../lib/embed-api";
 import { fetchProjectFromUrl, projectUrlFromLocation } from "../lib/project-url";
+import { shouldAwaitNativeMap } from "../lib/native-map-attach";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 import { isKnownWhiteboxToolId } from "../lib/whitebox-tool-url";
 import { loadDataUrl } from "./useDataUrlLoader";
@@ -420,12 +421,8 @@ export function useEmbedApi(
     let rafId: number | null = null;
     const attach = () => {
       const engine = controller();
-      // Same guard as useCommandBridge/useNotebookBridge: the loop was written to
-      // wait out MapCanvas's mount, when a null ref meant "not ready yet". The
-      // ref can now hold a `CesiumEngine`, whose `getMap()` is null forever — so
-      // without this it would schedule a frame every frame for the life of an
-      // embedded globe session (#2268 review).
-      if (engine && !engine.capabilities.nativeMapInstance) return;
+      // Stops the poll once a map can no longer arrive; see the helper.
+      if (!shouldAwaitNativeMap(engine)) return;
       const map = engine?.getMap();
       if (!map) {
         rafId = requestAnimationFrame(attach);

--- a/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
@@ -288,7 +288,17 @@ export function useEmbedApi(
         case "exportImage": {
           if (!useAppStore.getState().deploymentCapabilities.has("export:data"))
             throw new Error("Missing export:data capability");
-          const map = controller()?.getMap();
+          const engine = controller();
+          // Same distinction scriptingApi's `toImage` makes: "not ready yet" is
+          // a state that resolves, "not supported by this engine" never does —
+          // and an embedding host has no way to tell them apart otherwise
+          // (#2268 review).
+          if (engine && !engine.capabilities.nativeMapInstance) {
+            throw new Error(
+              "Capturing the map image is not supported by the current rendering engine",
+            );
+          }
+          const map = engine?.getMap();
           if (!map) throw new Error("The map is not ready yet");
           return captureMapImage(map).image.toDataURL("image/png");
         }

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -1,6 +1,6 @@
 import { parseProject, serializeProject, useAppStore, type GeoLibreProject } from "@geolibre/core";
 import { type RefObject, useEffect } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { buildProjectEgressSnapshot, buildProjectSnapshot } from "../lib/build-project-snapshot";
 import { getEmbedHost, isEmbedded } from "./embedHost";
 
@@ -59,7 +59,7 @@ type InboundMessage = LoadProjectMessage | RequestStateMessage;
  * @param mapControllerRef - Ref to the live map controller, read so the emitted
  *   snapshot captures the current camera (pan/zoom) rather than only the store.
  */
-export function useEmbedBridge(mapControllerRef: RefObject<MapController | null>): void {
+export function useEmbedBridge(mapControllerRef: RefObject<MapEngine | null>): void {
   useEffect(() => {
     if (!isEmbedded()) return;
     // The host is the embedding parent (the Jupyter/embed widget). The shared

--- a/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
+++ b/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
@@ -1,5 +1,5 @@
 import { type RefObject, useEffect } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { subscribeJupyterServer } from "../lib/jupyter";
 import {
   type RelayCommand,
@@ -34,7 +34,7 @@ import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
  * @param mapControllerRef - Ref to the live map controller, read lazily by the
  *   command handlers.
  */
-export function useJupyterRelay(mapControllerRef: RefObject<MapController | null>): void {
+export function useJupyterRelay(mapControllerRef: RefObject<MapEngine | null>): void {
   useEffect(() => {
     const handlers = createScriptingHandlers({
       getController: () => mapControllerRef.current,

--- a/apps/geolibre-desktop/src/hooks/useMapCapabilities.ts
+++ b/apps/geolibre-desktop/src/hooks/useMapCapabilities.ts
@@ -28,8 +28,14 @@ import type { MapControllerRef } from "../components/layout/toolbar/constants";
  */
 export function useMapCapabilities(mapControllerRef?: MapControllerRef): MapEngineCapabilities {
   const primaryRenderer = useAppStore((s) => s.primaryRenderer);
-  return (
-    mapControllerRef?.current?.capabilities ??
-    (primaryRenderer === "cesium" ? CESIUM_CAPABILITIES : MAPLIBRE_CAPABILITIES)
-  );
+  const fallback = primaryRenderer === "cesium" ? CESIUM_CAPABILITIES : MAPLIBRE_CAPABILITIES;
+  const engine = mapControllerRef?.current;
+  // Trust the ref only while it agrees with the store about which renderer is
+  // live. The store flips `primaryRenderer` during render; the canvases publish
+  // and clear the ref from passive effects, which run after — so for the render
+  // in between, the ref still holds the *outgoing* engine and would report the
+  // capabilities of a renderer that is already gone (#2268 review). `kind` is
+  // read here as an identity check on the ref, not to infer behaviour: what is
+  // returned is still the engine's own capability object.
+  return engine && engine.kind === primaryRenderer ? engine.capabilities : fallback;
 }

--- a/apps/geolibre-desktop/src/hooks/useMapCapabilities.ts
+++ b/apps/geolibre-desktop/src/hooks/useMapCapabilities.ts
@@ -1,0 +1,35 @@
+import { useAppStore } from "@geolibre/core";
+import {
+  CESIUM_CAPABILITIES,
+  MAPLIBRE_CAPABILITIES,
+  type MapEngineCapabilities,
+} from "@geolibre/map";
+import type { MapControllerRef } from "../components/layout/toolbar/constants";
+
+/**
+ * What the live map engine can do, for UI that needs to gate on it (issue #2260).
+ *
+ * Menus and panels used to ask `primaryRenderer === "cesium"` and disable
+ * accordingly. That got it wrong in both directions: it hid camera work,
+ * terrain, and framing that the globe does natively, and it would stop
+ * describing reality the moment a third engine appeared. This is the one place
+ * the question is asked, so every consumer gates on a capability instead.
+ *
+ * Reading `ref.current` is not reactive on its own, which is why the store's
+ * `primaryRenderer` is subscribed to: swapping engines is exactly when
+ * capabilities change, and between swaps they are constant. The renderer is
+ * also the fallback for the window before a canvas has published its engine —
+ * the only place the engine's *name* is still consulted, and it answers with
+ * that engine's own frozen capability object rather than a hand-written guess.
+ *
+ * The ref is optional because some menus never receive it. They get the same
+ * answer through the fallback, which is why this hook — not each call site — is
+ * where the renderer-to-capability mapping lives.
+ */
+export function useMapCapabilities(mapControllerRef?: MapControllerRef): MapEngineCapabilities {
+  const primaryRenderer = useAppStore((s) => s.primaryRenderer);
+  return (
+    mapControllerRef?.current?.capabilities ??
+    (primaryRenderer === "cesium" ? CESIUM_CAPABILITIES : MAPLIBRE_CAPABILITIES)
+  );
+}

--- a/apps/geolibre-desktop/src/hooks/useMapPanelControl.ts
+++ b/apps/geolibre-desktop/src/hooks/useMapPanelControl.ts
@@ -6,7 +6,7 @@
  * the control corners, and inclusion in Record Video's on-map panel capture,
  * which rasterizes elements inside the map container.
  */
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { ControlPosition, IControl } from "maplibre-gl";
 import { useEffect, useState, type RefObject } from "react";
 
@@ -24,7 +24,7 @@ import { useEffect, useState, type RefObject } from "react";
  * @returns The mounted host element, or null while hidden / map not ready.
  */
 export function useMapPanelControl(
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
   visible: boolean,
   position: ControlPosition,
   className: string,

--- a/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
@@ -3,7 +3,7 @@ import type { TFunction } from "i18next";
 import * as maplibregl from "maplibre-gl";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { bandMeasure } from "../lib/netcdf-band-axis";
 import {
   displayUnits,
@@ -133,7 +133,7 @@ export function netcdfIdentifyRows(
  *   the map finished loading.
  */
 export function useNetcdfIdentify(
-  mapControllerRef: React.RefObject<MapController | null>,
+  mapControllerRef: React.RefObject<MapEngine | null>,
   mapReadyGeneration: number,
 ): void {
   const { t } = useTranslation();

--- a/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
@@ -1,7 +1,7 @@
 import { useAppStore } from "@geolibre/core";
 import type * as maplibregl from "maplibre-gl";
 import { type RefObject, useEffect } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
 
 // The host side of the notebook scripting bridge. This is the MIRROR of
@@ -40,7 +40,7 @@ interface CommandMessage {
  */
 export function useNotebookBridge(
   iframeRef: RefObject<HTMLIFrameElement | null>,
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
 ): void {
   useEffect(() => {
     const controller = () => mapControllerRef.current;
@@ -152,7 +152,7 @@ export function useNotebookBridge(
 
     // Map click events. The controller/map appear asynchronously after the map
     // loads, so poll on animation frames until the map exists, then attach.
-    let clickMap: ReturnType<MapController["getMap"]> | null = null;
+    let clickMap: ReturnType<MapEngine["getMap"]> | null = null;
     const onMapClick = (event: maplibregl.MapMouseEvent) => {
       const lngLat: [number, number] = [event.lngLat.lng, event.lngLat.lat];
       emit("click", {

--- a/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
@@ -41,6 +41,12 @@ interface CommandMessage {
 export function useNotebookBridge(
   iframeRef: RefObject<HTMLIFrameElement | null>,
   mapControllerRef: RefObject<MapEngine | null>,
+  /**
+   * Bumped whenever a canvas publishes an engine. The ref itself is stable, so
+   * without this the effect would never re-run on an engine hand-off and the
+   * click listener would stay bound to the old map (#2268 review).
+   */
+  mapReadyGeneration: number,
 ): void {
   useEffect(() => {
     const controller = () => mapControllerRef.current;
@@ -162,7 +168,15 @@ export function useNotebookBridge(
     };
     let rafId: number | null = null;
     const attachClick = () => {
-      const map = controller()?.getMap();
+      const engine = controller();
+      // Stop polling for a map that will never arrive. The loop existed to wait
+      // out MapCanvas's mount, when a null ref meant "not ready yet"; the ref can
+      // now hold a `CesiumEngine`, whose `getMap()` is null forever — so without
+      // this the loop would schedule a frame every frame for the life of the
+      // globe (#2268 review). A later switch back to 2D re-runs this effect
+      // through `mapReadyGeneration`, which re-arms the attach.
+      if (engine && !engine.capabilities.nativeMapInstance) return;
+      const map = engine?.getMap();
       if (map) {
         clickMap = map;
         map.on("click", onMapClick);
@@ -179,5 +193,5 @@ export function useNotebookBridge(
       clickMap?.off("click", onMapClick);
     };
     // Mount-only: both refs are stable and read lazily inside the closures.
-  }, [iframeRef, mapControllerRef]);
+  }, [iframeRef, mapControllerRef, mapReadyGeneration]);
 }

--- a/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
@@ -195,6 +195,6 @@ export function useNotebookBridge(
       if (rafId !== null) cancelAnimationFrame(rafId);
       clickMap?.off("click", onMapClick);
     };
-    // Mount-only: both refs are stable and read lazily inside the closures.
+    // Re-runs on each engine hand-off; both refs are stable and read lazily.
   }, [iframeRef, mapControllerRef, mapReadyGeneration]);
 }

--- a/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
@@ -1,6 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import type * as maplibregl from "maplibre-gl";
-import { type RefObject, useEffect } from "react";
+import { type RefObject, useEffect, useRef } from "react";
 import type { MapEngine } from "@geolibre/map";
 import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
 
@@ -48,6 +48,8 @@ export function useNotebookBridge(
    */
   mapReadyGeneration: number,
 ): void {
+  // Survives the effect re-running on an engine hand-off; see `connected` below.
+  const connectedRef = useRef(false);
   useEffect(() => {
     const controller = () => mapControllerRef.current;
     const handlers = createScriptingHandlers({ getController: controller });
@@ -69,7 +71,12 @@ export function useNotebookBridge(
     // not broadcast; refined to the actual origin once a message is accepted.
     let frameOrigin = expectedOrigin() ?? window.location.origin;
     // Whether the notebook client has announced itself; gates outbound events.
-    let connected = false;
+    // Held in a ref, not a local, because this effect now re-runs on an engine
+    // hand-off (`mapReadyGeneration`) while `NotebookPanel` keeps the iframe
+    // mounted — a fresh `connected = false` would silently drop every selection,
+    // layer, and click event until the notebook happened to re-announce itself,
+    // which it has no reason to do (#2268 review).
+    const connected = connectedRef;
 
     const frameWindow = (): Window | null => iframeRef.current?.contentWindow ?? null;
 
@@ -112,7 +119,7 @@ export function useNotebookBridge(
       const data = event.data as { type?: string; requestId?: unknown } | null;
       if (!data || typeof data !== "object") return;
       if (data.type === "geolibre:notebook-ready") {
-        connected = true;
+        connected.current = true;
         return;
       }
       if (data.type === "geolibre:command" && typeof data.requestId === "string") {
@@ -121,7 +128,7 @@ export function useNotebookBridge(
     };
 
     const emit = (eventName: string, payload: unknown) => {
-      if (!connected) return;
+      if (!connected.current) return;
       const win = frameWindow();
       if (!win) return;
       win.postMessage({ type: "geolibre:event", event: eventName, payload }, frameOrigin);

--- a/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useNotebookBridge.ts
@@ -3,6 +3,7 @@ import type * as maplibregl from "maplibre-gl";
 import { type RefObject, useEffect, useRef } from "react";
 import type { MapEngine } from "@geolibre/map";
 import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
+import { shouldAwaitNativeMap } from "../lib/native-map-attach";
 
 // The host side of the notebook scripting bridge. This is the MIRROR of
 // useCommandBridge: there, the app is the embedded iframe talking up to a host;
@@ -176,13 +177,8 @@ export function useNotebookBridge(
     let rafId: number | null = null;
     const attachClick = () => {
       const engine = controller();
-      // Stop polling for a map that will never arrive. The loop existed to wait
-      // out MapCanvas's mount, when a null ref meant "not ready yet"; the ref can
-      // now hold a `CesiumEngine`, whose `getMap()` is null forever — so without
-      // this the loop would schedule a frame every frame for the life of the
-      // globe (#2268 review). A later switch back to 2D re-runs this effect
-      // through `mapReadyGeneration`, which re-arms the attach.
-      if (engine && !engine.capabilities.nativeMapInstance) return;
+      // Stops the poll once a map can no longer arrive; see the helper.
+      if (!shouldAwaitNativeMap(engine)) return;
       const map = engine?.getMap();
       if (map) {
         clickMap = map;

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -94,7 +94,7 @@ import {
   closeFloatingPanel,
   getOpenFloatingPanels,
 } from "@geolibre/plugins";
-import { getPrimaryCesiumControlHost, type MapController } from "@geolibre/map";
+import { getPrimaryCesiumControlHost, type MapEngine } from "@geolibre/map";
 import type {
   GeoLibreCogLayerOptions,
   GeoLibreCogRenderEngine,
@@ -338,7 +338,7 @@ export function subscribeToExternalPluginLoads(listener: () => void): () => void
 // action.
 export async function upgradeExternalPlugin(
   manifestUrl: string,
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
 ): Promise<void> {
   await reloadExternalUrlPlugin(manager, manifestUrl, createAppAPI(mapControllerRef));
 }
@@ -352,7 +352,7 @@ export async function upgradeExternalPlugin(
 // plugin id.
 export async function installPluginArchive(
   sourcePath: string,
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
 ): Promise<string> {
   if (!isTauriRuntime()) {
     throw new Error("Installing plugin archives requires the desktop app.");
@@ -379,7 +379,7 @@ export async function installPluginArchive(
 export async function installPluginArchiveFromFile(
   fileName: string,
   bytes: Uint8Array,
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
 ): Promise<string> {
   return installWebPluginArchive(manager, fileName, bytes, createAppAPI(mapControllerRef));
 }
@@ -387,7 +387,7 @@ export async function installPluginArchiveFromFile(
 // Uninstall a plugin that was installed from a file in the browser.
 export async function uninstallPluginArchiveFromFile(
   pluginId: string,
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
 ): Promise<void> {
   await uninstallWebPlugin(manager, pluginId, createAppAPI(mapControllerRef));
 }
@@ -499,9 +499,7 @@ export function usePluginRegistry() {
 // Built-in plugins are registered at module load so the toolbar can render
 // plugin menu items on the first pass. This hook additionally kicks off the
 // external plugin scan and reports whether it has finished.
-export function useExternalPluginsReady(
-  mapControllerRef: RefObject<MapController | null>,
-): boolean {
+export function useExternalPluginsReady(mapControllerRef: RefObject<MapEngine | null>): boolean {
   const desktopSettings = useDesktopSettingsStore((state) => state.desktopSettings);
 
   useEffect(() => {
@@ -606,9 +604,7 @@ export function useProjectPluginTrust(): ProjectPluginTrustState {
  * Mounted once near the app root so it covers every way into split view — the
  * View menu, loading a project, or a plugin — not just the toolbar item.
  */
-export function useSwipeSplitViewExclusivity(
-  mapControllerRef: RefObject<MapController | null>,
-): void {
+export function useSwipeSplitViewExclusivity(mapControllerRef: RefObject<MapEngine | null>): void {
   const paneCount = useAppStore((state) => state.mapLayout.rows * state.mapLayout.cols);
 
   useEffect(() => {
@@ -758,7 +754,7 @@ function ensureExternalPluginsLoadedWithSettings(
 export function bindTemporalLayer(
   layerId: string,
   adapter: TemporalLayerAdapter,
-  mapControllerRef?: RefObject<MapController | null>,
+  mapControllerRef?: RefObject<MapEngine | null>,
 ): boolean {
   const binding = buildSelectorTimeBinding(adapter.dimension ?? "time", adapter.getTimeValues(), {
     granularity: adapter.granularity,
@@ -794,9 +790,7 @@ export function bindTemporalLayer(
  *
  * @param mapControllerRef - Used to build the app API for activation.
  */
-export function activateTimeSliderForBinding(
-  mapControllerRef?: RefObject<MapController | null>,
-): void {
+export function activateTimeSliderForBinding(mapControllerRef?: RefObject<MapEngine | null>): void {
   if (manager.isActive(TIME_SLIDER_PLUGIN_ID)) return;
   const before = JSON.stringify(projectPluginStateSnapshot());
   try {
@@ -830,7 +824,7 @@ export function activateTimeSliderForBinding(
  * Mounted once near the app root so it covers every way a binding can
  * disappear, not just the Layers panel.
  */
-export function useTimeSliderAutoClose(mapControllerRef: RefObject<MapController | null>): void {
+export function useTimeSliderAutoClose(mapControllerRef: RefObject<MapEngine | null>): void {
   useEffect(() => {
     // Subscribed rather than selected from the store so no component re-renders
     // on every layer edit just to run this check.
@@ -855,7 +849,7 @@ export function useTimeSliderAutoClose(mapControllerRef: RefObject<MapController
   }, [mapControllerRef]);
 }
 
-export function createAppAPI(mapControllerRef?: RefObject<MapController | null>) {
+export function createAppAPI(mapControllerRef?: RefObject<MapEngine | null>) {
   const store = useAppStore.getState();
   // Captured so methods that delegate to plugin helpers taking the AppAPI
   // itself (e.g. addCogLayer -> addRasterToMap) can pass `api`. Only read
@@ -1196,13 +1190,13 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       }
     },
     addMapControl: (
-      control: Parameters<MapController["addControl"]>[0],
-      position?: Parameters<MapController["addControl"]>[1],
+      control: Parameters<MapEngine["addControl"]>[0],
+      position?: Parameters<MapEngine["addControl"]>[1],
     ) =>
       mapControllerRef?.current?.addControl(control, position) ??
       getPrimaryCesiumControlHost()?.addControl(control, position) ??
       false,
-    removeMapControl: (control: Parameters<MapController["removeControl"]>[0]) => {
+    removeMapControl: (control: Parameters<MapEngine["removeControl"]>[0]) => {
       if (mapControllerRef?.current) {
         mapControllerRef.current.removeControl(control);
       } else {
@@ -1210,18 +1204,18 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       }
     },
     setBuiltInMapControlVisible: (
-      control: Parameters<MapController["setBuiltInControlVisible"]>[0],
+      control: Parameters<MapEngine["setBuiltInControlVisible"]>[0],
       visible: boolean,
     ) => mapControllerRef?.current?.setBuiltInControlVisible(control, visible) ?? false,
     setTerrainEnabled: (enabled: boolean) =>
       mapControllerRef?.current?.setTerrainEnabled(enabled) ?? false,
     isTerrainEnabled: () => mapControllerRef?.current?.isTerrainEnabled() ?? false,
     getBuiltInMapControlPosition: (
-      control: Parameters<MapController["getBuiltInControlPosition"]>[0],
+      control: Parameters<MapEngine["getBuiltInControlPosition"]>[0],
     ) => mapControllerRef?.current?.getBuiltInControlPosition(control) ?? "top-right",
     setBuiltInMapControlPosition: (
-      control: Parameters<MapController["setBuiltInControlPosition"]>[0],
-      position: Parameters<MapController["setBuiltInControlPosition"]>[1],
+      control: Parameters<MapEngine["setBuiltInControlPosition"]>[0],
+      position: Parameters<MapEngine["setBuiltInControlPosition"]>[1],
     ) => mapControllerRef?.current?.setBuiltInControlPosition(control, position) ?? false,
     // Hand external plugins GeoLibre's own deck.gl modules so they render on the
     // host's single deck.gl instance (a bundled second copy throws on the

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -4,7 +4,7 @@ import {
   serializeProject,
   useAppStore,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { buildProjectSnapshot } from "../lib/build-project-snapshot";
@@ -33,7 +33,7 @@ function currentProjectKey(): string {
   return projectPath ? `path:${projectPath}` : `unsaved:${projectName}`;
 }
 
-export function useProjectHistory(mapControllerRef: RefObject<MapController | null>) {
+export function useProjectHistory(mapControllerRef: RefObject<MapEngine | null>) {
   const { t } = useTranslation();
   const [snapshots, setSnapshots] = useState<ProjectHistorySnapshot[]>([]);
   const [recoverySnapshot, setRecoverySnapshot] = useState<ProjectHistorySnapshot | null>(null);

--- a/apps/geolibre-desktop/src/hooks/useQuickFilterProfiles.ts
+++ b/apps/geolibre-desktop/src/hooks/useQuickFilterProfiles.ts
@@ -1,5 +1,5 @@
 import type { GeoLibreLayer } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { getColumnSettings } from "../lib/attribute-columns";
 import {
@@ -53,7 +53,7 @@ const EMPTY_PROFILES: QuickFilterProfiles = {
  */
 export function useQuickFilterProfiles(
   layer: GeoLibreLayer | null | undefined,
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
   mapReadyGeneration = 0,
 ): QuickFilterProfiles {
   const features = layer?.geojson?.features;

--- a/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
+++ b/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
@@ -1,12 +1,12 @@
 import { useEffect, type RefObject } from "react";
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { getRasterLoadState, getSharedDeckLoadState } from "@geolibre/plugins";
 import { inspectScreenshotLayers, screenshotReadinessEnabled } from "../lib/screenshot-readiness";
 
 /** Opt-in DOM contract for browser automation; adds no pixels to the screenshot. */
 export function useScreenshotReadiness(
-  controller: RefObject<MapController | null>,
+  controller: RefObject<MapEngine | null>,
   generation: number,
   pluginsReady: boolean,
   projectBusy: boolean,

--- a/apps/geolibre-desktop/src/hooks/useTerrainRestore.ts
+++ b/apps/geolibre-desktop/src/hooks/useTerrainRestore.ts
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { useEffect } from "react";
 
 /**
@@ -17,7 +17,7 @@ import { useEffect } from "react";
  *     projectGeneration: Bumped whenever a project is loaded.
  */
 export function useTerrainRestore(
-  mapControllerRef: React.RefObject<MapController | null>,
+  mapControllerRef: React.RefObject<MapEngine | null>,
   mapReadyGeneration: number,
   projectGeneration: number,
 ): void {

--- a/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
@@ -70,15 +70,35 @@ export function useViewportHistory(
   const projectGenerationRef = useRef(projectGeneration);
   const [nav, setNav] = useState({ canGoBack: false, canGoForward: false });
 
+  /**
+   * Whether history is usable right now.
+   *
+   * The stack is only fed by MapLibre's `moveend` (see the effect below), so on
+   * an engine without a native map it holds views from a renderer that is no
+   * longer drawing. Every entry point checks this — not just the effect — because
+   * the keyboard shortcuts reach `goBack`/`goForward` directly: `useGlobalShortcuts`
+   * runs a command on a key match without consulting the View menu's disabled
+   * state, so gating the menu alone left `[` and `]` able to ease the globe's
+   * camera through stale 2D history (#2268 review).
+   */
+  const canNavigateHistory = useCallback(
+    () => Boolean(mapControllerRef.current?.getMap()),
+    [mapControllerRef],
+  );
+
   const syncNav = useCallback(() => {
-    const canGoBack = indexRef.current > 0;
-    const canGoForward = indexRef.current >= 0 && indexRef.current < historyRef.current.length - 1;
+    // Report "nowhere to go" whenever history cannot be used, so a `restore()`
+    // that raced a hand-off cannot leave the menu items looking enabled.
+    const usable = canNavigateHistory();
+    const canGoBack = usable && indexRef.current > 0;
+    const canGoForward =
+      usable && indexRef.current >= 0 && indexRef.current < historyRef.current.length - 1;
     setNav((prev) =>
       prev.canGoBack === canGoBack && prev.canGoForward === canGoForward
         ? prev
         : { canGoBack, canGoForward },
     );
-  }, []);
+  }, [canNavigateHistory]);
 
   useEffect(() => {
     // MapLibre-only for now, and deliberately so. Recording is already
@@ -90,17 +110,13 @@ export function useViewportHistory(
     // then Previous/Next View stay disabled on the globe.
     const map = mapControllerRef.current?.getMap() ?? null;
     if (!map) {
-      // Report "nowhere to go" while there is no native map, rather than leaving
-      // the last 2D answer standing. Panning on the 2D map and *then* switching
-      // to the globe used to leave `canGoBack` true, and this PR removed the
-      // menu's renderer-name override that had been masking it — so the items
-      // would have rendered enabled on the globe and done nothing (#2268
-      // review). The stack itself is kept: switching back re-runs this effect
-      // and `syncNav` restores the real answer, so a round trip through the
-      // globe no longer costs the user their history.
-      setNav((prev) =>
-        prev.canGoBack || prev.canGoForward ? { canGoBack: false, canGoForward: false } : prev,
-      );
+      // Re-report on the hand-off: `syncNav` answers "nowhere to go" without a
+      // usable map, so panning on the 2D map and then switching to the globe no
+      // longer leaves the last 2D answer standing. The stack itself is kept —
+      // switching back re-runs this effect and `syncNav` restores the real
+      // answer, so a round trip through the globe does not cost the user their
+      // history.
+      syncNav();
       return;
     }
     const controller = mapControllerRef.current;
@@ -185,14 +201,18 @@ export function useViewportHistory(
       const controller = mapControllerRef.current;
       // Bail before touching the flag if there's no map to drive — otherwise it
       // would stay `true` (no `moveend` to clear it) and swallow the next pan.
-      if (!controller) return;
+      // `canNavigateHistory`, not just `!controller`: the ref now holds a live
+      // engine on the globe, so the old null check no longer covers the "no
+      // MapLibre map" case and a shortcut could animate the globe from stale 2D
+      // history (#2268 review).
+      if (!controller || !canNavigateHistory()) return;
       indexRef.current = nextIndex;
       restoringCountRef.current++;
       // Animate (easeTo) rather than jump, matching the browser-style framing.
       controller.easeToView(view);
       syncNav();
     },
-    [mapControllerRef, syncNav],
+    [canNavigateHistory, mapControllerRef, syncNav],
   );
 
   const goBack = useCallback(() => {

--- a/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
@@ -87,10 +87,22 @@ export function useViewportHistory(
     // on ride along as that event's `eventData`. Giving the globe a history
     // needs an engine-neutral camera-change subscription on `MapEngine`, which
     // is a follow-up rather than something to fake here (#2268 review). Until
-    // then Previous/Next View stay disabled on the globe, which is honest: there
-    // is nothing in the stack to go back to.
+    // then Previous/Next View stay disabled on the globe.
     const map = mapControllerRef.current?.getMap() ?? null;
-    if (!map) return;
+    if (!map) {
+      // Report "nowhere to go" while there is no native map, rather than leaving
+      // the last 2D answer standing. Panning on the 2D map and *then* switching
+      // to the globe used to leave `canGoBack` true, and this PR removed the
+      // menu's renderer-name override that had been masking it — so the items
+      // would have rendered enabled on the globe and done nothing (#2268
+      // review). The stack itself is kept: switching back re-runs this effect
+      // and `syncNav` restores the real answer, so a round trip through the
+      // globe no longer costs the user their history.
+      setNav((prev) =>
+        prev.canGoBack || prev.canGoForward ? { canGoBack: false, canGoForward: false } : prev,
+      );
+      return;
+    }
     const controller = mapControllerRef.current;
 
     // Loading a different project clears the stack so navigation can't cross

--- a/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
@@ -81,6 +81,14 @@ export function useViewportHistory(
   }, []);
 
   useEffect(() => {
+    // MapLibre-only for now, and deliberately so. Recording is already
+    // engine-neutral (`record` reads through `controller.readView()`), but the
+    // *trigger* is MapLibre's `moveend` — and the story/flight tokens it filters
+    // on ride along as that event's `eventData`. Giving the globe a history
+    // needs an engine-neutral camera-change subscription on `MapEngine`, which
+    // is a follow-up rather than something to fake here (#2268 review). Until
+    // then Previous/Next View stay disabled on the globe, which is honest: there
+    // is nothing in the stack to go back to.
     const map = mapControllerRef.current?.getMap() ?? null;
     if (!map) return;
     const controller = mapControllerRef.current;

--- a/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useViewportHistory.ts
@@ -1,5 +1,5 @@
 import type { MapViewState } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { MapLibreEvent } from "maplibre-gl";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -54,7 +54,7 @@ export interface ViewportHistory {
  *     The current navigability flags and the back/forward actions.
  */
 export function useViewportHistory(
-  mapControllerRef: React.RefObject<MapController | null>,
+  mapControllerRef: React.RefObject<MapEngine | null>,
   mapReadyGeneration: number,
   projectGeneration: number,
 ): ViewportHistory {

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -4,7 +4,7 @@ import {
   useAppStore,
   type GeoLibreLayer,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { ModelToolDescriptor } from "@geolibre/processing";
 import type { InvokableTool, JSONValue } from "@strands-agents/sdk";
 import * as maplibregl from "maplibre-gl";
@@ -23,7 +23,7 @@ import { webSearch } from "./web-search";
 /** Dependencies the assistant tools need beyond the global store. */
 export interface AssistantToolDeps {
   /** Returns the live map controller, or null before the map mounts. */
-  getMapController: () => MapController | null;
+  getMapController: () => MapEngine | null;
   /**
    * Ask the user to approve executing model-generated code before it runs.
    * Resolves true to proceed, false to decline. The assistant can be steered by

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -6,7 +6,7 @@ import {
   type GeoLibreProject,
 } from "@geolibre/core";
 import type { RefObject } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { getPluginManager } from "../hooks/usePlugins";
 import { prepareCollaborationLayers } from "./collaboration-layers";
 
@@ -27,7 +27,7 @@ import { prepareCollaborationLayers } from "./collaboration-layers";
  * @returns The serializable project snapshot.
  */
 export function buildProjectSnapshot(
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
   overrides: { layers?: GeoLibreLayer[] } = {},
 ): GeoLibreProject {
   const state = useAppStore.getState();
@@ -69,14 +69,14 @@ export function buildProjectSnapshot(
  * reverting to the credential-bearing local snapshot.
  */
 export function buildProjectEgressSnapshot(
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
 ): GeoLibreProject {
   return redactCredentials(buildProjectSnapshot(mapControllerRef));
 }
 
 /** Build a self-contained public snapshot for a remote collaborator. */
 export async function buildCollaborationSnapshot(
-  mapControllerRef: RefObject<MapController | null>,
+  mapControllerRef: RefObject<MapEngine | null>,
 ): Promise<GeoLibreProject> {
   // Keep the plugins barrel out of this module's eager dependency graph: some
   // optional controls load browser-only SDKs at module evaluation time.

--- a/apps/geolibre-desktop/src/lib/native-map-attach.ts
+++ b/apps/geolibre-desktop/src/lib/native-map-attach.ts
@@ -1,0 +1,25 @@
+import type { MapEngine } from "@geolibre/map";
+
+/**
+ * Whether a poll for the native MapLibre map is still worth another frame.
+ *
+ * Three hooks — `useCommandBridge`, `useNotebookBridge`, `useEmbedApi` — wait
+ * for `MapCanvas` to publish its controller by re-scheduling a
+ * `requestAnimationFrame` until `getMap()` answers. That loop was written when a
+ * null ref could only mean "not mounted yet". It can now mean "this engine has
+ * no MapLibre map and never will" (the globe), and a loop that cannot tell the
+ * two apart schedules a frame every frame for the life of the session.
+ *
+ * The check lives here rather than inline in each hook because it was inline in
+ * each hook: the guard was added to two of the three and the third was missed
+ * until review caught it (#2268). One definition means the next hook to poll for
+ * a map either uses it or is visibly not using it.
+ *
+ * @param engine - The live engine, or `null` when none has published yet.
+ * @returns `true` while a map may still arrive, `false` once it cannot.
+ */
+export function shouldAwaitNativeMap(engine: MapEngine | null | undefined): boolean {
+  // No engine yet: still mounting, so keep waiting.
+  if (!engine) return true;
+  return engine.capabilities.nativeMapInstance;
+}

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -1,4 +1,4 @@
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import consoleApiSource from "./console_api.py?raw";
 import { getPyodideIndexUrl, isDefaultPyodideIndexUrl } from "./pyodide-config";
 import { createScriptingHandlers, type ScriptingDeps } from "../scripting/scriptingApi";
@@ -329,6 +329,6 @@ export async function completeConsoleCode(
 }
 
 /** Convenience for the panel: pull a controller accessor into the deps shape. */
-export function consoleDeps(getController: () => MapController | null): ScriptingDeps {
+export function consoleDeps(getController: () => MapEngine | null): ScriptingDeps {
   return { getController };
 }

--- a/apps/geolibre-desktop/src/lib/quick-analysis.ts
+++ b/apps/geolibre-desktop/src/lib/quick-analysis.ts
@@ -4,7 +4,7 @@ import {
   type GeoLibreLayer,
   type MapScaleUnit,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   getNetworkTool,
   getVectorTool,
@@ -207,7 +207,7 @@ export interface QuickAnalysisRequest {
    */
   extraLayers?: GeoLibreLayer[];
   /** Live map controller, used to frame the result. */
-  mapControllerRef: { current: MapController | null };
+  mapControllerRef: { current: MapEngine | null };
 }
 
 /** Resolve a tool id against the registries Quick analysis draws from. */

--- a/apps/geolibre-desktop/src/lib/run-viewshed.ts
+++ b/apps/geolibre-desktop/src/lib/run-viewshed.ts
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import {
   assembleTerrainDem,
   computeViewshedAsync,
@@ -32,7 +32,7 @@ export interface RunViewshedOptions {
   lng: number;
   lat: number;
   /** Frames the result after adding it, as the sibling quick actions do. */
-  mapControllerRef?: React.RefObject<MapController | null>;
+  mapControllerRef?: React.RefObject<MapEngine | null>;
   radiusMeters: number;
   observerHeightMeters?: number;
   /** Layer name; callers pass a translated string. */

--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -17,7 +17,7 @@ import {
 import { SKETCHES_SOURCE_KIND, addRasterToMap } from "@geolibre/plugins";
 import type { Feature, FeatureCollection } from "geojson";
 import type { RefObject } from "react";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import { isTiff } from "./binary-output";
 import { beginProcessingRun } from "../processing-history";
 import { captureMapImage } from "../print-layout-export";
@@ -40,7 +40,7 @@ export type ScriptingHandlers = Record<string, ScriptingHandler>;
 
 export interface ScriptingDeps {
   /** Lazily resolve the live map controller (it is created asynchronously). */
-  getController: () => MapController | null;
+  getController: () => MapEngine | null;
 }
 
 /**
@@ -58,7 +58,7 @@ export interface ScriptingDeps {
  * @returns The id of the added layer.
  */
 function addWhiteboxRasterOutput(
-  getController: () => MapController | null,
+  getController: () => MapEngine | null,
   bytes: Uint8Array,
   name: string,
   fileName: string,
@@ -69,7 +69,7 @@ function addWhiteboxRasterOutput(
     get current() {
       return getController();
     },
-  } as RefObject<MapController | null>;
+  } as RefObject<MapEngine | null>;
   const file = new File([bytes as BlobPart], fileName, { type: "image/tiff" });
   return addRasterToMap(createAppAPI(controllerRef), file, { name });
 }
@@ -133,7 +133,7 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
     getCenter: () => getController()?.readView().center ?? null,
     getBounds: () => getController()?.readView().bbox ?? null,
     flyTo: (params) => {
-      getController()?.flyTo(params as Parameters<MapController["flyTo"]>[0]);
+      getController()?.flyTo(params as Parameters<MapEngine["flyTo"]>[0]);
       return null;
     },
     fitBounds: (params) => {

--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -306,10 +306,12 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
           },
           duckdb: createDuckDbCapability(),
           viewportBounds: () => {
-            const map = getController()?.getMap();
-            if (!map) return null;
-            const b = map.getBounds();
-            return [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()];
+            // `readView().bbox`, not `map.getBounds()`: the extent is a camera
+            // fact every engine reports, and the MapLibre escape hatch is null
+            // on the globe — which would have made every bounds-aware algorithm
+            // silently see "no viewport" there (#2268 review).
+            const view = getController()?.readView();
+            return view?.bbox ?? null;
           },
         };
         await algo.run(ctx);
@@ -516,7 +518,15 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
 
     // -- export -------------------------------------------------------------
     toImage: () => {
-      const map = getController()?.getMap();
+      const engine = getController();
+      // Say which of the two it is. `getMap()` is null both while the map is
+      // still mounting and, permanently, on an engine with no MapLibre canvas —
+      // reporting "not ready yet" for the second would have a script waiting
+      // forever for a map that is never coming (#2268 review).
+      if (engine && !engine.capabilities.nativeMapInstance) {
+        throw new Error("Capturing the map image is not supported by the current rendering engine");
+      }
+      const map = engine?.getMap();
       if (!map) throw new Error("The map is not ready yet");
       // toDataURL is a synchronous PNG encode (100-400ms on a large/high-DPI
       // viewport). In the in-app console (main thread) this briefly freezes the

--- a/apps/geolibre-desktop/src/lib/selection-actions.ts
+++ b/apps/geolibre-desktop/src/lib/selection-actions.ts
@@ -4,7 +4,7 @@ import {
   useAppStore,
   type GeoLibreLayer,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapEngine } from "@geolibre/map";
 import type { Feature, FeatureCollection } from "geojson";
 
 /**
@@ -56,7 +56,7 @@ export function clearFeatureSelection(): void {
 }
 
 /** Fit the map to the selected features (re-using the highlight overlay). */
-export function zoomToSelection(controller: MapController | null): void {
+export function zoomToSelection(controller: MapEngine | null): void {
   const store = useAppStore.getState();
   const layer = selectionHolderLayer();
   if (!layer || store.selectedFeatureIds.length === 0) return;

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -70,7 +70,7 @@ export interface CesiumCanvasProps {
    * menus and panels act on, and publishing it would let the last pane to mount
    * win the shared ref.
    */
-  engineRef?: React.MutableRefObject<MapEngine | null>;
+  engineRef?: React.RefObject<MapEngine | null>;
   /** Called once the engine is live and the ref is set. */
   onEngineReady?: () => void;
 }

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -12,6 +12,7 @@ import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { applyBasemapAppearance, applyBasemapImagery } from "./cesium-basemap";
 import { isSameView } from "./cesium-camera";
 import { CesiumEngine } from "./cesium-engine";
+import type { MapEngine } from "./map-engine";
 import { CesiumControlHost, setPrimaryCesiumControlHost } from "./cesium-control-host";
 
 // The Cesium 3D-globe view (see private/cesium-view-plan.md). M1 wired the
@@ -60,6 +61,18 @@ export interface CesiumCanvasProps {
    * CESIUM_TOKEN env var.
    */
   ionToken?: string;
+  /**
+   * Ref the globe publishes its {@link CesiumEngine} into, so the app can drive
+   * it the way it drives `MapController` through `MapCanvas`'s `controllerRef`
+   * (issue #2260). Set once the engine exists and nulled on unmount.
+   *
+   * Only meaningful for the primary globe: a grid pane's engine is not the one
+   * menus and panels act on, and publishing it would let the last pane to mount
+   * win the shared ref.
+   */
+  engineRef?: React.MutableRefObject<MapEngine | null>;
+  /** Called once the engine is live and the ref is set. */
+  onEngineReady?: () => void;
 }
 
 /**
@@ -97,11 +110,16 @@ function prepareCesiumEnvironment(): void {
  *   exists to make panes follow the primary camera), and draws every layer with
  *   no per-pane overrides.
  */
-export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: CesiumCanvasProps) {
+export const CesiumCanvas = memo(function CesiumCanvas({
+  viewId,
+  ionToken,
+  engineRef,
+  onEngineReady,
+}: CesiumCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<CesiumWidget | null>(null);
   const cesiumRef = useRef<typeof import("@cesium/engine") | null>(null);
-  const engineRef = useRef<CesiumEngine | null>(null);
+  const engineInstanceRef = useRef<CesiumEngine | null>(null);
   const controlHostRef = useRef<CesiumControlHost | null>(null);
   // The imagery layers currently drawing the project basemap, at the bottom of
   // the stack. Tracked so a basemap change replaces exactly these and leaves
@@ -118,6 +136,10 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   viewIdRef.current = viewId;
   const ionTokenRef = useRef(ionToken);
   ionTokenRef.current = ionToken;
+  const engineRefProp = useRef(engineRef);
+  engineRefProp.current = engineRef;
+  const onEngineReadyRef = useRef(onEngineReady);
+  onEngineReadyRef.current = onEngineReady;
 
   // No pane id means this globe *is* the primary map area, not a pane beside it.
   const isPrimary = viewId === undefined;
@@ -222,7 +244,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   // Push a store view into the camera. The engine remembers it as the expected
   // echo and re-applies it if terrain settles at a different height.
   function applyView(view: MapViewState): void {
-    engineRef.current?.applyView(view);
+    engineInstanceRef.current?.applyView(view);
   }
 
   /**
@@ -232,7 +254,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
    * scrolled since.
    */
   function isEchoOfOurOwnCamera(view: MapViewState): boolean {
-    const applied = engineRef.current?.getLastAppliedView();
+    const applied = engineInstanceRef.current?.getLastAppliedView();
     return Boolean(applied && isSameView(view, applied));
   }
 
@@ -294,7 +316,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         // constructed before the terrain await below so its listeners are armed
         // for the whole mount, exactly as the hand-rolled versions were.
         const engine = new CesiumEngine(Cesium, viewer, { viewId: viewIdRef.current });
-        engineRef.current = engine;
+        engineInstanceRef.current = engine;
 
         // With a token, add Cesium World Terrain so tilted views show relief.
         // Awaited before the camera is seeded: ground height is what turns
@@ -333,6 +355,12 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
         applyBasemap();
         engine.syncLayers(paneLayersRef.current);
 
+        // Publish the engine only for the primary globe — see `engineRef`.
+        if (isPrimaryRef.current && engineRefProp.current) {
+          engineRefProp.current.current = engine;
+          onEngineReadyRef.current?.();
+        }
+
         if (!cancelled) setReady(true);
       } catch (err) {
         if (cancelled) return;
@@ -344,8 +372,14 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
       cancelled = true;
       // Drops the engine's listeners and its layer sync; the viewer itself is
       // destroyed below.
-      engineRef.current?.destroy();
-      engineRef.current = null;
+      engineInstanceRef.current?.destroy();
+      // Clear the published ref before the engine is torn down, so nothing can
+      // reach a destroyed engine through it. Only ours is cleared: a pane never
+      // published one.
+      if (isPrimaryRef.current && engineRefProp.current?.current === engineInstanceRef.current) {
+        engineRefProp.current.current = null;
+      }
+      engineInstanceRef.current = null;
       // The viewer's destroy() below tears the imagery down with it; just drop
       // the handles so a remount starts from an empty stack and redraws.
       baseImageryLayersRef.current = [];
@@ -387,7 +421,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({ viewId, ionToken }: Ces
   // mount effect's initial sync already covers the value captured at ready time.
   useEffect(() => {
     if (!ready) return;
-    engineRef.current?.syncLayers(paneLayers);
+    engineInstanceRef.current?.syncLayers(paneLayers);
   }, [ready, paneLayers]);
 
   // Synced: follow the shared global camera. Depend on primitives so an

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -54,6 +54,7 @@ import {
 import { isGlobeControlToggleClick } from "./globe-control-toggle";
 import { createGlobalIdentifyHitDeduper } from "./identify-all";
 import { createMapController, type MapController } from "./map-controller";
+import type { MapEngine } from "./map-engine";
 import { createMapResizeScheduler } from "./map-resize";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "maplibre-gl-layer-control/style.css";
@@ -96,7 +97,7 @@ const DOUBLE_CLICK_VERTEX_TOLERANCE = 2;
 const MAX_SELECTION_SCAN_FEATURES = 250_000;
 
 export interface MapCanvasProps {
-  controllerRef?: React.MutableRefObject<MapController | null>;
+  controllerRef?: React.MutableRefObject<MapEngine | null>;
   onMapDiagnosticEvent?: (event: MapDiagnosticEvent) => void;
   onControllerReady?: () => void;
   /**

--- a/tests/native-map-attach.test.ts
+++ b/tests/native-map-attach.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CESIUM_CAPABILITIES } from "../packages/map/src/cesium-engine";
+import { MAPLIBRE_CAPABILITIES } from "../packages/map/src/map-engine";
+import type { MapEngine } from "../packages/map/src/map-engine";
+import { shouldAwaitNativeMap } from "../apps/geolibre-desktop/src/lib/native-map-attach";
+
+// The guard three hooks use to decide whether polling for the native MapLibre
+// map is still worth another frame (#2268). It exists as a shared function
+// precisely because it was written inline three times, two of them got the
+// Cesium case and the third did not — so the case that matters is asserted
+// against both engines' real capability objects rather than a hand-written stub.
+
+const engine = (capabilities: MapEngine["capabilities"]) =>
+  ({ capabilities }) as unknown as MapEngine;
+
+describe("shouldAwaitNativeMap", () => {
+  it("keeps waiting while no engine has published yet", () => {
+    // A null ref during mount is the case the polling loop was written for.
+    assert.equal(shouldAwaitNativeMap(null), true);
+    assert.equal(shouldAwaitNativeMap(undefined), true);
+  });
+
+  it("keeps waiting for a MapLibre engine, whose map is still coming", () => {
+    assert.equal(shouldAwaitNativeMap(engine(MAPLIBRE_CAPABILITIES)), true);
+  });
+
+  it("stops for an engine that will never have a native map", () => {
+    // The whole point: without this the loop schedules a frame every frame for
+    // the life of the globe, since `CesiumEngine.getMap()` is null forever.
+    assert.equal(shouldAwaitNativeMap(engine(CESIUM_CAPABILITIES)), false);
+  });
+
+  it("decides from the capability, not the engine's name", () => {
+    // A future engine that does expose a MapLibre map should be waited for, and
+    // one that does not should not — without this helper learning about it.
+    assert.equal(
+      shouldAwaitNativeMap(engine({ ...CESIUM_CAPABILITIES, nativeMapInstance: true })),
+      true,
+    );
+    assert.equal(
+      shouldAwaitNativeMap(engine({ ...MAPLIBRE_CAPABILITIES, nativeMapInstance: false })),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
Closes #2260. Final step of the sequence in #2259, after #2264 (the interface) and #2265 (`CesiumEngine`).

**This is the step that makes the previous two reach the user.** Until now the globe's engine was built, tested, and verified against a real Cesium Ion token — and nothing in the app called it, because `mapControllerRef` was typed to `MapController` and nulled the moment the globe took over.

## Three changes

**1. `mapControllerRef` is `RefObject<MapEngine | null>`** — 90 declarations across 77 files, plus the downstream signatures that took a `MapController` (scripting API, assistant tools, pyodide console, quick analysis, selection actions). No call site changed behaviour: every member they use is on the interface. That is exactly what the type-only split in #2264 bought — the compiler found the 30 places that needed widening and nothing else moved.

**2. `DesktopShell` no longer nulls the ref.** `PrimaryCesiumCanvas` publishes its `CesiumEngine` through a new `engineRef` / `onEngineReady` pair, mirroring how `MapCanvas` publishes its `MapController`. Each canvas clears its own engine on unmount, so the ref is never left aimed at a destroyed map — which is what the wholesale nulling was protecting against back when only MapLibre implemented the surface.

**3. The 29 engine-name gates are down to 13.** Every remaining one is genuinely about *which renderer is mounted*, not what it can do: choosing which canvas to render, showing the Rendering engine submenu, and the "2D only" layer badge (which keys off `isCesiumSupportedLayerType`). The capability gates go through one `useMapCapabilities` hook — the single place that maps a renderer to its engine's own frozen capability object, so the mapping exists once instead of 29 times.

## What this turns on, and what stays off *with a reason*

| Now available on the globe | Was greyed out because |
| --- | --- |
| Zoom In / Zoom Out, Reset Orientation, Set View, Google Maps + Earth hand-offs | the ref was null — not because Cesium cannot do them |
| The matching command-palette entries and keyboard shortcuts (`[`, `]`, `n`, `u`, `r`) | same |

**Correction to an earlier version of this description:** it also listed *viewport history*. That was wrong — `useViewportHistory` records engine-neutrally but is *triggered* by MapLibre's `moveend`, so Previous/Next View stay disabled on the globe. An engine-neutral camera-change subscription on `MapEngine` is the follow-up; the code now says so rather than implying it works.

| Still unavailable | Now gated on |
| --- | --- |
| Offline Basemap region | `styleSpec` — it walks the basemap's style document |
| AI object detection, segment-everything | `nativeMapInstance` — they read pixels off the MapLibre canvas |
| Raster-subset extract box | `onMapDrawing` — it drags a box on the map surface |
| Print layout, tour recording, comment placement, scripting `toImage`, plugin/3D-tiles restore | `nativeMapInstance` — see below |

## The hazard review caught

Un-nulling the ref changed **reachability**, not just types. Code that was inert because `mapControllerRef.current` was `null` on the globe now runs against a `CesiumEngine` whose `getMap()` is `null` — so MapLibre-only features became reachable-but-dead, and two `requestAnimationFrame` polling loops became infinite (`useCommandBridge`, `useNotebookBridge` scheduled a frame every frame forever, waiting for a map that never arrives). Both are fixed, and both hooks now take `mapReadyGeneration` so their attach re-arms on an engine hand-off — the ref alone is stable, so the effect never re-ran.

Four things turned out to be genuinely engine-neutral and now work on the globe rather than being gated: the Google Maps/Earth hand-offs, the Zoom In/Out "at limit" state, scripting `viewportBounds`, and zoom-to-comment. The rest are gated on `nativeMapInstance` so they read as unavailable instead of dead.

## Verification

In the real app, against a live `CESIUM_TOKEN`:

- On the globe the View menu now disables **only** Previous/Next View, where it previously disabled all eight items. (Those two stay disabled on the globe by design — see the viewport-history note above — including after panning on the 2D map first, which review caught as a stale-state bug and is fixed.)
- **View → Zoom In actually moves the camera**: `2.0016 → 3.0022`, driven through the shared ref into `CesiumEngine`.
- The live engine reports `kind: "cesium"` with its real capability set, reached through `mapControllerRef`.
- Offline Basemap is still correctly `[disabled]`, so the gating works in both directions.

Plus: 7676 frontend tests pass, full `npm run typecheck` build passes, pre-commit clean.

## Follow-ups this does not do

`CesiumEngine` still declares `picking: false` and `onMapDrawing: false`, so Identify and the extract box stay 2D-only until someone maps a picked Cesium primitive back to a layer/feature id. `usePlugins.ts` still calls `getPrimaryCesiumControlHost()` directly rather than going through `CesiumEngine.addControl` — now that the ref is an engine, that duplication can be collapsed, but it belongs with #2262's tier-2 audit rather than here.
