### PR TITLE
fix(core): ignore inherited properties in attribute joins

### DIFF
--- a/packages/core/src/joins.ts
+++ b/packages/core/src/joins.ts
@@ -71,6 +71,11 @@ export function layerJoinKey(value: unknown): string | null {
   return isEmpty ? null : valueToString(value);
 }
 
+/** GeoJSON columns are own properties; inherited object members are not data. */
+function fieldValue(properties: GeoJsonProperties, field: string): unknown {
+  return properties && Object.hasOwn(properties, field) ? properties[field] : undefined;
+}
+
 /**
  * Remove every column previously added by `joins` (per their `addedFields`
  * bookkeeping) from a copy of `features`, restoring the pre-join properties.
@@ -202,7 +207,7 @@ export function applyLayerJoins(
     // First-match lookup: when several join rows share a key, the first wins.
     const lookup = new Map<string, GeoJsonProperties>();
     for (const jf of joinFeatures) {
-      const key = layerJoinKey(jf.properties?.[join.joinField]);
+      const key = layerJoinKey(fieldValue(jf.properties, join.joinField));
       if (key === null || lookup.has(key)) continue;
       lookup.set(key, jf.properties ?? {});
     }
@@ -211,13 +216,13 @@ export function applyLayerJoins(
     const targetKeys = new Set<string>();
     for (const feature of out) {
       const props = feature.properties;
-      const key = layerJoinKey(props[join.targetField]);
+      const key = layerJoinKey(fieldValue(props, join.targetField));
       if (key !== null) targetKeys.add(key);
       const row = key === null ? undefined : lookup.get(key);
       if (row) {
         matched += 1;
         for (const [field, outputName] of fieldPairs) {
-          props[outputName] = row[field] !== undefined ? row[field] : null;
+          props[outputName] = fieldValue(row, field) ?? null;
         }
       } else {
         for (const [, outputName] of fieldPairs) props[outputName] = null;
@@ -228,7 +233,7 @@ export function applyLayerJoins(
     // the stat (and the UI copy) promise.
     let unmatchedJoin = 0;
     for (const jf of joinFeatures) {
-      const key = layerJoinKey(jf.properties?.[join.joinField]);
+      const key = layerJoinKey(fieldValue(jf.properties, join.joinField));
       if (key !== null && !targetKeys.has(key)) unmatchedJoin += 1;
     }
 

--- a/tests/layer-joins.test.ts
+++ b/tests/layer-joins.test.ts
@@ -149,6 +149,31 @@ describe("applyLayerJoins", () => {
     assert.equal(joins[0].stats?.unmatchedJoinCount, 2);
   });
 
+  it("does not match missing keys inherited from Object.prototype", () => {
+    const { features, joins } = applyLayerJoins(
+      [pointFeature({}), pointFeature({ constructor: "Alabama" })],
+      [join({ targetField: "constructor", joinField: "constructor" })],
+      () =>
+        collection([tableFeature({ pop: 99 }), tableFeature({ constructor: "Alabama", pop: 1 })]),
+    );
+    assert.equal(features[0].properties?.pop, null);
+    assert.equal(features[1].properties?.pop, 1);
+    assert.equal(joins[0].stats?.matchedCount, 1);
+    assert.equal(joins[0].stats?.unmatchedTargetCount, 1);
+    assert.equal(joins[0].stats?.unmatchedJoinCount, 0);
+  });
+
+  it("null-fills missing joined columns whose names exist on Object.prototype", () => {
+    const { features } = applyLayerJoins(states().features, [join()], () =>
+      collection([
+        tableFeature({ state_name: "Alabama", toString: "label" }),
+        tableFeature({ state_name: "Arizona" }),
+      ]),
+    );
+    assert.equal(features[0].properties?.toString, "label");
+    assert.equal(features[2].properties?.toString, null);
+  });
+
   it("keeps the first matching join row when keys repeat", () => {
     const { features } = applyLayerJoins(states().features, [join()], (id) =>
       id === "census"


### PR DESCRIPTION
Attribute joins currently read fields through the prototype chain. If a sparse GeoJSON column is named `constructor`, two rows missing that key can match each other and copy unrelated attributes (for example, a missing-key target incorrectly receives `pop: 99`). A missing `toString` output column can also become a function instead of null.

Use an own-property reader for source/target keys, joined values, and unmatched-source statistics. Real fields with these names still work, and existing empty-key semantics stay unchanged. Adds two behavior regression tests.

Validation:
- New tests before the fix: 27 passed, 2 failed; after the fix: 29 passed.
- Full frontend suite with Git Bash on PATH: 7,675 passed, 0 failed, 1 skipped.
- ESLint (0 errors), processing i18n catalog check, and production TypeScript/Vite build passed.
- All worker typechecks and 13 collaboration worker tests passed.
- Final repository-wide formatting/basic pre-commit checks passed, with the already-verified eslint and npm-build hooks skipped on that final rerun. Both changed files also pass oxfmt --check and git diff --check.

Environment limits:
- `npm run ci` stopped at frontend coverage because the default Windows Bash resolved to WSL: 7 packaging-script tests failed. Coverage metrics exceeded the floors (lines 86.84%, branches 85.05%, functions 76.22%), but that invocation failed. The subsequent full frontend run with Git Bash passed.
- Python backend and Rust checks were not reached by the chained gate; neither backend nor Rust code is changed.
- GitHub workflows currently report action_required; remote CI has not yet been verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Layer joins now ignore inherited object properties when matching records.
  - Missing join keys no longer incorrectly match built-in properties.
  - Unavailable joined fields are consistently represented as `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->