### PR TITLE
feat(map): add Cesium toolbar controls and Web Mercator scene switching

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -21,6 +21,7 @@
     "@carbonplan/zarr-layer": "^0.9.0",
     "@cereusdb/standard": "^0.2.0",
     "@cesium/engine": "^26.2.0",
+    "@cesium/widgets": "^16.1.1",
     "@clerk/react": "^6.14.8",
     "@deck.gl/aggregation-layers": "9.3.11",
     "@deck.gl/core": "^9.3.11",

--- a/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
@@ -1,5 +1,5 @@
-import { CesiumCanvas, type MapEngine } from "@geolibre/map";
-import type { RefObject } from "react";
+import { CesiumCanvas, type CesiumWidgetControlLabels, type MapEngine } from "@geolibre/map";
+import { useMemo, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useCesiumIonToken } from "../../hooks/useCesiumIonToken";
 
@@ -33,6 +33,20 @@ export interface PrimaryCesiumCanvasProps {
 export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumCanvasProps) {
   const { t } = useTranslation();
   const ionToken = useCesiumIonToken();
+  // Cesium's toolbar widgets render outside React and hardcode English, so the
+  // translated tooltips are handed to the canvas the way `MapController`'s
+  // compass and terrain labels are pushed in. Memoized on the language rather
+  // than rebuilt every render: the canvas re-pushes them whenever this object's
+  // identity changes.
+  const controlLabels = useMemo<CesiumWidgetControlLabels>(
+    () => ({
+      home: t("renderer.resetView"),
+      sceneMode3D: t("renderer.scene3D"),
+      sceneMode2D: t("renderer.scene2D"),
+      sceneModeColumbus: t("renderer.sceneColumbus"),
+    }),
+    [t],
+  );
 
   return (
     <div className="absolute inset-0" data-testid="primary-cesium">
@@ -45,6 +59,7 @@ export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumC
         ionToken={ionToken}
         engineRef={engineRef}
         onEngineReady={onEngineReady}
+        controlLabels={controlLabels}
       />
       {/* The globe works without an Ion token — it draws the project basemap —
           so say what a token would add rather than hiding the view. Bottom-end

--- a/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
@@ -44,6 +44,9 @@ export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumC
       sceneMode3D: t("renderer.scene3D"),
       sceneMode2D: t("renderer.scene2D"),
       sceneModeColumbus: t("renderer.sceneColumbus"),
+      fullscreenEnter: t("renderer.fullscreenEnter"),
+      fullscreenExit: t("renderer.fullscreenExit"),
+      fullscreenUnavailable: t("renderer.fullscreenUnavailable"),
     }),
     [t],
   );

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1232,6 +1232,12 @@ export function TopToolbar({
       {} as Record<ToolbarMapControl, boolean>,
     ),
   );
+  // A renderer swap replaces the engine and its controls while this toolbar
+  // keeps its checkbox state. Replay fullscreen once the new engine is ready.
+  useEffect(() => {
+    mapControllerRef.current?.setBuiltInControlVisible("fullscreen", controlsVisible.fullscreen);
+  }, [mapControllerRef, mapReadyGeneration, controlsVisible.fullscreen]);
+
   const terrainEnabled = useAppStore((state) => state.preferences.map.terrainEnabled);
 
   // Terrain is project state, unlike the other optional map chrome, so applying

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
@@ -275,8 +275,11 @@ export function ViewMenu({
               <LayoutGrid className="h-3.5 w-3.5 shrink-0" />
               <span className="whitespace-nowrap">{t("toolbar.item.splitView")}</span>
             </DropdownMenuSubTrigger>
-            {/* `style`, not `min-w-48` — see the Reset Orientation submenu above. */}
-            <DropdownMenuSubContent style={{ minWidth: "12rem" }}>
+            {/* No `minWidth` override: these labels ("2 × 2", "Single map") are
+                short, and a 12rem floor left most of the submenu empty. The
+                shared 8rem floor plus the content's own width is enough, and it
+                still yields to the available-width cap on a narrow screen. */}
+            <DropdownMenuSubContent>
               <DropdownMenuRadioGroup
                 value={gridKey}
                 onValueChange={(value: string) => {
@@ -328,8 +331,10 @@ export function ViewMenu({
               <Box className="h-3.5 w-3.5 shrink-0" />
               <span className="whitespace-nowrap">{t("toolbar.item.renderingEngine")}</span>
             </DropdownMenuSubTrigger>
-            {/* `style`, not `min-w-48` — see the Reset Orientation submenu above. */}
-            <DropdownMenuSubContent style={{ minWidth: "12rem" }}>
+            {/* No `minWidth` override — see the Split View submenu above. Two
+                one-word engine names sized to a 12rem floor read as a mostly
+                empty box. */}
+            <DropdownMenuSubContent>
               <DropdownMenuRadioGroup
                 value={primaryRenderer}
                 onValueChange={(value: string) =>

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -2054,7 +2054,10 @@
     "resetView": "إعادة تعيين العرض",
     "scene3D": "كرة أرضية ثلاثية الأبعاد",
     "scene2D": "خريطة ثنائية الأبعاد",
-    "sceneColumbus": "عرض كولومبوس"
+    "sceneColumbus": "عرض كولومبوس",
+    "fullscreenEnter": "ملء الشاشة",
+    "fullscreenExit": "إنهاء ملء الشاشة",
+    "fullscreenUnavailable": "ملء الشاشة غير متاح"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "نسخ الإحداثيات إلى الحافظة",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -2050,7 +2050,11 @@
     "cesiumTokenHint": "أضف رمز Cesium Ion من الإعدادات للحصول على التضاريس وصور Ion"
   },
   "renderer": {
-    "layerUnsupported": "لا تُعرَض على الكرة الأرضية ثلاثية الأبعاد"
+    "layerUnsupported": "لا تُعرَض على الكرة الأرضية ثلاثية الأبعاد",
+    "resetView": "إعادة تعيين العرض",
+    "scene3D": "كرة أرضية ثلاثية الأبعاد",
+    "scene2D": "خريطة ثنائية الأبعاد",
+    "sceneColumbus": "عرض كولومبوس"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "نسخ الإحداثيات إلى الحافظة",
@@ -2912,8 +2916,8 @@
       "splitViewGrid3x3": "شبكة 3 × 3",
       "splitViewSync": "مزامنة العروض",
       "renderingEngine": "محرك العرض",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "عرض في Google Maps",
       "viewInGoogleEarth": "عرض في Google Earth",
       "zoomIn": "تكبير",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1875,7 +1875,10 @@
     "resetView": "Ansicht zurücksetzen",
     "scene3D": "3D-Globus",
     "scene2D": "2D-Karte",
-    "sceneColumbus": "Columbus-Ansicht"
+    "sceneColumbus": "Columbus-Ansicht",
+    "fullscreenEnter": "Vollbild",
+    "fullscreenExit": "Vollbild beenden",
+    "fullscreenUnavailable": "Vollbild nicht verfügbar"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Koordinaten in die Zwischenablage kopieren",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "Fügen Sie in den Einstellungen ein Cesium-Ion-Token für Gelände und Ion-Bilder hinzu"
   },
   "renderer": {
-    "layerUnsupported": "Wird vom 3D-Globus nicht dargestellt"
+    "layerUnsupported": "Wird vom 3D-Globus nicht dargestellt",
+    "resetView": "Ansicht zurücksetzen",
+    "scene3D": "3D-Globus",
+    "scene2D": "2D-Karte",
+    "sceneColumbus": "Columbus-Ansicht"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Koordinaten in die Zwischenablage kopieren",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "3 × 3-Raster",
       "splitViewSync": "Ansichten synchronisieren",
       "renderingEngine": "Rendering-Engine",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "In Google Maps ansehen",
       "viewInGoogleEarth": "In Google Earth ansehen",
       "zoomIn": "Vergrößern",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1884,7 +1884,10 @@
     "resetView": "Reset view",
     "scene3D": "3D globe",
     "scene2D": "2D map",
-    "sceneColumbus": "Columbus view"
+    "sceneColumbus": "Columbus view",
+    "fullscreenEnter": "Enter fullscreen",
+    "fullscreenExit": "Exit fullscreen",
+    "fullscreenUnavailable": "Fullscreen unavailable"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copy coordinates to clipboard",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1880,7 +1880,11 @@
     "cesiumTokenHint": "Add a Cesium Ion token in Settings for terrain and Ion imagery"
   },
   "renderer": {
-    "layerUnsupported": "Not rendered by the 3D globe"
+    "layerUnsupported": "Not rendered by the 3D globe",
+    "resetView": "Reset view",
+    "scene3D": "3D globe",
+    "scene2D": "2D map",
+    "sceneColumbus": "Columbus view"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copy coordinates to clipboard",
@@ -2734,8 +2738,8 @@
       "splitViewGrid3x3": "3 × 3 grid",
       "splitViewSync": "Sync views",
       "renderingEngine": "Rendering engine",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "View in Google Maps",
       "viewInGoogleEarth": "View in Google Earth",
       "zoomIn": "Zoom In",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1875,7 +1875,10 @@
     "resetView": "Restablecer vista",
     "scene3D": "Globo 3D",
     "scene2D": "Mapa 2D",
-    "sceneColumbus": "Vista Columbus"
+    "sceneColumbus": "Vista Columbus",
+    "fullscreenEnter": "Pantalla completa",
+    "fullscreenExit": "Salir de pantalla completa",
+    "fullscreenUnavailable": "Pantalla completa no disponible"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copiar coordenadas al portapapeles",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "Añada un token de Cesium Ion en Configuración para el terreno y las imágenes de Ion"
   },
   "renderer": {
-    "layerUnsupported": "No se representa en el globo 3D"
+    "layerUnsupported": "No se representa en el globo 3D",
+    "resetView": "Restablecer vista",
+    "scene3D": "Globo 3D",
+    "scene2D": "Mapa 2D",
+    "sceneColumbus": "Vista Columbus"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copiar coordenadas al portapapeles",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "Cuadrícula 3 × 3",
       "splitViewSync": "Sincronizar vistas",
       "renderingEngine": "Motor de representación",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Ver en Google Maps",
       "viewInGoogleEarth": "Ver en Google Earth",
       "zoomIn": "Acercar",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1875,7 +1875,10 @@
     "resetView": "بازنشانی نما",
     "scene3D": "کرهٔ سه‌بعدی",
     "scene2D": "نقشهٔ دوبعدی",
-    "sceneColumbus": "نمای کلمبوس"
+    "sceneColumbus": "نمای کلمبوس",
+    "fullscreenEnter": "تمام‌صفحه",
+    "fullscreenExit": "خروج از تمام‌صفحه",
+    "fullscreenUnavailable": "تمام‌صفحه در دسترس نیست"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "رونوشت مختصات در بریده‌دان",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "برای زمین و تصاویر Ion، یک توکن Cesium Ion در تنظیمات بیفزایید"
   },
   "renderer": {
-    "layerUnsupported": "روی کرهٔ سه‌بعدی ترسیم نمی‌شود"
+    "layerUnsupported": "روی کرهٔ سه‌بعدی ترسیم نمی‌شود",
+    "resetView": "بازنشانی نما",
+    "scene3D": "کرهٔ سه‌بعدی",
+    "scene2D": "نقشهٔ دوبعدی",
+    "sceneColumbus": "نمای کلمبوس"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "رونوشت مختصات در بریده‌دان",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "شبکهٔ ۳ × ۳",
       "splitViewSync": "هم‌گام‌سازی نماها",
       "renderingEngine": "موتور ترسیم",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "دیدن در Google Maps",
       "viewInGoogleEarth": "دیدن در Google Earth",
       "zoomIn": "بزرگ‌نمایی",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1875,7 +1875,10 @@
     "resetView": "Réinitialiser la vue",
     "scene3D": "Globe 3D",
     "scene2D": "Carte 2D",
-    "sceneColumbus": "Vue Columbus"
+    "sceneColumbus": "Vue Columbus",
+    "fullscreenEnter": "Plein écran",
+    "fullscreenExit": "Quitter le plein écran",
+    "fullscreenUnavailable": "Plein écran indisponible"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copier les coordonnées dans le presse-papiers",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "Ajoutez un jeton Cesium Ion dans les Paramètres pour le relief et l'imagerie Ion"
   },
   "renderer": {
-    "layerUnsupported": "Non rendu par le globe 3D"
+    "layerUnsupported": "Non rendu par le globe 3D",
+    "resetView": "Réinitialiser la vue",
+    "scene3D": "Globe 3D",
+    "scene2D": "Carte 2D",
+    "sceneColumbus": "Vue Columbus"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copier les coordonnées dans le presse-papiers",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "Grille 3 × 3",
       "splitViewSync": "Synchroniser les vues",
       "renderingEngine": "Moteur de rendu",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Voir dans Google Maps",
       "viewInGoogleEarth": "Voir dans Google Earth",
       "zoomIn": "Zoomer",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1875,7 +1875,10 @@
     "resetView": "दृश्य रीसेट करें",
     "scene3D": "3D ग्लोब",
     "scene2D": "2D मानचित्र",
-    "sceneColumbus": "कोलंबस दृश्य"
+    "sceneColumbus": "कोलंबस दृश्य",
+    "fullscreenEnter": "पूर्ण स्क्रीन",
+    "fullscreenExit": "पूर्ण स्क्रीन से बाहर निकलें",
+    "fullscreenUnavailable": "पूर्ण स्क्रीन उपलब्ध नहीं"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "निर्देशांक क्लिपबोर्ड पर कॉपी करें",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "टेरेन और Ion इमेजरी के लिए सेटिंग्स में Cesium Ion टोकन जोड़ें"
   },
   "renderer": {
-    "layerUnsupported": "3D ग्लोब द्वारा रेंडर नहीं किया गया"
+    "layerUnsupported": "3D ग्लोब द्वारा रेंडर नहीं किया गया",
+    "resetView": "दृश्य रीसेट करें",
+    "scene3D": "3D ग्लोब",
+    "scene2D": "2D मानचित्र",
+    "sceneColumbus": "कोलंबस दृश्य"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "निर्देशांक क्लिपबोर्ड पर कॉपी करें",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "3 × 3 ग्रिड",
       "splitViewSync": "दृश्य सिंक करें",
       "renderingEngine": "रेंडरिंग इंजन",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Google Maps में देखें",
       "viewInGoogleEarth": "Google Earth में देखें",
       "zoomIn": "ज़ूम इन",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1826,7 +1826,11 @@
     "cesiumTokenHint": "Tambahkan token Cesium Ion di Pengaturan untuk medan dan citra Ion"
   },
   "renderer": {
-    "layerUnsupported": "Tidak dirender oleh bola dunia 3D"
+    "layerUnsupported": "Tidak dirender oleh bola dunia 3D",
+    "resetView": "Atur Ulang Tampilan",
+    "scene3D": "Bola dunia 3D",
+    "scene2D": "Peta 2D",
+    "sceneColumbus": "Tampilan Columbus"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Salin koordinat ke papan klip",
@@ -2678,8 +2682,8 @@
       "splitViewGrid3x3": "Grid 3 × 3",
       "splitViewSync": "Sinkronkan tampilan",
       "renderingEngine": "Mesin render",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Lihat di Google Maps",
       "viewInGoogleEarth": "Lihat di Google Earth",
       "zoomIn": "Perbesar",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1830,7 +1830,10 @@
     "resetView": "Atur Ulang Tampilan",
     "scene3D": "Bola dunia 3D",
     "scene2D": "Peta 2D",
-    "sceneColumbus": "Tampilan Columbus"
+    "sceneColumbus": "Tampilan Columbus",
+    "fullscreenEnter": "Layar penuh",
+    "fullscreenExit": "Keluar dari layar penuh",
+    "fullscreenUnavailable": "Layar penuh tidak tersedia"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Salin koordinat ke papan klip",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1875,7 +1875,10 @@
     "resetView": "Ripristina vista",
     "scene3D": "Globo 3D",
     "scene2D": "Mappa 2D",
-    "sceneColumbus": "Vista Columbus"
+    "sceneColumbus": "Vista Columbus",
+    "fullscreenEnter": "Schermo intero",
+    "fullscreenExit": "Esci da schermo intero",
+    "fullscreenUnavailable": "Schermo intero non disponibile"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copia le coordinate negli appunti",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "Aggiungi un token Cesium Ion nelle Impostazioni per il terreno e le immagini Ion"
   },
   "renderer": {
-    "layerUnsupported": "Non visualizzato dal globo 3D"
+    "layerUnsupported": "Non visualizzato dal globo 3D",
+    "resetView": "Ripristina vista",
+    "scene3D": "Globo 3D",
+    "scene2D": "Mappa 2D",
+    "sceneColumbus": "Vista Columbus"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copia le coordinate negli appunti",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "Griglia 3 × 3",
       "splitViewSync": "Sincronizza viste",
       "renderingEngine": "Motore di rendering",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Visualizza in Google Maps",
       "viewInGoogleEarth": "Visualizza in Google Earth",
       "zoomIn": "Aumenta zoom",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1826,7 +1826,11 @@
     "cesiumTokenHint": "地形とIon衛星画像を使うには、設定でCesium Ionトークンを追加してください"
   },
   "renderer": {
-    "layerUnsupported": "3D地球儀では描画されません"
+    "layerUnsupported": "3D地球儀では描画されません",
+    "resetView": "表示をリセット",
+    "scene3D": "3D地球儀",
+    "scene2D": "2D地図",
+    "sceneColumbus": "コロンバスビュー"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "座標をクリップボードにコピー",
@@ -2678,8 +2682,8 @@
       "splitViewGrid3x3": "3 × 3 グリッド",
       "splitViewSync": "ビューを同期",
       "renderingEngine": "レンダリングエンジン",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Google マップで表示",
       "viewInGoogleEarth": "Google Earth で表示",
       "zoomIn": "ズームイン",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1830,7 +1830,10 @@
     "resetView": "表示をリセット",
     "scene3D": "3D地球儀",
     "scene2D": "2D地図",
-    "sceneColumbus": "コロンバスビュー"
+    "sceneColumbus": "コロンバスビュー",
+    "fullscreenEnter": "全画面表示",
+    "fullscreenExit": "全画面表示を終了",
+    "fullscreenUnavailable": "全画面表示は利用できません"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "座標をクリップボードにコピー",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "რელიეფისა და Ion-ის სურათებისთვის დაამატეთ Cesium Ion-ის token პარამეტრებში"
   },
   "renderer": {
-    "layerUnsupported": "3D გლობუსზე არ ისახება"
+    "layerUnsupported": "3D გლობუსზე არ ისახება",
+    "resetView": "ხედის საწყისზე დაბრუნება",
+    "scene3D": "3D გლობუსი",
+    "scene2D": "2D რუკა",
+    "sceneColumbus": "კოლუმბუსის ხედი"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "კოორდინატების კოპირება ბუფერში",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "3 × 3 ბადე",
       "splitViewSync": "ხედების სინქრონიზაცია",
       "renderingEngine": "რენდერინგის ძრავა",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "ნახვა Google Maps-ში",
       "viewInGoogleEarth": "ნახვა Google Earth-ში",
       "zoomIn": "მიახლოება",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1875,7 +1875,10 @@
     "resetView": "ხედის საწყისზე დაბრუნება",
     "scene3D": "3D გლობუსი",
     "scene2D": "2D რუკა",
-    "sceneColumbus": "კოლუმბუსის ხედი"
+    "sceneColumbus": "კოლუმბუსის ხედი",
+    "fullscreenEnter": "სრულ ეკრანზე",
+    "fullscreenExit": "სრული ეკრანიდან გასვლა",
+    "fullscreenUnavailable": "სრული ეკრანი მიუწვდომელია"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "კოორდინატების კოპირება ბუფერში",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1826,7 +1826,11 @@
     "cesiumTokenHint": "지형과 Ion 영상을 사용하려면 설정에서 Cesium Ion 토큰을 추가하세요"
   },
   "renderer": {
-    "layerUnsupported": "3D 지구본에서는 렌더링되지 않음"
+    "layerUnsupported": "3D 지구본에서는 렌더링되지 않음",
+    "resetView": "보기 재설정",
+    "scene3D": "3D 지구본",
+    "scene2D": "2D 지도",
+    "sceneColumbus": "콜럼버스 뷰"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "좌표를 클립보드에 복사",
@@ -2678,8 +2682,8 @@
       "splitViewGrid3x3": "3 × 3 격자",
       "splitViewSync": "보기 동기화",
       "renderingEngine": "렌더링 엔진",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Google 지도에서 보기",
       "viewInGoogleEarth": "Google Earth에서 보기",
       "zoomIn": "확대",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1830,7 +1830,10 @@
     "resetView": "보기 재설정",
     "scene3D": "3D 지구본",
     "scene2D": "2D 지도",
-    "sceneColumbus": "콜럼버스 뷰"
+    "sceneColumbus": "콜럼버스 뷰",
+    "fullscreenEnter": "전체 화면",
+    "fullscreenExit": "전체 화면 종료",
+    "fullscreenUnavailable": "전체 화면을 사용할 수 없음"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "좌표를 클립보드에 복사",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "Voeg in Instellingen een Cesium Ion-token toe voor terrein en Ion-beelden"
   },
   "renderer": {
-    "layerUnsupported": "Niet weergegeven door de 3D-globe"
+    "layerUnsupported": "Niet weergegeven door de 3D-globe",
+    "resetView": "Weergave herstellen",
+    "scene3D": "3D-globe",
+    "scene2D": "2D-kaart",
+    "sceneColumbus": "Columbus-weergave"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Coördinaten naar klembord kopiëren",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "3 × 3-raster",
       "splitViewSync": "Weergaven synchroniseren",
       "renderingEngine": "Renderengine",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Bekijken in Google Maps",
       "viewInGoogleEarth": "Bekijken in Google Earth",
       "zoomIn": "Inzoomen",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1875,7 +1875,10 @@
     "resetView": "Weergave herstellen",
     "scene3D": "3D-globe",
     "scene2D": "2D-kaart",
-    "sceneColumbus": "Columbus-weergave"
+    "sceneColumbus": "Columbus-weergave",
+    "fullscreenEnter": "Volledig scherm",
+    "fullscreenExit": "Volledig scherm verlaten",
+    "fullscreenUnavailable": "Volledig scherm niet beschikbaar"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Coördinaten naar klembord kopiëren",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1875,7 +1875,10 @@
     "resetView": "Redefinir vista",
     "scene3D": "Globo 3D",
     "scene2D": "Mapa 2D",
-    "sceneColumbus": "Vista Columbus"
+    "sceneColumbus": "Vista Columbus",
+    "fullscreenEnter": "Tela cheia",
+    "fullscreenExit": "Sair da tela cheia",
+    "fullscreenUnavailable": "Tela cheia indisponível"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copiar coordenadas para a área de transferência",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "Adicione um token do Cesium Ion em Configurações para terreno e imagens do Ion"
   },
   "renderer": {
-    "layerUnsupported": "Não renderizado pelo globo 3D"
+    "layerUnsupported": "Não renderizado pelo globo 3D",
+    "resetView": "Redefinir vista",
+    "scene3D": "Globo 3D",
+    "scene2D": "Mapa 2D",
+    "sceneColumbus": "Vista Columbus"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Copiar coordenadas para a área de transferência",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "Grade 3 × 3",
       "splitViewSync": "Sincronizar visualizações",
       "renderingEngine": "Motor de renderização",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Ver no Google Maps",
       "viewInGoogleEarth": "Ver no Google Earth",
       "zoomIn": "Ampliar",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1965,7 +1965,10 @@
     "resetView": "Сбросить вид",
     "scene3D": "3D-глобус",
     "scene2D": "2D-карта",
-    "sceneColumbus": "Вид Колумба"
+    "sceneColumbus": "Вид Колумба",
+    "fullscreenEnter": "Полный экран",
+    "fullscreenExit": "Выйти из полного экрана",
+    "fullscreenUnavailable": "Полный экран недоступен"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Копировать координаты в буфер обмена",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1961,7 +1961,11 @@
     "cesiumTokenHint": "Добавьте токен Cesium Ion в настройках, чтобы получить рельеф и снимки Ion"
   },
   "renderer": {
-    "layerUnsupported": "Не отображается на 3D-глобусе"
+    "layerUnsupported": "Не отображается на 3D-глобусе",
+    "resetView": "Сбросить вид",
+    "scene3D": "3D-глобус",
+    "scene2D": "2D-карта",
+    "sceneColumbus": "Вид Колумба"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Копировать координаты в буфер обмена",
@@ -2819,8 +2823,8 @@
       "splitViewGrid3x3": "Сетка 3 × 3",
       "splitViewSync": "Синхронизировать виды",
       "renderingEngine": "Механизм отрисовки",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Открыть в Google Maps",
       "viewInGoogleEarth": "Открыть в Google Earth",
       "zoomIn": "Приблизить",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1830,7 +1830,10 @@
     "resetView": "รีเซ็ตมุมมอง",
     "scene3D": "ลูกโลก 3 มิติ",
     "scene2D": "แผนที่ 2 มิติ",
-    "sceneColumbus": "มุมมองโคลัมบัส"
+    "sceneColumbus": "มุมมองโคลัมบัส",
+    "fullscreenEnter": "เต็มหน้าจอ",
+    "fullscreenExit": "ออกจากเต็มหน้าจอ",
+    "fullscreenUnavailable": "ไม่รองรับเต็มหน้าจอ"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "คัดลอกพิกัดไปยังคลิปบอร์ด",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1826,7 +1826,11 @@
     "cesiumTokenHint": "เพิ่มโทเค็น Cesium Ion ในการตั้งค่าเพื่อใช้ข้อมูลภูมิประเทศและภาพถ่ายจาก Ion"
   },
   "renderer": {
-    "layerUnsupported": "ไม่แสดงผลบนลูกโลก 3 มิติ"
+    "layerUnsupported": "ไม่แสดงผลบนลูกโลก 3 มิติ",
+    "resetView": "รีเซ็ตมุมมอง",
+    "scene3D": "ลูกโลก 3 มิติ",
+    "scene2D": "แผนที่ 2 มิติ",
+    "sceneColumbus": "มุมมองโคลัมบัส"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "คัดลอกพิกัดไปยังคลิปบอร์ด",
@@ -2678,8 +2682,8 @@
       "splitViewGrid3x3": "กริด 3 × 3",
       "splitViewSync": "ซิงค์มุมมอง",
       "renderingEngine": "เอนจินการแสดงผล",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "ดูใน Google Maps",
       "viewInGoogleEarth": "ดูใน Google Earth",
       "zoomIn": "ซูมเข้า",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1875,7 +1875,10 @@
     "resetView": "Görünümü Sıfırla",
     "scene3D": "3B küre",
     "scene2D": "2B harita",
-    "sceneColumbus": "Columbus görünümü"
+    "sceneColumbus": "Columbus görünümü",
+    "fullscreenEnter": "Tam ekran",
+    "fullscreenExit": "Tam ekrandan çık",
+    "fullscreenUnavailable": "Tam ekran kullanılamıyor"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Koordinatları panoya kopyala",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1871,7 +1871,11 @@
     "cesiumTokenHint": "Arazi ve Ion görüntüleri için Ayarlar'dan bir Cesium Ion belirteci ekleyin"
   },
   "renderer": {
-    "layerUnsupported": "3D küre tarafından çizilmiyor"
+    "layerUnsupported": "3D küre tarafından çizilmiyor",
+    "resetView": "Görünümü Sıfırla",
+    "scene3D": "3B küre",
+    "scene2D": "2B harita",
+    "sceneColumbus": "Columbus görünümü"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "Koordinatları panoya kopyala",
@@ -2725,8 +2729,8 @@
       "splitViewGrid3x3": "3 × 3 ızgara",
       "splitViewSync": "Görünümleri eşzamanla",
       "renderingEngine": "Çizim motoru",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Google Haritalar'da görüntüle",
       "viewInGoogleEarth": "Google Earth'te görüntüle",
       "zoomIn": "Yakınlaştır",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -1830,7 +1830,10 @@
     "resetView": "Đặt lại chế độ xem",
     "scene3D": "Quả địa cầu 3D",
     "scene2D": "Bản đồ 2D",
-    "sceneColumbus": "Chế độ xem Columbus"
+    "sceneColumbus": "Chế độ xem Columbus",
+    "fullscreenEnter": "Toàn màn hình",
+    "fullscreenExit": "Thoát toàn màn hình",
+    "fullscreenUnavailable": "Không hỗ trợ toàn màn hình"
   },
   "mapContextMenu": {
     "zoomInHere": "Phóng to ở đây",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -1826,7 +1826,11 @@
     "cesiumTokenHint": "Thêm mã thông báo Cesium Ion trong Cài đặt để dùng địa hình và ảnh vệ tinh Ion"
   },
   "renderer": {
-    "layerUnsupported": "Không được kết xuất trên quả địa cầu 3D"
+    "layerUnsupported": "Không được kết xuất trên quả địa cầu 3D",
+    "resetView": "Đặt lại chế độ xem",
+    "scene3D": "Quả địa cầu 3D",
+    "scene2D": "Bản đồ 2D",
+    "sceneColumbus": "Chế độ xem Columbus"
   },
   "mapContextMenu": {
     "zoomInHere": "Phóng to ở đây",
@@ -2678,8 +2682,8 @@
       "splitViewGrid3x3": "Lưới 3 × 3",
       "splitViewSync": "Đồng bộ hóa lượt xem",
       "renderingEngine": "Bộ kết xuất",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "Xem trên Google Maps",
       "viewInGoogleEarth": "Xem trong Google Earth",
       "zoomIn": "Phóng to",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1826,7 +1826,11 @@
     "cesiumTokenHint": "在设置中添加 Cesium Ion 令牌即可使用地形和 Ion 影像"
   },
   "renderer": {
-    "layerUnsupported": "3D 地球不渲染此图层"
+    "layerUnsupported": "3D 地球不渲染此图层",
+    "resetView": "重置视图",
+    "scene3D": "3D 地球",
+    "scene2D": "2D 地图",
+    "sceneColumbus": "哥伦布视图"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "复制坐标到剪贴板",
@@ -2678,8 +2682,8 @@
       "splitViewGrid3x3": "3 × 3 网格",
       "splitViewSync": "同步视图",
       "renderingEngine": "渲染引擎",
-      "rendererMapLibre": "MapLibre 2D",
-      "rendererCesium": "Cesium 3D",
+      "rendererMapLibre": "MapLibre",
+      "rendererCesium": "Cesium",
       "viewInGoogleMaps": "在 Google 地图中查看",
       "viewInGoogleEarth": "在 Google Earth 中查看",
       "zoomIn": "放大",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1830,7 +1830,10 @@
     "resetView": "重置视图",
     "scene3D": "3D 地球",
     "scene2D": "2D 地图",
-    "sceneColumbus": "哥伦布视图"
+    "sceneColumbus": "哥伦布视图",
+    "fullscreenEnter": "全屏",
+    "fullscreenExit": "退出全屏",
+    "fullscreenUnavailable": "全屏不可用"
   },
   "mapContextMenu": {
     "copyCoordinatesHint": "复制坐标到剪贴板",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -4328,14 +4328,14 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 
 /* ---------------------------------------------------------------------------
  * Cesium's toolbar widgets on the globe (`cesium-widget-controls.ts`): the
- * home button and the scene-mode picker.
+ * home button, the scene-mode picker, and the fullscreen button.
  *
  * Cesium ships them in its own dark-blue toolbar look — `#303336` on a `#444`
  * border, a `#48b` hover with a white glow — which reads as a foreign control
  * next to MapLibre's white buttons, and does so in both themes (GeoLibre keeps
  * the map chrome white in dark mode too, see the graticule control above).
- * These rules restyle the chrome to MapLibre's while leaving the widgets'
- * own SVG icons and expand/collapse behaviour alone.
+ * These rules restyle the chrome to MapLibre's while leaving the widgets' own
+ * SVG icons and expand/collapse behaviour alone.
  *
  * Everything is scoped under `.geolibre-cesium-ctrl`, the wrapper the controls
  * add, so Cesium's other DOM — the credit display, the render-error panel — is
@@ -4358,13 +4358,42 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   padding: 0;
 }
 
-.geolibre-cesium-ctrl .cesium-toolbar-button {
+/* Two selectors because the widgets do not agree on a class. The home button
+   and the scene-mode picker are `cesium-toolbar-button`s, which Cesium leaves
+   unsized for a toolbar to place; the fullscreen button is not one, and
+   FullscreenButton.css sizes it to `100%` of a parent it expects `Viewer` to
+   have given a height. Sizing every button here covers both, and the wrapper
+   `<span>` the scene-mode picker nests its button in needs it too — it is not a
+   `<button>`, so the element-qualified selector alone would miss it. */
+.geolibre-cesium-ctrl .cesium-toolbar-button,
+.geolibre-cesium-ctrl button.cesium-button {
   width: 29px;
   height: 29px;
 }
 
-.geolibre-cesium-ctrl .cesium-button:hover,
-.geolibre-cesium-ctrl .cesium-button:focus {
+/* The scene-mode picker nests its button inside a wrapper `<span>` that
+   SceneModePicker.css gives `margin: 0 3px`. The controls are stacked in a
+   right-aligned corner, so that padding makes the picker's wrapper 6px wider
+   than the home button's and shifts the button itself 3px left of the one above
+   it — a visible misalignment in a vertical toolbar. The buttons are spaced by
+   the `.maplibregl-ctrl` margins already; this padding is pure offset. */
+.geolibre-cesium-ctrl .cesium-sceneModePicker-wrapper {
+  margin: 0;
+}
+
+/* Hover and focus.
+ *
+ * The specificity here is load-bearing, not decoration. MapLibre's own
+ * `.maplibregl-ctrl button:not(:disabled):hover` scores higher than a plain
+ * `.geolibre-cesium-ctrl .cesium-button:hover` (an extra element selector), so
+ * it wins and replaces the white background with its `rgba(0, 0, 0, .05)`.
+ * That colour is *translucent*: on the light 2D map it reads as a faint grey,
+ * but here it lets the globe show straight through the button, which over a
+ * night-side globe or dark imagery leaves a dark icon on a near-black square.
+ * Matching MapLibre's selector shape (`button` + `:not(:disabled)`) and adding
+ * the scoping class outranks it without reaching for `!important`. */
+.geolibre-cesium-ctrl button.cesium-button:not(:disabled):hover,
+.geolibre-cesium-ctrl button.cesium-button:not(:disabled):focus {
   background: #f2f2f2;
   border: none;
   box-shadow: none;
@@ -4372,17 +4401,38 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   outline: none;
 }
 
-.geolibre-cesium-ctrl .cesium-button:active {
+.geolibre-cesium-ctrl button.cesium-button:not(:disabled):active {
   background: #e6e6e6;
   box-shadow: none;
   fill: #000;
 }
 
+/* A disabled Cesium button (the fullscreen one, where the browser forbids
+   fullscreen) keeps Cesium's dark palette otherwise. */
+.geolibre-cesium-ctrl button.cesium-button:disabled {
+  background: #fff;
+  border: none;
+  box-shadow: none;
+  fill: #b0b0b0;
+}
+
 /* The scene-mode picker's drop-down is a stack of buttons below the trigger.
    Cesium spaces them with its own margins and leaves them borderless once the
-   rules above land; re-add a small gap so the three modes read as separate
-   targets rather than one tall button. */
+   rules above land; give each the same outline the trigger has so the three
+   modes read as separate targets rather than one tall button. */
 .geolibre-cesium-ctrl .cesium-sceneModePicker-wrapper .cesium-button {
   box-shadow: 0 0 0 2px rgb(0 0 0 / 0.1);
   margin-bottom: 4px;
+}
+
+/* Those drop-down buttons overflow the wrapper's box, so in a vertical toolbar
+   they land over the control below — and paint *behind* it, since a later
+   sibling wins by default, which leaves the entries visible-but-unclickable
+   under the fullscreen button. Raising the picker puts the open drop-down on
+   top of its neighbours, as a drop-down should be, whatever order the controls
+   were mounted in (toggling Controls → Fullscreen re-adds that button at the
+   end of the corner). */
+.geolibre-cesium-ctrl-expands {
+  position: relative;
+  z-index: 1;
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -4325,3 +4325,64 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 .geolibre-legend-panel.maplibregl-ctrl textarea::placeholder {
   color: hsl(var(--muted-foreground)) !important;
 }
+
+/* ---------------------------------------------------------------------------
+ * Cesium's toolbar widgets on the globe (`cesium-widget-controls.ts`): the
+ * home button and the scene-mode picker.
+ *
+ * Cesium ships them in its own dark-blue toolbar look — `#303336` on a `#444`
+ * border, a `#48b` hover with a white glow — which reads as a foreign control
+ * next to MapLibre's white buttons, and does so in both themes (GeoLibre keeps
+ * the map chrome white in dark mode too, see the graticule control above).
+ * These rules restyle the chrome to MapLibre's while leaving the widgets'
+ * own SVG icons and expand/collapse behaviour alone.
+ *
+ * Everything is scoped under `.geolibre-cesium-ctrl`, the wrapper the controls
+ * add, so Cesium's other DOM — the credit display, the render-error panel — is
+ * untouched. `29px` and the shadow are MapLibre's own control-button metrics.
+ * ------------------------------------------------------------------------- */
+.geolibre-cesium-ctrl {
+  /* MapLibre's control shadow, so the buttons sit on the map like their
+     neighbours rather than floating flat. */
+  box-shadow: 0 0 0 2px rgb(0 0 0 / 0.1);
+  border-radius: 4px;
+}
+
+.geolibre-cesium-ctrl .cesium-button {
+  background: #fff;
+  border: none;
+  border-radius: 4px;
+  /* `fill`, not `color`: the widgets draw their icons as SVG paths. */
+  fill: #333;
+  margin: 0;
+  padding: 0;
+}
+
+.geolibre-cesium-ctrl .cesium-toolbar-button {
+  width: 29px;
+  height: 29px;
+}
+
+.geolibre-cesium-ctrl .cesium-button:hover,
+.geolibre-cesium-ctrl .cesium-button:focus {
+  background: #f2f2f2;
+  border: none;
+  box-shadow: none;
+  fill: #000;
+  outline: none;
+}
+
+.geolibre-cesium-ctrl .cesium-button:active {
+  background: #e6e6e6;
+  box-shadow: none;
+  fill: #000;
+}
+
+/* The scene-mode picker's drop-down is a stack of buttons below the trigger.
+   Cesium spaces them with its own margins and leaves them borderless once the
+   rules above land; re-add a small gap so the three modes read as separate
+   targets rather than one tall button. */
+.geolibre-cesium-ctrl .cesium-sceneModePicker-wrapper .cesium-button {
+  box-shadow: 0 0 0 2px rgb(0 0 0 / 0.1);
+  margin-bottom: 4px;
+}

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -4401,6 +4401,17 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   outline: none;
 }
 
+/* Keyboard focus keeps a ring, and it is MapLibre's own — its control buttons
+   draw `0 0 2px 2px #0096ff` on `:focus-visible` — so tabbing through the map
+   toolbar looks the same whichever renderer drew the button. The rule above
+   clears the ring for a *pointer* focus on purpose, mirroring MapLibre's
+   `:focus:not(:focus-visible) { box-shadow: none }`; without this rule after it,
+   that clearing would swallow the keyboard indicator too and leave only the
+   hover background, which is far too subtle to locate focus by. */
+.geolibre-cesium-ctrl button.cesium-button:not(:disabled):focus-visible {
+  box-shadow: 0 0 2px 2px #0096ff;
+}
+
 .geolibre-cesium-ctrl button.cesium-button:not(:disabled):active {
   background: #e6e6e6;
   box-shadow: none;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -4437,13 +4437,25 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 }
 
 /* Those drop-down buttons overflow the wrapper's box, so in a vertical toolbar
-   they land over the control below — and paint *behind* it, since a later
-   sibling wins by default, which leaves the entries visible-but-unclickable
-   under the fullscreen button. Raising the picker puts the open drop-down on
-   top of its neighbours, as a drop-down should be, whatever order the controls
-   were mounted in (toggling Controls → Fullscreen re-adds that button at the
-   end of the corner). */
+   they land over whichever control sits below. Two separate problems follow,
+   and both need fixing.
+ *
+ * Open: the entries paint *behind* the control below, because a later sibling
+ * wins by default, leaving them visible but unclickable. Raising the picker
+ * puts the open drop-down on top of its neighbours, as a drop-down should be,
+ * whatever order the controls were mounted in (toggling Controls → Fullscreen
+ * re-adds that button at the end of the corner).
+ *
+ * Closed: Cesium collapses the entries with `visibility: hidden`, which keeps
+ * their boxes in layout — and with the picker raised, that dead footprint sits
+ * over the fullscreen button and swallows its clicks, with nothing visible to
+ * explain why. Collapsing them out of layout instead costs only the quarter-
+ * second fade-out, which a vertical toolbar reads better without anyway. */
 .geolibre-cesium-ctrl-expands {
   position: relative;
   z-index: 1;
+}
+
+.geolibre-cesium-ctrl .cesium-sceneModePicker-hidden {
+  display: none;
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -4392,30 +4392,31 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
  * night-side globe or dark imagery leaves a dark icon on a near-black square.
  * Matching MapLibre's selector shape (`button` + `:not(:disabled)`) and adding
  * the scoping class outranks it without reaching for `!important`. */
-.geolibre-cesium-ctrl button.cesium-button:not(:disabled):hover,
+/* Cesium's focused icon is white; keep it legible after pointer clicks. */
 .geolibre-cesium-ctrl button.cesium-button:not(:disabled):focus {
-  background: #f2f2f2;
+  background: #fff;
   border: none;
   box-shadow: none;
-  fill: #000;
+  fill: #333;
   outline: none;
 }
 
-/* Keyboard focus keeps a ring, and it is MapLibre's own — its control buttons
-   draw `0 0 2px 2px #0096ff` on `:focus-visible` — so tabbing through the map
-   toolbar looks the same whichever renderer drew the button. The rule above
-   clears the ring for a *pointer* focus on purpose, mirroring MapLibre's
-   `:focus:not(:focus-visible) { box-shadow: none }`; without this rule after it,
-   that clearing would swallow the keyboard indicator too and leave only the
-   hover background, which is far too subtle to locate focus by. */
+.geolibre-cesium-ctrl button.cesium-button:not(:disabled):hover {
+  background: #dbeafe;
+  border: none;
+  box-shadow: inset 0 0 0 2px #60a5fa;
+  fill: #1e40af;
+}
+
 .geolibre-cesium-ctrl button.cesium-button:not(:disabled):focus-visible {
-  box-shadow: 0 0 2px 2px #0096ff;
+  outline: 2px solid #0096ff;
+  outline-offset: 2px;
 }
 
 .geolibre-cesium-ctrl button.cesium-button:not(:disabled):active {
-  background: #e6e6e6;
-  box-shadow: none;
-  fill: #000;
+  background: #bfdbfe;
+  box-shadow: inset 0 0 0 2px #2563eb;
+  fill: #1e3a8a;
 }
 
 /* A disabled Cesium button (the fullscreen one, where the browser forbids
@@ -4427,30 +4428,24 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   fill: #b0b0b0;
 }
 
-/* The scene-mode picker's drop-down is a stack of buttons below the trigger.
-   Cesium spaces them with its own margins and leaves them borderless once the
-   rules above land; give each the same outline the trigger has so the three
-   modes read as separate targets rather than one tall button. */
-.geolibre-cesium-ctrl .cesium-sceneModePicker-wrapper .cesium-button {
-  box-shadow: 0 0 0 2px rgb(0 0 0 / 0.1);
-  margin-bottom: 4px;
+/* Expand left into the map instead of down over the fullscreen button.
+   Keep the wrapper one button wide so opening it never shifts the toolbar.
+   Flex lays out only the visible alternatives, regardless of the selected mode. */
+.geolibre-cesium-ctrl .cesium-sceneModePicker-wrapper {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  gap: 6px;
 }
 
-/* Those drop-down buttons overflow the wrapper's box, so in a vertical toolbar
-   they land over whichever control sits below. Two separate problems follow,
-   and both need fixing.
- *
- * Open: the entries paint *behind* the control below, because a later sibling
- * wins by default, leaving them visible but unclickable. Raising the picker
- * puts the open drop-down on top of its neighbours, as a drop-down should be,
- * whatever order the controls were mounted in (toggling Controls → Fullscreen
- * re-adds that button at the end of the corner).
- *
- * Closed: Cesium collapses the entries with `visibility: hidden`, which keeps
- * their boxes in layout — and with the picker raised, that dead footprint sits
- * over the fullscreen button and swallows its clicks, with nothing visible to
- * explain why. Collapsing them out of layout instead costs only the quarter-
- * second fade-out, which a vertical toolbar reads better without anyway. */
+.geolibre-cesium-ctrl .cesium-sceneModePicker-wrapper .cesium-button {
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.geolibre-cesium-ctrl .cesium-sceneModePicker-dropDown-icon {
+  box-shadow: 0 0 0 2px rgb(0 0 0 / 0.1);
+}
+
 .geolibre-cesium-ctrl-expands {
   position: relative;
   z-index: 1;

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1229,6 +1229,12 @@ export default defineConfig({
       // leave `@cesium/engine` to be discovered on first open — the full-page
       // reload this list exists to prevent.
       "@cesium/engine",
+      // Cesium's toolbar widgets (the globe's home and scene-mode buttons),
+      // reached through a second lazy import in CesiumCanvas's mount effect.
+      // Listed for the same reason as the engine above: without it Vite
+      // discovers the package on first open of the globe and triggers a
+      // full-page reload to re-optimize.
+      "@cesium/widgets",
     ],
     // PGlite ships its own WASM + filesystem bundles and must not be pre-bundled
     // by esbuild, which mangles those asset references (per PGlite's Vite guide).

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -308,8 +308,9 @@ After a bump, check all five — none of these fail the build:
   class names (`.cesium-button`, `.cesium-toolbar-button`,
   `.cesium-sceneModePicker-wrapper`). A renamed observable leaves the English
   default in place; a renamed class leaves Cesium's dark-blue chrome on a
-  GeoLibre toolbar. Neither fails the build, and only the tooltips are asserted
-  (`e2e/cesium-primary-renderer.spec.ts`). The fullscreen button is the fragile
+  GeoLibre toolbar. Neither fails the build. Tooltip assertions live in
+  `e2e/cesium-primary-renderer.spec.ts`, alongside control mounting and alignment
+  checks. The fullscreen button is the fragile
   one: its tooltip is a read-only computed, so the translated string is written
   onto the element from a `fullscreenchange` listener and survives only because
   DOM listeners fire in registration order. If a bump makes the widget update

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -318,6 +318,13 @@ After a bump, check all five — none of these fail the build:
   target — the label reverts to English *after the first toggle*, which is why
   the spec toggles fullscreen and re-reads the title rather than checking it
   once at mount.
+
+  **Scene-mode lifetime:** the 2D/3D/Columbus picker controls the current
+  `CesiumWidget` only. Recreating the widget, including switching to MapLibre
+  and back or reopening a project, starts in 3D. The project retains its
+  rendering engine and camera, but does not serialize the Cesium scene mode.
+  Scene-mode persistence is outside the toolbar integration's scope; adding it
+  requires an explicit project/store field and restoration for each Cesium pane.
 - **PWA globs.** `**/cesium-*` / `**/Cesium-*` in `vite.config.ts` keep the
   chunk out of the app-shell precache and CacheFirst-cache it instead. A chunk
   renamed out of that pattern would be precached, adding megabytes to first load.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -309,7 +309,14 @@ After a bump, check all five — none of these fail the build:
   `.cesium-sceneModePicker-wrapper`). A renamed observable leaves the English
   default in place; a renamed class leaves Cesium's dark-blue chrome on a
   GeoLibre toolbar. Neither fails the build, and only the tooltips are asserted
-  (`e2e/cesium-primary-renderer.spec.ts`).
+  (`e2e/cesium-primary-renderer.spec.ts`). The fullscreen button is the fragile
+  one: its tooltip is a read-only computed, so the translated string is written
+  onto the element from a `fullscreenchange` listener and survives only because
+  DOM listeners fire in registration order. If a bump makes the widget update
+  its own title differently — batched on a microtask, or bound to another
+  target — the label reverts to English *after the first toggle*, which is why
+  the spec toggles fullscreen and re-reads the title rather than checking it
+  once at mount.
 - **PWA globs.** `**/cesium-*` / `**/Cesium-*` in `vite.config.ts` keep the
   chunk out of the app-shell precache and CacheFirst-cache it instead. A chunk
   renamed out of that pattern would be precached, adding megabytes to first load.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -259,20 +259,23 @@ both behaviors against the sources above; the failure modes are a leaked token a
 a sidecar that is unreachable only for proxied users, neither of which shows up in
 CI or on an unproxied dev machine.
 
-### `cesium` / `@cesium/engine` — runtime assets fetched by URL
+### `cesium` / `@cesium/engine` / `@cesium/widgets` — runtime assets fetched by URL
 
 The 3D globe pane loads its code from **`@cesium/engine`** but its runtime
 assets from the **`cesium`** wrapper. Both are dependencies and both must move
 together: `cesium@1.x` pins the matching `@cesium/engine`, and the prebuilt
 Workers/Assets staged from the wrapper have to match the engine running them.
+**`@cesium/widgets`** is a third dependency on the same clock — it depends on
+`@cesium/engine` itself — and it supplies the globe's home, scene-mode and
+fullscreen buttons (`packages/map/src/cesium-widget-controls.ts`).
 
-The code imports the engine directly because the `cesium` barrel re-exports
-`@cesium/widgets` as well, and that defeats tree-shaking — the base-layer
-picker, geocoder, info box and Knockout all shipped in the lazy chunk even
-though the pane builds a bare `CesiumWidget`. Reverting to `import("cesium")`
-adds ~340 KB back with no build error and no test failure.
+The code imports the engine and the widgets directly rather than through the
+`cesium` barrel, which re-exports both and defeats tree-shaking — the base-layer
+picker, geocoder, info box and Knockout all shipped in the lazy chunk even when
+the pane built a bare `CesiumWidget`. Reverting to `import("cesium")` adds
+~340 KB back with no build error and no test failure.
 
-After a bump, check all four — none of these fail the build:
+After a bump, check all five — none of these fail the build:
 
 - **Asset copy.** `vite-plugins/copy-cesium-assets.ts` copies `Assets`,
   `ThirdParty`, `Widgets` and `Workers` out of `cesium/Build/Cesium` into
@@ -286,18 +289,38 @@ After a bump, check all four — none of these fail the build:
   `BASE_URL`, not a hardcoded `/cesium`, so a sub-path deploy (the `/demo/`
   build) still resolves. Cesium reads it at import time; if the Workers 404 the
   render loop dies with no error boundary.
-- **The stylesheet.** The pane links `Widgets/CesiumWidget/CesiumWidget.css`,
-  not the 32 KB `Widgets/widgets.css` — it only needs the canvas sizing, credit
-  container and error panel. If upstream moves that file the globe still mounts
-  but its canvas stops filling the pane, which no assertion catches.
+- **The stylesheets.** `CesiumCanvas.tsx` links four paths by hand
+  (`CESIUM_CSS_PATHS`) rather than the 32 KB `Widgets/widgets.css`:
+  `Widgets/CesiumWidget/CesiumWidget.css` for the canvas sizing, credit
+  container and error panel; `Widgets/shared.css` for the `.cesium-button`
+  chrome both toolbar widgets are built from; and
+  `Widgets/SceneModePicker/SceneModePicker.css` plus
+  `Widgets/FullscreenButton/FullscreenButton.css` for those two widgets. Check
+  every one after a bump — a `<link>` to a path upstream moved 404s silently, and
+  the failure is cosmetic in a way no assertion catches: the globe still mounts,
+  but its canvas stops filling the pane, or a toolbar button loses its size and
+  renders 0x0. (The home button has no stylesheet of its own; `shared.css` is
+  all it needs.)
+- **The widget classes and view models.** `cesium-widget-controls.ts` builds
+  `HomeButton`, `SceneModePicker` and `FullscreenButton` directly and writes
+  their tooltips through `viewModel.tooltip` / `tooltip2D` / `tooltip3D` /
+  `tooltipColumbusView`. `index.css` then restyles them through Cesium's own
+  class names (`.cesium-button`, `.cesium-toolbar-button`,
+  `.cesium-sceneModePicker-wrapper`). A renamed observable leaves the English
+  default in place; a renamed class leaves Cesium's dark-blue chrome on a
+  GeoLibre toolbar. Neither fails the build, and only the tooltips are asserted
+  (`e2e/cesium-primary-renderer.spec.ts`).
 - **PWA globs.** `**/cesium-*` / `**/Cesium-*` in `vite.config.ts` keep the
   chunk out of the app-shell precache and CacheFirst-cache it instead. A chunk
   renamed out of that pattern would be precached, adding megabytes to first load.
 
 `e2e/cesium-globe.spec.ts` mounts the real engine keyless and drags the globe,
-so it catches a broken `CESIUM_BASE_URL` or a dead chunk. It cannot catch the
-CSS regression or the bundle-size one — check those by eye and in the build
-output.
+so it catches a broken `CESIUM_BASE_URL` or a dead chunk.
+`e2e/cesium-primary-renderer.spec.ts` adds the toolbar: it asserts the three
+buttons mount, carry translated tooltips, and share a right edge, which catches a
+renamed view-model observable and the 0x0-button case of a missing stylesheet.
+Neither catches the rest of the CSS regression or the bundle-size one — check
+those by eye and in the build output.
 
 ## Adding a blend mode
 

--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -171,8 +171,8 @@ test.describe("Cesium as the primary rendering engine", () => {
 });
 
 /**
- * Cesium's own toolbar buttons on the globe (issue #2270): the home button and
- * the scene-mode picker.
+ * Cesium's own toolbar buttons on the globe (issue #2270): the home button, the
+ * scene-mode picker, and the fullscreen button.
  *
  * The unit tests cover the camera maths and the morph guards against a fake
  * Cesium, which by construction cannot catch what matters here — that the
@@ -185,17 +185,24 @@ test.describe("Cesium as the primary rendering engine", () => {
  * Keyless like the specs above, and asserts nothing about tiles.
  */
 test.describe("Cesium toolbar controls on the globe", () => {
-  /** One of the scene-mode picker's buttons, addressed by its tooltip. */
+  /** One of the scene-mode picker's *drop-down* entries, by its tooltip. */
   const sceneMode = (page: Page, title: string) =>
-    page.locator(`.cesium-sceneModePicker-wrapper button[title="${title}"]`);
+    page.locator(`.cesium-sceneModePicker-dropDown-icon[title="${title}"]`);
 
   /** Open the picker's drop-down and choose a mode, then wait out the morph. */
   async function chooseSceneMode(page: Page, title: string): Promise<void> {
+    // The trigger carries the *selected* mode's tooltip, so it collides with the
+    // drop-down entry of the same name; `sceneMode` matches only the entries.
     await page.locator(".cesium-sceneModePicker-wrapper button").first().click();
-    await sceneMode(page, title).last().click();
-    // The morph is animated, and the engine deliberately publishes nothing
-    // while it runs, so the readout only settles on the far side of it.
-    await page.waitForTimeout(2_000);
+    await sceneMode(page, title).click();
+    // A 3D↔2D morph is two animations back to back — Cesium flies the camera out
+    // before it morphs — and the whole time the engine refuses camera reads and
+    // writes, because Cesium throws from them mid-morph. There is no DOM signal
+    // for "the morph landed", and the zoom readout is no help either: it is
+    // *frozen* at the last applied view for the duration, so it looks stable the
+    // instant the morph begins. Hence a plain wait, generous enough to cover both
+    // animations on a software renderer.
+    await page.waitForTimeout(6_000);
   }
 
   test("switches scene mode and resets the view without losing the camera", async ({ page }) => {
@@ -207,10 +214,10 @@ test.describe("Cesium toolbar controls on the globe", () => {
     // than the default whole-Earth view. That is not incidental tidying: wheel
     // zoom on a globe framed at the full Earth trips a `DeveloperError:
     // normalized result is not a number` inside Cesium's own
-    // ScreenSpaceCameraController and stops the render loop. It reproduces on
-    // an unmodified build, so it predates these controls and is not what this
-    // test is here to catch — the test above avoids it the same way, by
-    // arriving on the globe already zoomed in.
+    // ScreenSpaceCameraController and stops the render loop. It reproduces on an
+    // unmodified build, so it predates these controls and is not what this test
+    // is here to catch — the test above avoids it the same way, by arriving on
+    // the globe already zoomed in.
     const mapBox = await page.getByTestId("map-canvas").boundingBox();
     expect(mapBox).not.toBeNull();
     await page.mouse.move(mapBox!.x + mapBox!.width / 2, mapBox!.y + mapBox!.height / 2);
@@ -218,56 +225,65 @@ test.describe("Cesium toolbar controls on the globe", () => {
       await page.mouse.wheel(0, -200);
       await page.waitForTimeout(80);
     }
-    await waitForStableZoom(page);
+    const zoomOn2dMap = await waitForStableZoom(page);
+    expect(zoomOn2dMap).toBeGreaterThan(2);
 
     await chooseRenderer(page, "Cesium");
     const globe = page.getByTestId("primary-cesium");
     await expect(globe).toBeVisible({ timeout: 60_000 });
     await expect(globe.locator("canvas")).toBeVisible({ timeout: 60_000 });
 
-    // Both controls mount into the globe's control host.
+    // All three controls mount into the globe's control host.
     await expect(page.locator(".cesium-home-button")).toBeVisible({ timeout: 60_000 });
     await expect(page.locator(".cesium-sceneModePicker-wrapper")).toBeVisible();
+    await expect(page.locator(".cesium-fullscreenButton")).toBeVisible();
     // Tooltips come from the app's catalogs, not the widgets' English defaults.
+    // The fullscreen one is the interesting case: Cesium derives it from the
+    // fullscreen state as a read-only computed, so it is written onto the button
+    // rather than pushed through a view model.
     await expect(page.locator(".cesium-home-button")).toHaveAttribute("title", "Reset view");
+    await expect(page.locator(".cesium-fullscreenButton")).toHaveAttribute(
+      "title",
+      "Enter fullscreen",
+    );
 
-    // Move off the seeded camera, so "the zoom survived" means something. Same
-    // burst-and-poll shape as the test above: one wheel tick can land while the
-    // globe is still settling and be swallowed.
-    const globeBox = await globe.locator("canvas").boundingBox();
-    expect(globeBox).not.toBeNull();
-    await page.mouse.move(globeBox!.x + globeBox!.width / 2, globeBox!.y + globeBox!.height / 2);
-    let previous = await waitForStableZoom(page);
-    for (let burst = 0; burst < 2; burst++) {
-      const settled = previous;
-      for (let tick = 0; tick < 3; tick++) {
-        await page.mouse.wheel(0, -200);
-        await page.waitForTimeout(80);
-      }
-      await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBeGreaterThan(settled + 0.1);
-      previous = await waitForStableZoom(page);
-    }
-    const zoomOn3d = previous;
+    // They line up. Cesium gives the scene-mode picker's wrapper a 3px side
+    // margin and leaves the fullscreen button to inherit a size from a `Viewer`
+    // layout that does not exist here, so both drifted out of the column before
+    // `index.css` pinned them.
+    const edges = await page
+      .locator(".geolibre-cesium-ctrl button:visible")
+      .evaluateAll((buttons) => buttons.map((button) => button.getBoundingClientRect().right));
+    expect(edges).toHaveLength(3);
+    for (const edge of edges) expect(edge).toBeCloseTo(edges[0], 0);
 
-    // 2D keeps the scale: the orthographic frustum has no camera distance, so
-    // an engine that did not re-derive the zoom would report a constant here.
+    // The globe seeded from the 2D camera, so this is the scale to preserve.
+    const zoomOn3d = await waitForStableZoom(page);
+    expectSameZoom(zoomOn3d, zoomOn2dMap);
+
+    // 2D keeps that scale. The orthographic frustum has no camera distance, so
+    // an engine that kept deriving the zoom from one would report a constant.
     await chooseSceneMode(page, "2D map");
     expectSameZoom(await waitForStableZoom(page), zoomOn3d);
     // 2D is north-up and untilted, and says so. Sub-degree rather than exactly
-    // zero: `isSameView`'s 0.1° tolerance is what suppresses the camera echo,
-    // so a residual tenth of a degree from the 3D camera can survive the morph
-    // unpublished. Anything a user could see would be far larger.
-    await expect(page.getByText(/^Pitch:/)).toHaveText(/^Pitch: 0\.\d°$/);
-    await expect(page.getByText(/^Bearing:/)).toHaveText(/^Bearing: 0\.\d°$/);
+    // zero, and signed: `isSameView`'s 0.1° tolerance is what suppresses the
+    // camera echo, so a residual tenth of a degree can survive the morph
+    // unpublished (and reads as "-0.0" once formatted). Anything a user could
+    // see would be far larger.
+    await expect(page.getByText(/^Pitch:/)).toHaveText(/^Pitch: -?0\.\d°$/);
+    await expect(page.getByText(/^Bearing:/)).toHaveText(/^Bearing: -?0\.\d°$/);
 
-    // Wheel zoom in 2D still reaches the shared store — the assertion that the
-    // 2D-specific readback is wired up at all, not just the morph.
+    // Navigating in 2D still reaches the shared store. Nothing in the 3D
+    // readback survives the switch — there is no camera distance to measure —
+    // so this is what says the 2D-specific path is actually wired up.
+    const globeBox = await globe.locator("canvas").boundingBox();
+    expect(globeBox).not.toBeNull();
     await page.mouse.move(globeBox!.x + globeBox!.width / 2, globeBox!.y + globeBox!.height / 2);
-    for (let tick = 0; tick < 3; tick++) {
+    for (let tick = 0; tick < 4; tick++) {
       await page.mouse.wheel(0, -200);
-      await page.waitForTimeout(80);
+      await page.waitForTimeout(100);
     }
-    await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBeGreaterThan(zoomOn3d + 0.1);
+    await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBeGreaterThan(zoomOn3d + 0.3);
     const zoomOn2d = await waitForStableZoom(page);
 
     // Back to 3D, carrying the zoom the user reached in 2D.
@@ -280,5 +296,30 @@ test.describe("Cesium toolbar controls on the globe", () => {
     // camera publisher rather than moving the globe behind the store's back.
     await page.locator(".cesium-home-button").click();
     await expect.poll(() => readZoom(page), { timeout: 60_000 }).toBeLessThan(zoomOn2d - 1);
+  });
+
+  test("lets Controls -> Fullscreen govern the globe's fullscreen button", async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await waitForMap(page);
+    await chooseRenderer(page, "Cesium");
+    await expect(page.locator(".cesium-fullscreenButton")).toBeVisible({ timeout: 60_000 });
+
+    // The menu row exists for every renderer, but the globe used to refuse every
+    // built-in control outright, so toggling it did nothing and the checkmark
+    // would not even move. The engine now answers for this one id.
+    const toggleFullscreen = async () => {
+      await page.getByRole("button", { name: "Controls", exact: true }).click();
+      await page.getByRole("menuitem", { name: /^Fullscreen/ }).click();
+      await page.keyboard.press("Escape");
+    };
+
+    await toggleFullscreen();
+    await expect(page.locator(".cesium-fullscreenButton")).toHaveCount(0);
+    // The other two have no menu counterpart and are unaffected.
+    await expect(page.locator(".cesium-home-button")).toBeVisible();
+
+    await toggleFullscreen();
+    await expect(page.locator(".cesium-fullscreenButton")).toBeVisible();
   });
 });

--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -177,10 +177,8 @@ test.describe("Cesium as the primary rendering engine", () => {
  * The unit tests cover the camera maths and the morph guards against a fake
  * Cesium, which by construction cannot catch what matters here — that the
  * widgets actually mount and bind (they are Knockout-driven DOM built outside
- * React), that a real morph runs to completion, and that the scale the store
- * carries survives it. That last one is the whole point: 2D swaps the frustum
- * for an orthographic box, so a zoom Cesium considers preserved is not the one
- * the rest of the app holds unless the engine re-derives it.
+ * React), that animated morphs run to completion, and that the shared camera
+ * follows the native endpoint instead of resetting to the pre-morph view.
  *
  * Keyless like the specs above, and asserts nothing about tiles.
  */
@@ -195,15 +193,17 @@ test.describe("Cesium toolbar controls on the globe", () => {
     // drop-down entry of the same name; `sceneMode` matches only the entries.
     await page.locator(".cesium-sceneModePicker-wrapper button").first().click();
     await sceneMode(page, title).click();
-    // Projection switches are synchronous so the camera never flies out to
-    // Cesium's intermediate extent before restoring the project view.
+    const picker = page.locator(".geolibre-cesium-ctrl-expands");
+    // This must enter a real animation, then finish before camera assertions.
+    await expect(picker).toHaveAttribute("aria-busy", "true");
+    await expect(picker).toHaveAttribute("aria-busy", "false", { timeout: 15_000 });
     await expect(page.locator(".cesium-sceneModePicker-wrapper button").first()).toHaveAttribute(
       "title",
       title,
     );
   }
 
-  test("switches scene mode and resets the view without losing the camera", async ({ page }) => {
+  test("animates scene changes and publishes the settled camera", async ({ page }) => {
     test.setTimeout(180_000);
 
     await waitForMap(page);
@@ -259,10 +259,11 @@ test.describe("Cesium toolbar controls on the globe", () => {
     const zoomOn3d = await waitForStableZoom(page);
     expectSameZoom(zoomOn3d, zoomOn2dMap);
 
-    // 2D keeps that scale. The orthographic frustum has no camera distance, so
-    // an engine that kept deriving the zoom from one would report a constant.
+    // Cesium animates out to its native 2D world extent. The store must follow
+    // that new scale rather than snap back to the zoomed-in 3D view.
     await chooseSceneMode(page, "2D map");
-    expectSameZoom(await waitForStableZoom(page), zoomOn3d);
+    const native2dZoom = await waitForStableZoom(page);
+    expect(native2dZoom).toBeLessThan(zoomOn3d - 0.5);
     // 2D is north-up and untilted, and says so. Sub-degree rather than exactly
     // zero, and signed: `isSameView`'s 0.1° tolerance is what suppresses the
     // camera echo, so a residual tenth of a degree can survive the morph
@@ -281,24 +282,26 @@ test.describe("Cesium toolbar controls on the globe", () => {
       await page.mouse.wheel(0, -200);
       await page.waitForTimeout(100);
     }
-    await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBeGreaterThan(zoomOn3d + 0.3);
-    const zoomOn2d = await waitForStableZoom(page);
+    await expect
+      .poll(() => readZoom(page), { timeout: 30_000 })
+      .toBeGreaterThan(native2dZoom + 0.3);
+    await waitForStableZoom(page);
 
-    // Columbus uses the same projected scale as 2D, despite its perspective
-    // camera. A latitude correction here would change the visible zoom.
+    // Columbus and 3D choose their own native endpoints too. They must remain
+    // navigable and publish a finite camera after each animation.
     await chooseSceneMode(page, "Columbus view");
-    expectSameZoom(await waitForStableZoom(page), zoomOn2d);
+    expect(Number.isFinite(await waitForStableZoom(page))).toBe(true);
 
-    // Back to 3D, carrying the zoom the user reached in 2D.
+    // Back to the native 3D endpoint.
     await chooseSceneMode(page, "3D globe");
-    expectSameZoom(await waitForStableZoom(page), zoomOn2d);
+    expect(Number.isFinite(await waitForStableZoom(page))).toBe(true);
 
-    // Home flies out to a view of the whole Earth, and the store follows it
-    // there — the button drives Cesium's own `camera.flyHome`, so this also
-    // asserts that such a move still reaches `mapView` through the engine's
-    // camera publisher rather than moving the globe behind the store's back.
+    // Home returns to its whole-Earth view. Cesium's native 3D morph may
+    // finish even farther out, so Home need not be a zoom-out from that pose.
+    const beforeHome = await waitForStableZoom(page);
     await page.locator(".cesium-home-button").click();
-    await expect.poll(() => readZoom(page), { timeout: 60_000 }).toBeLessThan(zoomOn2d - 1);
+    await expect.poll(() => readZoom(page), { timeout: 60_000 }).not.toBe(beforeHome);
+    expect(await waitForStableZoom(page)).toBeLessThan(zoomOn3d - 1);
   });
 
   test("lets Controls -> Fullscreen govern the globe's fullscreen button", async ({ page }) => {

--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -195,14 +195,12 @@ test.describe("Cesium toolbar controls on the globe", () => {
     // drop-down entry of the same name; `sceneMode` matches only the entries.
     await page.locator(".cesium-sceneModePicker-wrapper button").first().click();
     await sceneMode(page, title).click();
-    // A 3D↔2D morph is two animations back to back — Cesium flies the camera out
-    // before it morphs — and the whole time the engine refuses camera reads and
-    // writes, because Cesium throws from them mid-morph. There is no DOM signal
-    // for "the morph landed", and the zoom readout is no help either: it is
-    // *frozen* at the last applied view for the duration, so it looks stable the
-    // instant the morph begins. Hence a plain wait, generous enough to cover both
-    // animations on a software renderer.
-    await page.waitForTimeout(6_000);
+    // Projection switches are synchronous so the camera never flies out to
+    // Cesium's intermediate extent before restoring the project view.
+    await expect(page.locator(".cesium-sceneModePicker-wrapper button").first()).toHaveAttribute(
+      "title",
+      title,
+    );
   }
 
   test("switches scene mode and resets the view without losing the camera", async ({ page }) => {
@@ -286,6 +284,11 @@ test.describe("Cesium toolbar controls on the globe", () => {
     await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBeGreaterThan(zoomOn3d + 0.3);
     const zoomOn2d = await waitForStableZoom(page);
 
+    // Columbus uses the same projected scale as 2D, despite its perspective
+    // camera. A latitude correction here would change the visible zoom.
+    await chooseSceneMode(page, "Columbus view");
+    expectSameZoom(await waitForStableZoom(page), zoomOn2d);
+
     // Back to 3D, carrying the zoom the user reached in 2D.
     await chooseSceneMode(page, "3D globe");
     expectSameZoom(await waitForStableZoom(page), zoomOn2d);
@@ -323,26 +326,60 @@ test.describe("Cesium toolbar controls on the globe", () => {
     await expect(page.locator(".cesium-fullscreenButton")).toBeVisible();
   });
 
-  test("keeps the fullscreen tooltip translated across a state change", async ({ page }) => {
+  test("keeps fullscreen hidden across renderer swaps", async ({ page }) => {
     test.setTimeout(120_000);
-
     await waitForMap(page);
+    await page.getByRole("button", { name: "Controls", exact: true }).click();
+    await page.getByRole("menuitem", { name: /^Fullscreen/ }).click();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".maplibregl-ctrl-fullscreen")).toHaveCount(0);
     await chooseRenderer(page, "Cesium");
-    const button = page.locator(".cesium-fullscreenButton");
-    await expect(button).toBeVisible({ timeout: 60_000 });
-    await expect(button).toHaveAttribute("title", "Enter fullscreen");
-
-    // The label is not pushed through a view model like the other two: Cesium
-    // derives this tooltip from the fullscreen state as a read-only computed and
-    // rewrites the attribute on every `fullscreenchange`. The translated string
-    // is written back from a listener on the same event, which survives only
-    // because DOM listeners fire in registration order and the widget registers
-    // its own at construction. That is an implementation detail of
-    // `@cesium/widgets` rather than a contract (#2270 review), so the assertion
-    // that matters is this one — after a real toggle, not just at mount.
-    await button.click();
-    await expect(button).toHaveAttribute("title", "Exit fullscreen");
-    await button.click();
-    await expect(button).toHaveAttribute("title", "Enter fullscreen");
+    await expect(page.locator(".cesium-home-button")).toBeVisible({ timeout: 60_000 });
+    await expect(page.locator(".cesium-fullscreenButton")).toHaveCount(0);
+    await chooseRenderer(page, "MapLibre");
+    await expect(page.locator(".maplibregl-canvas")).toBeVisible();
+    await expect(page.locator(".maplibregl-ctrl-fullscreen")).toHaveCount(0);
   });
+
+  for (const theme of ["light", "dark"] as const) {
+    test(`fullscreen stays reachable with the scene picker open (${theme})`, async ({ page }) => {
+      test.setTimeout(120_000);
+
+      await waitForMap(page, `/?theme=${theme}`);
+      await chooseRenderer(page, "Cesium");
+      const button = page.locator(".cesium-fullscreenButton");
+      await expect(button).toBeVisible({ timeout: 60_000 });
+      await expect(button).toHaveAttribute("title", "Enter fullscreen");
+
+      // An open picker must not intercept clicks on the fullscreen control.
+      // Repeat with it closed to cover the ordinary toggle as well.
+      for (const openPicker of [true, false]) {
+        if (openPicker) {
+          await page.locator(".cesium-sceneModePicker-wrapper button").first().click();
+        }
+        await button.click({ timeout: 3_000 });
+        // Cesium recomputes the English tooltip on fullscreenchange; the app's
+        // translated title must survive that update.
+        await expect(button).toHaveAttribute("title", "Exit fullscreen");
+        await expect
+          .poll(() =>
+            page.evaluate(() => {
+              const fullscreen = document.fullscreenElement;
+              const canvas = fullscreen?.querySelector("canvas");
+              if (!fullscreen || !canvas) return false;
+              const rect = canvas.getBoundingClientRect();
+              return (
+                Math.abs(rect.width - innerWidth) < 2 && Math.abs(rect.height - innerHeight) < 2
+              );
+            }),
+          )
+          .toBe(true);
+        await button.click();
+        await expect(button).toHaveAttribute("title", "Enter fullscreen");
+        await expect
+          .poll(() => page.evaluate(() => document.fullscreenElement === null))
+          .toBe(true);
+      }
+    });
+  }
 });

--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -78,7 +78,7 @@ function expectSameZoom(actual: number, expected: number): void {
 }
 
 /** Pick a primary renderer from View → Rendering engine. */
-async function chooseRenderer(page: Page, label: "MapLibre 2D" | "Cesium 3D"): Promise<void> {
+async function chooseRenderer(page: Page, label: "MapLibre" | "Cesium"): Promise<void> {
   await page.getByRole("button", { name: "View", exact: true }).click();
   await page.getByRole("menuitem", { name: "Rendering engine" }).click();
   await page.getByRole("menuitemradio", { name: label }).click();
@@ -110,7 +110,7 @@ test.describe("Cesium as the primary rendering engine", () => {
     const zoomOn2d = await waitForStableZoom(page);
     expect(zoomOn2d).toBeGreaterThan(0);
 
-    await chooseRenderer(page, "Cesium 3D");
+    await chooseRenderer(page, "Cesium");
 
     // The globe replaces the 2D map rather than joining it: no grid appears,
     // and MapLibre is unmounted (not merely hidden) so it frees its context.
@@ -160,12 +160,125 @@ test.describe("Cesium as the primary rendering engine", () => {
     // Switching back remounts MapLibre, which runs CesiumWidget's teardown —
     // a destroy that threw, or Cesium state left holding the container, shows
     // up as the 2D canvas never reappearing.
-    await chooseRenderer(page, "MapLibre 2D");
+    await chooseRenderer(page, "MapLibre");
     await expect(page.getByTestId("map-canvas")).toBeVisible({ timeout: 60_000 });
     await expect(page.locator(".maplibregl-canvas")).toBeVisible({ timeout: 30_000 });
     await expect(page.getByTestId("primary-cesium")).toHaveCount(0);
     await expect(layerRow(page, "cities")).toBeVisible();
     // The camera the globe left behind is the one the 2D map picks up.
     expectSameZoom(await waitForStableZoom(page), zoomOn3d);
+  });
+});
+
+/**
+ * Cesium's own toolbar buttons on the globe (issue #2270): the home button and
+ * the scene-mode picker.
+ *
+ * The unit tests cover the camera maths and the morph guards against a fake
+ * Cesium, which by construction cannot catch what matters here — that the
+ * widgets actually mount and bind (they are Knockout-driven DOM built outside
+ * React), that a real morph runs to completion, and that the scale the store
+ * carries survives it. That last one is the whole point: 2D swaps the frustum
+ * for an orthographic box, so a zoom Cesium considers preserved is not the one
+ * the rest of the app holds unless the engine re-derives it.
+ *
+ * Keyless like the specs above, and asserts nothing about tiles.
+ */
+test.describe("Cesium toolbar controls on the globe", () => {
+  /** One of the scene-mode picker's buttons, addressed by its tooltip. */
+  const sceneMode = (page: Page, title: string) =>
+    page.locator(`.cesium-sceneModePicker-wrapper button[title="${title}"]`);
+
+  /** Open the picker's drop-down and choose a mode, then wait out the morph. */
+  async function chooseSceneMode(page: Page, title: string): Promise<void> {
+    await page.locator(".cesium-sceneModePicker-wrapper button").first().click();
+    await sceneMode(page, title).last().click();
+    // The morph is animated, and the engine deliberately publishes nothing
+    // while it runs, so the readout only settles on the far side of it.
+    await page.waitForTimeout(2_000);
+  }
+
+  test("switches scene mode and resets the view without losing the camera", async ({ page }) => {
+    test.setTimeout(180_000);
+
+    await waitForMap(page);
+
+    // Zoom the 2D map in first, so the globe seeds from a close camera rather
+    // than the default whole-Earth view. That is not incidental tidying: wheel
+    // zoom on a globe framed at the full Earth trips a `DeveloperError:
+    // normalized result is not a number` inside Cesium's own
+    // ScreenSpaceCameraController and stops the render loop. It reproduces on
+    // an unmodified build, so it predates these controls and is not what this
+    // test is here to catch — the test above avoids it the same way, by
+    // arriving on the globe already zoomed in.
+    const mapBox = await page.getByTestId("map-canvas").boundingBox();
+    expect(mapBox).not.toBeNull();
+    await page.mouse.move(mapBox!.x + mapBox!.width / 2, mapBox!.y + mapBox!.height / 2);
+    for (let tick = 0; tick < 5; tick++) {
+      await page.mouse.wheel(0, -200);
+      await page.waitForTimeout(80);
+    }
+    await waitForStableZoom(page);
+
+    await chooseRenderer(page, "Cesium");
+    const globe = page.getByTestId("primary-cesium");
+    await expect(globe).toBeVisible({ timeout: 60_000 });
+    await expect(globe.locator("canvas")).toBeVisible({ timeout: 60_000 });
+
+    // Both controls mount into the globe's control host.
+    await expect(page.locator(".cesium-home-button")).toBeVisible({ timeout: 60_000 });
+    await expect(page.locator(".cesium-sceneModePicker-wrapper")).toBeVisible();
+    // Tooltips come from the app's catalogs, not the widgets' English defaults.
+    await expect(page.locator(".cesium-home-button")).toHaveAttribute("title", "Reset view");
+
+    // Move off the seeded camera, so "the zoom survived" means something. Same
+    // burst-and-poll shape as the test above: one wheel tick can land while the
+    // globe is still settling and be swallowed.
+    const globeBox = await globe.locator("canvas").boundingBox();
+    expect(globeBox).not.toBeNull();
+    await page.mouse.move(globeBox!.x + globeBox!.width / 2, globeBox!.y + globeBox!.height / 2);
+    let previous = await waitForStableZoom(page);
+    for (let burst = 0; burst < 2; burst++) {
+      const settled = previous;
+      for (let tick = 0; tick < 3; tick++) {
+        await page.mouse.wheel(0, -200);
+        await page.waitForTimeout(80);
+      }
+      await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBeGreaterThan(settled + 0.1);
+      previous = await waitForStableZoom(page);
+    }
+    const zoomOn3d = previous;
+
+    // 2D keeps the scale: the orthographic frustum has no camera distance, so
+    // an engine that did not re-derive the zoom would report a constant here.
+    await chooseSceneMode(page, "2D map");
+    expectSameZoom(await waitForStableZoom(page), zoomOn3d);
+    // 2D is north-up and untilted, and says so. Sub-degree rather than exactly
+    // zero: `isSameView`'s 0.1° tolerance is what suppresses the camera echo,
+    // so a residual tenth of a degree from the 3D camera can survive the morph
+    // unpublished. Anything a user could see would be far larger.
+    await expect(page.getByText(/^Pitch:/)).toHaveText(/^Pitch: 0\.\d°$/);
+    await expect(page.getByText(/^Bearing:/)).toHaveText(/^Bearing: 0\.\d°$/);
+
+    // Wheel zoom in 2D still reaches the shared store — the assertion that the
+    // 2D-specific readback is wired up at all, not just the morph.
+    await page.mouse.move(globeBox!.x + globeBox!.width / 2, globeBox!.y + globeBox!.height / 2);
+    for (let tick = 0; tick < 3; tick++) {
+      await page.mouse.wheel(0, -200);
+      await page.waitForTimeout(80);
+    }
+    await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBeGreaterThan(zoomOn3d + 0.1);
+    const zoomOn2d = await waitForStableZoom(page);
+
+    // Back to 3D, carrying the zoom the user reached in 2D.
+    await chooseSceneMode(page, "3D globe");
+    expectSameZoom(await waitForStableZoom(page), zoomOn2d);
+
+    // Home flies out to a view of the whole Earth, and the store follows it
+    // there — the button drives Cesium's own `camera.flyHome`, so this also
+    // asserts that such a move still reaches `mapView` through the engine's
+    // camera publisher rather than moving the globe behind the store's back.
+    await page.locator(".cesium-home-button").click();
+    await expect.poll(() => readZoom(page), { timeout: 60_000 }).toBeLessThan(zoomOn2d - 1);
   });
 });

--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -322,4 +322,27 @@ test.describe("Cesium toolbar controls on the globe", () => {
     await toggleFullscreen();
     await expect(page.locator(".cesium-fullscreenButton")).toBeVisible();
   });
+
+  test("keeps the fullscreen tooltip translated across a state change", async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await waitForMap(page);
+    await chooseRenderer(page, "Cesium");
+    const button = page.locator(".cesium-fullscreenButton");
+    await expect(button).toBeVisible({ timeout: 60_000 });
+    await expect(button).toHaveAttribute("title", "Enter fullscreen");
+
+    // The label is not pushed through a view model like the other two: Cesium
+    // derives this tooltip from the fullscreen state as a read-only computed and
+    // rewrites the attribute on every `fullscreenchange`. The translated string
+    // is written back from a listener on the same event, which survives only
+    // because DOM listeners fire in registration order and the widget registers
+    // its own at construction. That is an implementation detail of
+    // `@cesium/widgets` rather than a contract (#2270 review), so the assertion
+    // that matters is this one — after a real toggle, not just at mount.
+    await button.click();
+    await expect(button).toHaveAttribute("title", "Exit fullscreen");
+    await button.click();
+    await expect(button).toHaveAttribute("title", "Enter fullscreen");
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@carbonplan/zarr-layer": "^0.9.0",
         "@cereusdb/standard": "^0.2.0",
         "@cesium/engine": "^26.2.0",
+        "@cesium/widgets": "^16.1.1",
         "@clerk/react": "^6.14.8",
         "@deck.gl/aggregation-layers": "9.3.11",
         "@deck.gl/core": "^9.3.11",
@@ -25108,6 +25109,7 @@
       "license": "MIT",
       "dependencies": {
         "@cesium/engine": "^26.2.0",
+        "@cesium/widgets": "^16.1.1",
         "@geolibre/core": "*",
         "@maplibre/geojson-vt": "^6.1.1",
         "@maplibre/vt-pbf": "^4.3.2",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "@cesium/engine": "^26.2.0",
+    "@cesium/widgets": "^16.1.1",
     "@geolibre/core": "*",
     "@maplibre/geojson-vt": "^6.1.1",
     "@maplibre/vt-pbf": "^4.3.2",

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -332,6 +332,8 @@ export const CesiumCanvas = memo(function CesiumCanvas({
           // choice and fail without an Ion token (Ion's default imagery needs
           // one), which is what used to keep the globe off the keyless path.
           baseLayer: false,
+          // Match the project map in flat modes, including its vertical extent.
+          mapProjection: new Cesium.WebMercatorProjection(),
         });
         if (cancelled) {
           viewer.destroy();

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -14,6 +14,10 @@ import { isSameView } from "./cesium-camera";
 import { CesiumEngine } from "./cesium-engine";
 import type { MapEngine } from "./map-engine";
 import { CesiumControlHost, setPrimaryCesiumControlHost } from "./cesium-control-host";
+import type {
+  CesiumWidgetControlHandle,
+  CesiumWidgetControlLabels,
+} from "./cesium-widget-controls";
 
 // The Cesium 3D-globe view (see private/cesium-view-plan.md). M1 wired the
 // build, token, and split-pane mount; M2 synced the camera with the shared store
@@ -35,13 +39,29 @@ const CESIUM_BASE_URL = `${APP_BASE_URL}cesium`;
 /** id for the one-time <link> to Cesium's widget stylesheet (served from base). */
 const CESIUM_CSS_LINK_ID = "cesium-widgets-css";
 /**
- * Just the `CesiumWidget` styles — the canvas sizing, the credit container, and
- * the render-error panel. The full `Widgets/widgets.css` (32 KB) also carries
- * the chrome for the base-layer picker, geocoder, timeline, animation dial and
- * info box, none of which this pane creates. Both are staged by
- * copy-cesium-assets, so narrowing the link costs nothing.
+ * The Cesium stylesheets this pane actually needs, in cascade order.
+ *
+ * Not the full `Widgets/widgets.css` (32 KB), which also carries the chrome for
+ * the base-layer picker, geocoder, timeline, animation dial and info box — none
+ * of which this pane creates. All of them are staged by copy-cesium-assets, so
+ * narrowing the links costs nothing and keeps unused rules out of the document.
+ *
+ * - `CesiumWidget.css` — canvas sizing, the credit container, the render-error
+ *   panel. Always needed.
+ * - `shared.css` — the `.cesium-button` / `.cesium-toolbar-button` base both
+ *   toolbar widgets are built from. The home button has no stylesheet of its
+ *   own; this is all it needs.
+ * - `SceneModePicker.css` — the expanding drop-down that widget adds on top.
+ *
+ * The last two are only meaningful on the primary globe, the one pane that
+ * hosts controls, but are linked unconditionally: the links are document-level
+ * and a pane can become the primary map without a reload.
  */
-const CESIUM_CSS_PATH = "/Widgets/CesiumWidget/CesiumWidget.css";
+const CESIUM_CSS_PATHS = [
+  "/Widgets/CesiumWidget/CesiumWidget.css",
+  "/Widgets/shared.css",
+  "/Widgets/SceneModePicker/SceneModePicker.css",
+] as const;
 
 export interface CesiumCanvasProps {
   /**
@@ -73,6 +93,17 @@ export interface CesiumCanvasProps {
   engineRef?: React.RefObject<MapEngine | null>;
   /** Called once the engine is live and the ref is set. */
   onEngineReady?: () => void;
+  /**
+   * Translated tooltips for the Cesium toolbar controls (home, scene mode).
+   *
+   * The controls are Cesium widgets rendered outside React, so their labels are
+   * pushed in the way `MapController`'s compass and terrain labels are, rather
+   * than read from a hook here — `@geolibre/map` has no i18n of its own. Omit
+   * them and the widgets keep their English defaults.
+   *
+   * Only the primary globe hosts controls, so this is ignored on a grid pane.
+   */
+  controlLabels?: CesiumWidgetControlLabels;
 }
 
 /**
@@ -84,13 +115,15 @@ export interface CesiumCanvasProps {
 function prepareCesiumEnvironment(): void {
   const globalWindow = window as typeof window & { CESIUM_BASE_URL?: string };
   globalWindow.CESIUM_BASE_URL ??= CESIUM_BASE_URL;
-  if (!document.getElementById(CESIUM_CSS_LINK_ID)) {
+  CESIUM_CSS_PATHS.forEach((path, index) => {
+    const id = `${CESIUM_CSS_LINK_ID}-${index}`;
+    if (document.getElementById(id)) return;
     const link = document.createElement("link");
-    link.id = CESIUM_CSS_LINK_ID;
+    link.id = id;
     link.rel = "stylesheet";
-    link.href = `${CESIUM_BASE_URL}${CESIUM_CSS_PATH}`;
+    link.href = `${CESIUM_BASE_URL}${path}`;
     document.head.appendChild(link);
-  }
+  });
 }
 
 /**
@@ -115,12 +148,16 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   ionToken,
   engineRef,
   onEngineReady,
+  controlLabels,
 }: CesiumCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<CesiumWidget | null>(null);
   const cesiumRef = useRef<typeof import("@cesium/engine") | null>(null);
   const engineInstanceRef = useRef<CesiumEngine | null>(null);
   const controlHostRef = useRef<CesiumControlHost | null>(null);
+  // The Cesium toolbar widgets mounted on the primary globe, kept so the label
+  // effect can retranslate them and the unmount can remove them.
+  const widgetControlsRef = useRef<CesiumWidgetControlHandle[]>([]);
   // The imagery layers currently drawing the project basemap, at the bottom of
   // the stack. Tracked so a basemap change replaces exactly these and leaves
   // the data layers above them alone.
@@ -140,6 +177,8 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   engineRefProp.current = engineRef;
   const onEngineReadyRef = useRef(onEngineReady);
   onEngineReadyRef.current = onEngineReady;
+  const controlLabelsRef = useRef(controlLabels);
+  controlLabelsRef.current = controlLabels;
 
   // No pane id means this globe *is* the primary map area, not a pane beside it.
   const isPrimary = viewId === undefined;
@@ -331,8 +370,22 @@ export const CesiumCanvas = memo(function CesiumCanvas({
         if (cancelled || viewer.isDestroyed()) return;
 
         if (viewId === undefined) {
-          controlHostRef.current = new CesiumControlHost(viewer, container);
-          setPrimaryCesiumControlHost(controlHostRef.current);
+          const host = new CesiumControlHost(viewer, container);
+          controlHostRef.current = host;
+          setPrimaryCesiumControlHost(host);
+          // Cesium's own home and scene-mode buttons (issue #2270). Imported
+          // here rather than at module scope so `@cesium/widgets` stays in the
+          // lazily fetched `cesium` chunk instead of joining the 2D boot path.
+          const { createCesiumWidgetControls } = await import("./cesium-widget-controls");
+          if (!cancelled && !viewer.isDestroyed()) {
+            widgetControlsRef.current = createCesiumWidgetControls(
+              viewer,
+              controlLabelsRef.current,
+            );
+            // Top-right, above MapLibre's navigation control on the 2D map, so
+            // the pair reads as one toolbar whichever renderer is drawing.
+            for (const control of widgetControlsRef.current) host.addControl(control, "top-right");
+          }
         }
 
         // Seed the camera from the shared store camera before the first frame.
@@ -385,6 +438,10 @@ export const CesiumCanvas = memo(function CesiumCanvas({
       baseImageryLayersRef.current = [];
       appliedImageryRef.current = null;
       if (viewId === undefined) {
+        // The host's own destroy() removes every control it holds, these
+        // included; dropping the handles here is what stops the label effect
+        // from writing to a destroyed widget's view model afterwards.
+        widgetControlsRef.current = [];
         if (controlHostRef.current) {
           controlHostRef.current.destroy();
           controlHostRef.current = null;
@@ -415,6 +472,14 @@ export const CesiumCanvas = memo(function CesiumCanvas({
     applyBasemapLook();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, basemapVisible, basemapOpacity]);
+
+  // Retranslate the Cesium toolbar tooltips when the UI language changes. The
+  // widgets expose them as observables, so this updates the live DOM without
+  // rebuilding the controls or touching the camera.
+  useEffect(() => {
+    if (!ready || !controlLabels) return;
+    for (const control of widgetControlsRef.current) control.setLabels(controlLabels);
+  }, [ready, controlLabels]);
 
   // Reconcile the store layers (with this pane's overrides) onto the globe
   // whenever they change. `ready` re-runs this once the viewer exists; the

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -14,10 +14,7 @@ import { isSameView } from "./cesium-camera";
 import { CesiumEngine } from "./cesium-engine";
 import type { MapEngine } from "./map-engine";
 import { CesiumControlHost, setPrimaryCesiumControlHost } from "./cesium-control-host";
-import type {
-  CesiumWidgetControlHandle,
-  CesiumWidgetControlLabels,
-} from "./cesium-widget-controls";
+import type { CesiumWidgetControls, CesiumWidgetControlLabels } from "./cesium-widget-controls";
 
 // The Cesium 3D-globe view (see private/cesium-view-plan.md). M1 wired the
 // build, token, and split-pane mount; M2 synced the camera with the shared store
@@ -52,8 +49,9 @@ const CESIUM_CSS_LINK_ID = "cesium-widgets-css";
  *   toolbar widgets are built from. The home button has no stylesheet of its
  *   own; this is all it needs.
  * - `SceneModePicker.css` — the expanding drop-down that widget adds on top.
+ * - `FullscreenButton.css` — the fullscreen button's own sizing.
  *
- * The last two are only meaningful on the primary globe, the one pane that
+ * The widget sheets are only meaningful on the primary globe, the one pane that
  * hosts controls, but are linked unconditionally: the links are document-level
  * and a pane can become the primary map without a reload.
  */
@@ -61,6 +59,7 @@ const CESIUM_CSS_PATHS = [
   "/Widgets/CesiumWidget/CesiumWidget.css",
   "/Widgets/shared.css",
   "/Widgets/SceneModePicker/SceneModePicker.css",
+  "/Widgets/FullscreenButton/FullscreenButton.css",
 ] as const;
 
 export interface CesiumCanvasProps {
@@ -157,7 +156,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   const controlHostRef = useRef<CesiumControlHost | null>(null);
   // The Cesium toolbar widgets mounted on the primary globe, kept so the label
   // effect can retranslate them and the unmount can remove them.
-  const widgetControlsRef = useRef<CesiumWidgetControlHandle[]>([]);
+  const widgetControlsRef = useRef<CesiumWidgetControls | null>(null);
   // The imagery layers currently drawing the project basemap, at the bottom of
   // the stack. Tracked so a basemap change replaces exactly these and leaves
   // the data layers above them alone.
@@ -378,13 +377,23 @@ export const CesiumCanvas = memo(function CesiumCanvas({
           // lazily fetched `cesium` chunk instead of joining the 2D boot path.
           const { createCesiumWidgetControls } = await import("./cesium-widget-controls");
           if (!cancelled && !viewer.isDestroyed()) {
-            widgetControlsRef.current = createCesiumWidgetControls(
+            // Fullscreen expands the globe's own container, matching what
+            // MapLibre's fullscreen control does with the 2D map's — the app
+            // chrome around it goes away, the map fills the screen, and the
+            // control host inside it comes along so the buttons stay reachable.
+            const controls = createCesiumWidgetControls(
               viewer,
+              container,
               controlLabelsRef.current,
             );
+            widgetControlsRef.current = controls;
             // Top-right, above MapLibre's navigation control on the 2D map, so
-            // the pair reads as one toolbar whichever renderer is drawing.
-            for (const control of widgetControlsRef.current) host.addControl(control, "top-right");
+            // the toolbar reads the same whichever renderer is drawing.
+            for (const control of controls.all) host.addControl(control, "top-right");
+            // Hand the fullscreen button to the engine so Controls → Fullscreen
+            // governs it here as it does on the 2D map. The other two have no
+            // menu counterpart and stay unconditional.
+            engine.registerBuiltInControl("fullscreen", controls.fullscreen);
           }
         }
 
@@ -441,7 +450,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({
         // The host's own destroy() removes every control it holds, these
         // included; dropping the handles here is what stops the label effect
         // from writing to a destroyed widget's view model afterwards.
-        widgetControlsRef.current = [];
+        widgetControlsRef.current = null;
         if (controlHostRef.current) {
           controlHostRef.current.destroy();
           controlHostRef.current = null;
@@ -478,7 +487,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   // rebuilding the controls or touching the camera.
   useEffect(() => {
     if (!ready || !controlLabels) return;
-    for (const control of widgetControlsRef.current) control.setLabels(controlLabels);
+    for (const control of widgetControlsRef.current?.all ?? []) control.setLabels(controlLabels);
   }, [ready, controlLabels]);
 
   // Reconcile the store layers (with this pane's overrides) onto the globe

--- a/packages/map/src/cesium-camera.ts
+++ b/packages/map/src/cesium-camera.ts
@@ -164,6 +164,18 @@ function pickGlobe(
   );
 }
 
+/** Columbus uses projected distances when the flat scene is Web Mercator. */
+function isMercatorColumbus(
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
+): boolean {
+  return (
+    viewer.scene.mode === Cesium.SceneMode.COLUMBUS_VIEW &&
+    !!viewer.scene.mapProjection &&
+    viewer.scene.mapProjection instanceof Cesium.WebMercatorProjection
+  );
+}
+
 /**
  * The camera-to-ground distance that encodes `view.zoom` in the scene mode the
  * viewer is currently drawing in.
@@ -180,20 +192,13 @@ export function zoomToSceneRange(
   viewer: CesiumWidget,
   view: MapViewState,
 ): number {
-  // Columbus view takes the 3D branch, latitude correction and all, which is
-  // right for the projection Cesium actually draws it in (#2270 review). The
-  // `cos(lat)` in `groundResolution` converts a projected pixel width into true
-  // ground metres, so it only belongs where the camera measures ground metres —
-  // and Columbus view, on `CesiumWidget`'s default `GeographicProjection`, does:
-  // a metre on its vertical axis is `a·Δlat`, a true meridian metre, not a
-  // Mercator-stretched one. `zoomToRange` matches the *vertical* extent, so that
-  // is the axis that has to line up. It is 2D that drops the correction, and for
-  // a different reason: MapLibre's zoom is defined on the horizontal projected
-  // span, which is a full circumference in either projection.
+  // Mercator Columbus view measures projected metres. The latitude correction
+  // belongs only to the globe (or the legacy geographic flat projection).
+  const scaleLatitude = isMercatorColumbus(Cesium, viewer) ? 0 : view.center[1];
   const range =
     viewer.scene.mode === Cesium.SceneMode.SCENE2D
       ? zoomToOrthoWidth(view.zoom, canvasWidth(viewer))
-      : zoomToRange(view.zoom, view.center[1], canvasHeight(viewer), cameraFovy(viewer));
+      : zoomToRange(view.zoom, scaleLatitude, canvasHeight(viewer), cameraFovy(viewer));
   return Math.max(range, 1);
 }
 
@@ -272,7 +277,8 @@ export function readMapViewFromCamera(
     range = carto.height;
   }
 
-  const zoom = clamp(rangeToZoom(range, lat, height, cameraFovy(viewer)), 0, 24);
+  const scaleLatitude = isMercatorColumbus(Cesium, viewer) ? 0 : lat;
+  const zoom = clamp(rangeToZoom(range, scaleLatitude, height, cameraFovy(viewer)), 0, 24);
   return {
     center: [lng, lat],
     zoom,

--- a/packages/map/src/cesium-camera.ts
+++ b/packages/map/src/cesium-camera.ts
@@ -82,6 +82,39 @@ export function canvasHeight(viewer: CesiumWidget): number {
   return canvas.clientHeight || canvas.height || 1;
 }
 
+/** The viewer canvas width in CSS pixels. See {@link canvasHeight}. */
+export function canvasWidth(viewer: CesiumWidget): number {
+  const canvas = viewer.scene.canvas;
+  return canvas.clientWidth || canvas.width || 1;
+}
+
+/**
+ * Horizontal extent, in projected metres, that a 2D scene must span across a
+ * `widthPx`-wide canvas to show the same ground as MapLibre at `zoom`.
+ *
+ * The globe's 3D camera encodes zoom as a *distance* ({@link zoomToRange}),
+ * which only works against a perspective frustum. Cesium's 2D scene mode swaps
+ * that for an orthographic one, where there is no meaningful camera distance —
+ * the view is defined by the width of the frustum box instead, and Cesium's own
+ * camera API (`lookAt`'s range, `flyToBoundingSphere`'s offset range, a
+ * `setView` destination's height) all resolve to exactly that width in 2D.
+ *
+ * So this is the 2D counterpart of `zoomToRange`, and it is *simpler* than its
+ * 3D sibling: MapLibre's zoom is defined on the projected plane (the world is
+ * `TILE_SIZE * 2**zoom` pixels wide), and both projections Cesium can draw a 2D
+ * scene in — geographic and Web Mercator — span the same full circumference
+ * across x. Latitude and field of view, which the 3D conversion has to correct
+ * for, drop out entirely.
+ */
+export function zoomToOrthoWidth(zoom: number, widthPx: number): number {
+  return (widthPx * EARTH_CIRCUMFERENCE) / (TILE_SIZE * 2 ** zoom);
+}
+
+/** Inverse of {@link zoomToOrthoWidth}: the MapLibre zoom a 2D view is showing. */
+export function orthoWidthToZoom(width: number, widthPx: number): number {
+  return Math.log2((widthPx * EARTH_CIRCUMFERENCE) / (TILE_SIZE * width));
+}
+
 /**
  * Height (metres) of the rendered ground at a position — the terrain surface
  * when terrain is on and its tiles have loaded, otherwise 0 (the ellipsoid).
@@ -132,6 +165,29 @@ function pickGlobe(
 }
 
 /**
+ * The camera-to-ground distance that encodes `view.zoom` in the scene mode the
+ * viewer is currently drawing in.
+ *
+ * Every programmatic camera move — `lookAt` in {@link applyMapViewToCamera},
+ * `flyToBoundingSphere` in the engine's animated moves — takes a "range", and
+ * Cesium quietly reinterprets that number per scene mode: a true distance
+ * through a perspective frustum in 3D and Columbus view, and the *width* of the
+ * orthographic box in 2D. Funnelling both through here is what keeps one stored
+ * `zoom` meaning the same thing on screen in all three.
+ */
+export function zoomToSceneRange(
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
+  view: MapViewState,
+): number {
+  const range =
+    viewer.scene.mode === Cesium.SceneMode.SCENE2D
+      ? zoomToOrthoWidth(view.zoom, canvasWidth(viewer))
+      : zoomToRange(view.zoom, view.center[1], canvasHeight(viewer), cameraFovy(viewer));
+  return Math.max(range, 1);
+}
+
+/**
  * Point a viewer's camera at the map center described by `view`, matching
  * MapLibre's scale, bearing, and pitch. Requires the Cesium namespace so this
  * module stays free of a runtime Cesium import.
@@ -142,9 +198,16 @@ export function applyMapViewToCamera(
   view: MapViewState,
 ): void {
   const [lng, lat] = view.center;
-  const range = Math.max(zoomToRange(view.zoom, lat, canvasHeight(viewer), cameraFovy(viewer)), 1);
-  const heading = Cesium.Math.toRadians(normalizeBearing(view.bearing));
-  const pitch = Cesium.Math.toRadians(mapLibrePitchToCesiumDeg(view.pitch));
+  const range = zoomToSceneRange(Cesium, viewer, view);
+  // 2D is north-up and untilted, and must be *applied* that way and not merely
+  // read that way. `lookAt` still rotates the orthographic view to a heading it
+  // is given, but `readMapViewFromCamera` reports 2D as bearing 0 (Cesium's
+  // heading getter is meaningless once the world is the flattened map) — so
+  // carrying a bearing in would leave a visibly rotated map under a status bar
+  // insisting it is north-up.
+  const flat = viewer.scene.mode === Cesium.SceneMode.SCENE2D;
+  const heading = flat ? 0 : Cesium.Math.toRadians(normalizeBearing(view.bearing));
+  const pitch = Cesium.Math.toRadians(mapLibrePitchToCesiumDeg(flat ? 0 : view.pitch));
   // Aim at the ground, not the ellipsoid beneath it: `range` is the distance
   // that encodes MapLibre's zoom, so on a terrain globe the target has to sit on
   // the terrain or the pane renders far more zoomed in than its 2D twin.
@@ -171,6 +234,8 @@ export function readMapViewFromCamera(
   const height = canvas.clientHeight || canvas.height || 1;
   const ellipsoid = scene.globe?.ellipsoid ?? Cesium.Ellipsoid.WGS84;
 
+  if (scene.mode === Cesium.SceneMode.SCENE2D) return read2DMapView(Cesium, viewer, width);
+
   const centerPx = new Cesium.Cartesian2(width / 2, height / 2);
   // Pick the terrain, not the ellipsoid, so the range read back is the same
   // ground distance applyMapViewToCamera set — otherwise a terrain globe reads
@@ -184,7 +249,10 @@ export function readMapViewFromCamera(
     const carto = Cesium.Cartographic.fromCartesian(groundPoint, ellipsoid);
     lng = Cesium.Math.toDegrees(carto.longitude);
     lat = Cesium.Math.toDegrees(carto.latitude);
-    range = Cesium.Cartesian3.distance(camera.positionWC, groundPoint);
+    range =
+      scene.mode === Cesium.SceneMode.SCENE3D
+        ? Cesium.Cartesian3.distance(camera.positionWC, groundPoint)
+        : columbusRange(Cesium, viewer, carto.height);
   } else {
     // Horizon in view. The camera is thousands of kilometres out here, so the
     // ellipsoid height is close enough and terrain is not worth sampling.
@@ -200,6 +268,76 @@ export function readMapViewFromCamera(
     zoom,
     bearing: normalizeBearing(Cesium.Math.toDegrees(camera.heading)),
     pitch: cesiumPitchToMapLibreDeg(Cesium.Math.toDegrees(camera.pitch)),
+  };
+}
+
+/**
+ * Camera-to-ground distance in Columbus view, derived from heights rather than
+ * from a point-to-point measurement.
+ *
+ * The direct measurement the 3D branch uses is unavailable here: `Globe.pick`
+ * returns an Earth-centred point in every scene mode, while `camera.positionWC`
+ * is in the *scene's* frame — the two coincide on the globe and are unrelated
+ * once the world is the flattened map, so their distance is meaningless in
+ * Columbus view. (Cesium has an internal pick that stays in world coordinates,
+ * but it is absent from the published typings, so it is not something to build
+ * on.)
+ *
+ * Heights are well defined in both frames, though, and Columbus view is flat by
+ * construction: a ray leaving the camera at pitch `p` drops `range · sin|p|` for
+ * every `range` it travels, so the camera's height above the ground divides
+ * straight back out. Near the horizon that divisor collapses, and the camera's
+ * own altitude is the better answer there — the same fallback the 3D branch
+ * makes when the pick misses the globe entirely.
+ */
+function columbusRange(
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
+  groundHeight: number,
+): number {
+  const { camera } = viewer;
+  const cameraHeight = camera.positionCartographic.height;
+  const drop = cameraHeight - groundHeight;
+  const sinPitch = Math.abs(Math.sin(camera.pitch));
+  // ~6° off the horizon; below that the division amplifies the pitch's own
+  // rounding into a range several times too large.
+  if (!(sinPitch > 0.1) || !(drop > 0)) return cameraHeight;
+  return drop / sinPitch;
+}
+
+/**
+ * Read a 2D scene's camera back into a `MapViewState`.
+ *
+ * Nothing the 3D readback does survives the switch to an orthographic frustum:
+ * there is no camera distance to measure (Cesium parks the 2D camera at a fixed
+ * ~12,700 km and expresses the view through the frustum box instead), and
+ * `camera.heading` is derived by treating `positionWC` as an Earth-centred
+ * point — true in 3D, meaningless once the world is the flattened map.
+ *
+ * What is available is simpler and exact. The 2D camera looks straight down at
+ * its own position, so unprojecting it gives the map centre outright with no
+ * picking; and Cesium keeps `positionCartographic.height` equal to the frustum
+ * width in this mode, which {@link orthoWidthToZoom} turns back into a zoom.
+ * Bearing and pitch are reported as zero because 2D is north-up and untilted —
+ * Cesium's default `mapMode2D` does not even offer rotation.
+ */
+function read2DMapView(
+  Cesium: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
+  widthPx: number,
+): MapViewState {
+  const { camera } = viewer;
+  const carto = camera.positionCartographic;
+  const frustum = camera.frustum as { left?: number; right?: number };
+  const orthoWidth =
+    frustum.right !== undefined && frustum.left !== undefined
+      ? frustum.right - frustum.left
+      : carto.height;
+  return {
+    center: [Cesium.Math.toDegrees(carto.longitude), Cesium.Math.toDegrees(carto.latitude)],
+    zoom: clamp(orthoWidthToZoom(Math.max(orthoWidth, 1), widthPx), 0, 24),
+    bearing: 0,
+    pitch: 0,
   };
 }
 

--- a/packages/map/src/cesium-camera.ts
+++ b/packages/map/src/cesium-camera.ts
@@ -180,6 +180,16 @@ export function zoomToSceneRange(
   viewer: CesiumWidget,
   view: MapViewState,
 ): number {
+  // Columbus view takes the 3D branch, latitude correction and all, which is
+  // right for the projection Cesium actually draws it in (#2270 review). The
+  // `cos(lat)` in `groundResolution` converts a projected pixel width into true
+  // ground metres, so it only belongs where the camera measures ground metres —
+  // and Columbus view, on `CesiumWidget`'s default `GeographicProjection`, does:
+  // a metre on its vertical axis is `a·Δlat`, a true meridian metre, not a
+  // Mercator-stretched one. `zoomToRange` matches the *vertical* extent, so that
+  // is the axis that has to line up. It is 2D that drops the correction, and for
+  // a different reason: MapLibre's zoom is defined on the horizontal projected
+  // span, which is a full circumference in either projection.
   const range =
     viewer.scene.mode === Cesium.SceneMode.SCENE2D
       ? zoomToOrthoWidth(view.zoom, canvasWidth(viewer))

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -201,6 +201,11 @@ export class CesiumEngine implements MapEngine {
   private terrainEnabled = false;
   private terrainExaggeration = 1;
   private disposers: Array<() => void> = [];
+  /**
+   * Controls `CesiumCanvas` built and handed over under a built-in control id.
+   * See {@link registerBuiltInControl}.
+   */
+  private builtInControls = new Map<BuiltInMapControl, maplibregl.IControl>();
 
   constructor(Cesium: CesiumNs, viewer: CesiumWidget, options: CesiumEngineOptions = {}) {
     this.Cesium = Cesium;
@@ -246,6 +251,9 @@ export class CesiumEngine implements MapEngine {
   destroy(): void {
     for (const dispose of this.disposers.splice(0)) dispose();
     this.layerSync.destroy();
+    // The control host tears the controls themselves down; drop the references
+    // so a late setBuiltInControlVisible cannot re-add one to a dead globe.
+    this.builtInControls.clear();
     // The widget itself belongs to CesiumCanvas, which destroys it; dropping the
     // handle here is what stops a late listener from touching a dead viewer.
     this.viewer = null;
@@ -265,7 +273,16 @@ export class CesiumEngine implements MapEngine {
 
   readView(): MapViewState {
     const viewer = this.live();
-    if (!viewer) {
+    // A morph is as unreadable as a destroyed viewer, and for a sharper reason:
+    // `camera.heading` returns `undefined` while `scene.mode` is MORPHING, and
+    // Cesium's `Math.toDegrees` *throws* on that rather than returning NaN. So a
+    // read that lands mid-morph does not merely report a half-projected camera,
+    // it takes its caller down — and the callers are ordinary background work
+    // (the autosave snapshot, the View menu's limit check, the status bar),
+    // none of which expects reading the camera to be fallible. The last applied
+    // view is the honest answer: the morph is on its way to it, and
+    // `installMorphHandling` re-applies it on arrival.
+    if (!viewer || this.isMorphing()) {
       return this.lastApplied ?? useAppStore.getState().mapView;
     }
     return readMapViewFromCamera(this.Cesium, viewer);
@@ -376,7 +393,10 @@ export class CesiumEngine implements MapEngine {
 
   readCameraAltitude(): number | null {
     const viewer = this.live();
-    if (!viewer) return null;
+    // Unreadable mid-morph, the same way {@link readView} is: the camera is
+    // between two frames of reference and its cartographic height means nothing
+    // in either. `null` is the value callers already handle for "no altitude".
+    if (!viewer || this.isMorphing()) return null;
     const carto = this.Cesium.Cartographic.fromCartesian(viewer.camera.positionWC);
     if (!carto || !Number.isFinite(carto.height)) return null;
     const ground = groundHeightAt(
@@ -541,8 +561,31 @@ export class CesiumEngine implements MapEngine {
     getPrimaryCesiumControlHost()?.removeControl(control);
   }
 
-  setBuiltInControlVisible(_control: BuiltInMapControl, _visible: boolean): boolean {
-    return false;
+  /**
+   * Put a control the canvas built under a built-in control id, so the app's
+   * existing Controls menu can govern it (issue #2270).
+   *
+   * Only the fullscreen button uses this today. The globe's other two Cesium
+   * widgets — home and scene mode — have no entry in that menu and stay
+   * unconditional; the rest of the built-in controls are MapLibre's own and
+   * have no globe counterpart at all, which is why
+   * {@link setBuiltInControlVisible} still answers `false` for them.
+   */
+  registerBuiltInControl(control: BuiltInMapControl, instance: maplibregl.IControl): void {
+    this.builtInControls.set(control, instance);
+  }
+
+  setBuiltInControlVisible(control: BuiltInMapControl, visible: boolean): boolean {
+    const instance = this.builtInControls.get(control);
+    if (!instance || !this.isPrimary) return false;
+    const host = getPrimaryCesiumControlHost();
+    if (!host) return false;
+    // `addControl` is a no-op for a control already mounted and `removeControl`
+    // for one already gone, so repeated calls (project restore replays every
+    // control's visibility) settle rather than stacking duplicates.
+    if (visible) host.addControl(instance, "top-right");
+    else host.removeControl(instance);
+    return true;
   }
 
   getBuiltInControlPosition(_control: BuiltInMapControl): maplibregl.ControlPosition {

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -730,6 +730,21 @@ export class CesiumEngine implements MapEngine {
     // the orthographic box in 2D. `flyToBoundingSphere` reinterprets the offset
     // range exactly as `lookAt` does, so both paths agree on what a zoom means.
     const range = zoomToSceneRange(this.Cesium, viewer, { ...view, zoom });
+    // The heading and pitch below are *not* flattened for 2D the way
+    // `applyMapViewToCamera` flattens them (#2270 review). They do not need to
+    // be: `lookAt` honours an offset's orientation in 2D — which is why the
+    // instant path has to force it flat, or the map would sit visibly rotated
+    // under a status bar reporting bearing 0 — but `flyToBoundingSphere` reads
+    // the offset's orientation only when the scene is 3D, and passes no
+    // direction/up at all in 2D *and Columbus view*. Mirroring the guard here
+    // would be dead code.
+    //
+    // The Columbus half of that is a real limitation rather than a nicety: an
+    // animated move cannot tilt or rotate a Columbus-view camera, so a story
+    // chapter authored with a bearing plays back flat there. The instant path
+    // (`applyView`, and the morph re-apply) does honour both, and the readback
+    // reports whatever ends up on screen, so nothing desynchronizes — the
+    // animation is simply less expressive than in 3D.
     viewer.camera.flyToBoundingSphere(
       new this.Cesium.BoundingSphere(
         this.Cesium.Cartesian3.fromDegrees(lng, lat, ground),

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -20,6 +20,7 @@ import {
   isSameView,
   readMapViewFromCamera,
   zoomToRange,
+  zoomToSceneRange,
 } from "./cesium-camera";
 import { getPrimaryCesiumControlHost } from "./cesium-control-host";
 import { CesiumLayerSync } from "./cesium-layer-sync";
@@ -212,6 +213,7 @@ export class CesiumEngine implements MapEngine {
     this.installInputTracking();
     this.installTerrainCorrection();
     this.installCameraPublisher();
+    this.installMorphHandling();
   }
 
   /** Whether this globe is the primary map area rather than a grid pane. */
@@ -223,6 +225,20 @@ export class CesiumEngine implements MapEngine {
   private live(): CesiumWidget | null {
     const viewer = this.viewer;
     return viewer && !viewer.isDestroyed() ? viewer : null;
+  }
+
+  /**
+   * Whether the scene is mid-flight between 2D, 3D and Columbus view.
+   *
+   * A morph is the one window where the camera cannot be read or written.
+   * Cesium throws outright from `lookAt` and `flyTo` while morphing, and
+   * `camera.heading` returns `undefined` — so both halves of the camera sync
+   * have to stand down and let the morph finish. {@link installMorphHandling}
+   * re-applies the stored view once it does.
+   */
+  private isMorphing(): boolean {
+    const viewer = this.live();
+    return viewer?.scene.mode === this.Cesium.SceneMode.MORPHING;
   }
 
   // ---------------------------------------------------------------- lifecycle
@@ -239,7 +255,7 @@ export class CesiumEngine implements MapEngine {
 
   applyView(view: MapViewState): void {
     const viewer = this.live();
-    if (!viewer) return;
+    if (!viewer || this.isMorphing()) return;
     this.lastApplied = view;
     // This placement is ours, so the terrain correction may adjust it.
     this.userOwnsCamera = false;
@@ -657,7 +673,7 @@ export class CesiumEngine implements MapEngine {
    */
   private animateTo(view: MapViewState, seconds?: number): void {
     const viewer = this.live();
-    if (!viewer) return;
+    if (!viewer || this.isMorphing()) return;
     // Cesium has no "ease to a MapLibre view" primitive, so the flight is
     // expressed the same way applyView expresses a placement — a lookAt in the
     // target's local frame — with `flyTo`'s duration doing the animating.
@@ -667,7 +683,10 @@ export class CesiumEngine implements MapEngine {
     // project's zoom bounds are enforced — the counterpart to MapLibre clamping
     // inside its own camera API.
     const zoom = Math.min(this.maxZoom, Math.max(this.minZoom, view.zoom));
-    const range = Math.max(zoomToRange(zoom, lat, canvasHeight(viewer), cameraFovy(viewer)), 1);
+    // Per scene mode: a camera distance in 3D and Columbus view, the width of
+    // the orthographic box in 2D. `flyToBoundingSphere` reinterprets the offset
+    // range exactly as `lookAt` does, so both paths agree on what a zoom means.
+    const range = zoomToSceneRange(this.Cesium, viewer, { ...view, zoom });
     viewer.camera.flyToBoundingSphere(
       new this.Cesium.BoundingSphere(
         this.Cesium.Cartesian3.fromDegrees(lng, lat, ground),
@@ -754,6 +773,44 @@ export class CesiumEngine implements MapEngine {
   }
 
   /**
+   * Put the camera back where it was once a 2D/3D/Columbus morph finishes.
+   *
+   * Cesium's morph preserves *its own* notion of the view, which is not the
+   * one the store holds: the modes encode scale differently (a camera distance
+   * through a perspective frustum in 3D and Columbus view, the width of an
+   * orthographic box in 2D), so a morph that Cesium considers faithful still
+   * lands at a different MapLibre zoom — and 2D drops the tilt and rotation
+   * outright. Re-applying the stored view on arrival is what makes the switch
+   * read as "the same map, drawn differently" rather than a camera jump.
+   *
+   * It re-applies the *store's* camera rather than {@link lastApplied}: the
+   * morph itself fires `moveEnd` repeatedly, and although
+   * {@link installCameraPublisher} stands down while `MORPHING`, the settle on
+   * the far side is a real move that has already overwritten `lastApplied` with
+   * the view Cesium arrived at.
+   */
+  private installMorphHandling(): void {
+    const viewer = this.live();
+    if (!viewer) return;
+    const onMorphComplete = () => {
+      const live = this.live();
+      if (!live) return;
+      const store = useAppStore.getState();
+      const view =
+        this.isPrimary || store.mapLayout.syncView
+          ? store.mapView
+          : (store.secondaryMapViews.find((pane) => pane.id === this.viewId)?.view ??
+            store.mapView);
+      this.applyView(view);
+    };
+    viewer.scene.morphComplete.addEventListener(onMorphComplete);
+    this.disposers.push(() => {
+      const live = this.live();
+      live?.scene.morphComplete.removeEventListener(onMorphComplete);
+    });
+  }
+
+  /**
    * Mirror the globe's camera back into the shared store. Echoes of our own
    * {@link applyView} are filtered by the `isSameView` guard.
    */
@@ -762,7 +819,7 @@ export class CesiumEngine implements MapEngine {
     if (!viewer) return;
     const onMoveEnd = () => {
       const live = this.live();
-      if (!live) return;
+      if (!live || this.isMorphing()) return;
       // Nothing to publish until the camera has been seeded. A fresh
       // CesiumWidget starts on its own default camera and settles onto it, which
       // fires moveEnd before `CesiumCanvas` has applied the project's view —

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -742,7 +742,7 @@ export class CesiumEngine implements MapEngine {
     // The Columbus half of that is a real limitation rather than a nicety: an
     // animated move cannot tilt or rotate a Columbus-view camera, so a story
     // chapter authored with a bearing plays back flat there. The instant path
-    // (`applyView`, and the morph re-apply) does honour both, and the readback
+    // (`applyView`) does honour both, and the readback
     // reports whatever ends up on screen, so nothing desynchronizes — the
     // animation is simply less expressive than in 3D.
     viewer.camera.flyToBoundingSphere(
@@ -830,36 +830,14 @@ export class CesiumEngine implements MapEngine {
     });
   }
 
-  /**
-   * Put the camera back where it was once a 2D/3D/Columbus morph finishes.
-   *
-   * Cesium's morph preserves *its own* notion of the view, which is not the
-   * one the store holds: the modes encode scale differently (a camera distance
-   * through a perspective frustum in 3D and Columbus view, the width of an
-   * orthographic box in 2D), so a morph that Cesium considers faithful still
-   * lands at a different MapLibre zoom — and 2D drops the tilt and rotation
-   * outright. Re-applying the stored view on arrival is what makes the switch
-   * read as "the same map, drawn differently" rather than a camera jump.
-   *
-   * It re-applies the *store's* camera rather than {@link lastApplied}: the
-   * morph itself fires `moveEnd` repeatedly, and although
-   * {@link installCameraPublisher} stands down while `MORPHING`, the settle on
-   * the far side is a real move that has already overwritten `lastApplied` with
-   * the view Cesium arrived at.
-   */
+  /** Follow Cesium's native morph endpoint without a second camera move. */
   private installMorphHandling(): void {
     const viewer = this.live();
     if (!viewer) return;
     const onMorphComplete = () => {
-      const live = this.live();
-      if (!live) return;
-      const store = useAppStore.getState();
-      const view =
-        this.isPrimary || store.mapLayout.syncView
-          ? store.mapView
-          : (store.secondaryMapViews.find((pane) => pane.id === this.viewId)?.view ??
-            store.mapView);
-      this.applyView(view);
+      // The native animation owns this camera, including any terrain settling.
+      this.userOwnsCamera = true;
+      this.publishCameraView();
     };
     viewer.scene.morphComplete.addEventListener(onMorphComplete);
     this.disposers.push(() => {
@@ -875,53 +853,56 @@ export class CesiumEngine implements MapEngine {
   private installCameraPublisher(): void {
     const viewer = this.live();
     if (!viewer) return;
-    const onMoveEnd = () => {
-      const live = this.live();
-      if (!live || this.isMorphing()) return;
-      // Nothing to publish until the camera has been seeded. A fresh
-      // CesiumWidget starts on its own default camera and settles onto it, which
-      // fires moveEnd before `CesiumCanvas` has applied the project's view —
-      // with no `lastApplied` to recognize it by, that settle would look like a
-      // real move and overwrite the stored camera with Cesium's default. The
-      // listener is armed in the constructor (so it cannot miss a move) rather
-      // than after the seed, so the guard lives here.
-      if (!this.lastApplied) return;
-      const view = readMapViewFromCamera(this.Cesium, live);
-      if (isSameView(view, this.lastApplied)) return;
-      this.lastApplied = view;
-      // Only the moves that follow real user input dirty the project; an
-      // autonomous settle still syncs the camera (markDirty=false) so the panes
-      // stay in step without flipping isDirty on a freshly opened project.
-      const userDriven = this.userMoved;
-      this.userMoved = false;
-      const store = useAppStore.getState();
-      // Write only when the view actually differs from the stored camera:
-      // `setMapView` has no same-camera guard in the store, and
-      // `setSecondaryMapView`'s guard uses exact equality (which Cesium's lossy
-      // readback never hits), so both are gated here with isSameView.
-      if (this.isPrimary) {
-        // The primary globe owns `mapView` outright (there is no pane record to
-        // mirror into), so it writes regardless of the `syncView` toggle — that
-        // toggle governs the secondary panes, and the primary map is the camera
-        // they follow.
-        if (!isSameView(view, store.mapView)) store.setMapView(view, userDriven);
-        return;
-      }
-      if (store.mapLayout.syncView && !isSameView(view, store.mapView)) {
-        store.setMapView(view, userDriven);
-      }
-      const paneId = this.viewId;
-      if (paneId === undefined) return;
-      const paneView = store.secondaryMapViews.find((pane) => pane.id === paneId)?.view;
-      if (!paneView || !isSameView(view, paneView)) {
-        store.setSecondaryMapView(paneId, view, userDriven);
-      }
-    };
+    const onMoveEnd = () => this.publishCameraView();
     viewer.camera.moveEnd.addEventListener(onMoveEnd);
     this.disposers.push(() => {
       const live = this.live();
       live?.camera.moveEnd.removeEventListener(onMoveEnd);
     });
+  }
+
+  /** Publish a settled camera, shared by navigation and projection changes. */
+  private publishCameraView(): void {
+    const live = this.live();
+    if (!live || this.isMorphing()) return;
+    // Nothing to publish until the camera has been seeded. A fresh
+    // CesiumWidget starts on its own default camera and settles onto it, which
+    // fires moveEnd before `CesiumCanvas` has applied the project's view —
+    // with no `lastApplied` to recognize it by, that settle would look like a
+    // real move and overwrite the stored camera with Cesium's default. The
+    // listener is armed in the constructor (so it cannot miss a move) rather
+    // than after the seed, so the guard lives here.
+    if (!this.lastApplied) return;
+    const view = readMapViewFromCamera(this.Cesium, live);
+    if (isSameView(view, this.lastApplied)) return;
+    this.lastApplied = view;
+    // Only the moves that follow real user input dirty the project; an
+    // autonomous settle still syncs the camera (markDirty=false) so the panes
+    // stay in step without flipping isDirty on a freshly opened project.
+    const userDriven = this.userMoved;
+    this.userMoved = false;
+    const store = useAppStore.getState();
+    // Write only when the view actually differs from the stored camera:
+    // `setMapView` has no same-camera guard in the store, and
+    // `setSecondaryMapView`'s guard uses exact equality (which Cesium's lossy
+    // readback never hits), so both are gated here with isSameView.
+    if (this.isPrimary) {
+      // The primary globe owns `mapView` outright (there is no pane record to
+      // mirror into), so it writes regardless of the `syncView` toggle — that
+      // toggle governs the secondary panes, and the primary map is the camera
+      // they follow.
+      if (!isSameView(view, store.mapView)) store.setMapView(view, userDriven);
+      return;
+    }
+    if (store.mapLayout.syncView && !isSameView(view, store.mapView)) {
+      store.setMapView(view, userDriven);
+    }
+    const paneId = this.viewId;
+    if (paneId === undefined) return;
+    const paneView = store.secondaryMapViews.find((pane) => pane.id === paneId)?.view;
+    if (!paneView || !isSameView(view, paneView)) {
+      store.setSecondaryMapView(paneId, view, userDriven);
+    }
   }
 
   /**

--- a/packages/map/src/cesium-widget-controls.ts
+++ b/packages/map/src/cesium-widget-controls.ts
@@ -26,13 +26,6 @@ import type { CesiumWidget } from "@cesium/engine";
 import { FullscreenButton, HomeButton, SceneModePicker } from "@cesium/widgets";
 
 /**
- * Switch projection synchronously, then let the engine restore the project
- * camera in morphComplete. Cesium's animated morph flies to a different extent
- * first, producing a fly-out followed by a snap back to the saved center.
- */
-const MORPH_SECONDS = 0;
-
-/**
  * Marks the wrapper GeoLibre's stylesheet themes the Cesium chrome through.
  *
  * The widgets carry Cesium's own dark-blue toolbar look, which sits oddly beside
@@ -189,24 +182,36 @@ class CesiumHomeControl extends CesiumWidgetControl<HomeButton> {
  *
  * The morph is animated, and Cesium refuses camera reads and writes while one
  * runs, so `CesiumEngine` stands its camera sync down for the duration and
- * re-applies the stored view on `morphComplete`.
+ * publishes the native final view on `morphComplete`.
  */
 class CesiumSceneModeControl extends CesiumWidgetControl<SceneModePicker> {
-  /**
-   * Marks this control as the one whose drop-down escapes its own box.
-   *
-   * The picker expands into a column of buttons that overflow the wrapper, so
-   * in a vertical toolbar they land on top of whichever control sits below —
-   * painting *behind* it, because later siblings win, and leaving the entries
-   * unclickable. `index.css` raises this one control so the drop-down covers
-   * its neighbours instead of hiding under them.
-   */
+  private stopWatching: (() => void) | null = null;
+
+  /** Keep the sideways picker above adjacent map controls. */
   protected extraClass(): string {
     return "geolibre-cesium-ctrl-expands";
   }
 
   protected create(container: HTMLElement): SceneModePicker {
-    return new SceneModePicker(container, this.viewer.scene, MORPH_SECONDS);
+    // Use Cesium's default duration and easing, just like Viewer/Sandcastle.
+    const widget = new SceneModePicker(container, this.viewer.scene);
+    const start = () => container.setAttribute("aria-busy", "true");
+    const complete = () => container.setAttribute("aria-busy", "false");
+    complete();
+    const scene = this.viewer.scene;
+    scene.morphStart.addEventListener(start);
+    scene.morphComplete.addEventListener(complete);
+    this.stopWatching = () => {
+      scene.morphStart.removeEventListener(start);
+      scene.morphComplete.removeEventListener(complete);
+    };
+    return widget;
+  }
+
+  onRemove(): void {
+    this.stopWatching?.();
+    this.stopWatching = null;
+    super.onRemove();
   }
 
   protected applyLabels(widget: SceneModePicker): void {

--- a/packages/map/src/cesium-widget-controls.ts
+++ b/packages/map/src/cesium-widget-controls.ts
@@ -26,11 +26,11 @@ import type { CesiumWidget } from "@cesium/engine";
 import { FullscreenButton, HomeButton, SceneModePicker } from "@cesium/widgets";
 
 /**
- * Scene-morph duration, in seconds. Cesium defaults to 2 s, which reads as a
- * stall on a map the rest of the app animates in well under one; this matches
- * `MapController.flyTo`'s 800 ms, the longest camera animation GeoLibre runs.
+ * Switch projection synchronously, then let the engine restore the project
+ * camera in morphComplete. Cesium's animated morph flies to a different extent
+ * first, producing a fly-out followed by a snap back to the saved center.
  */
-const MORPH_SECONDS = 0.8;
+const MORPH_SECONDS = 0;
 
 /**
  * Marks the wrapper GeoLibre's stylesheet themes the Cesium chrome through.

--- a/packages/map/src/cesium-widget-controls.ts
+++ b/packages/map/src/cesium-widget-controls.ts
@@ -164,6 +164,12 @@ abstract class CesiumWidgetControl<T extends DestroyableWidget> implements mapli
  */
 class CesiumHomeControl extends CesiumWidgetControl<HomeButton> {
   protected create(container: HTMLElement): HomeButton {
+    // No duration argument, so the flight keeps Cesium's own distance-derived
+    // one rather than the 0.8 s the rest of the app animates in (#2270 review).
+    // That is the right default here and not an oversight: this button always
+    // travels from wherever the user is to the whole Earth, and forcing a
+    // street-level-to-orbit flight into 0.8 s reads as a jump cut. Cesium scales
+    // the duration with the distance and caps it at 3 s.
     return new HomeButton(container, this.viewer.scene);
   }
 

--- a/packages/map/src/cesium-widget-controls.ts
+++ b/packages/map/src/cesium-widget-controls.ts
@@ -1,0 +1,202 @@
+import type * as maplibregl from "maplibre-gl";
+import type { CesiumWidget } from "@cesium/engine";
+
+// Cesium's own toolbar widgets, mounted on GeoLibre's map as regular map
+// controls (issue #2270).
+//
+// `CesiumCanvas` builds a bare `CesiumWidget` rather than a `Viewer`, precisely
+// so it does not inherit the toolbar Cesium's full app wrapper constructs —
+// base-layer picker, geocoder, home button, scene-mode picker, help button,
+// timeline, animation dial, info box — most of which duplicate something
+// GeoLibre already owns. Two of them do not: nothing else in the app returns the
+// camera to a whole-Earth view, and nothing at all reaches Cesium's 2D and
+// Columbus scene modes.
+//
+// Each widget is constructible on its own against a container element, so
+// neither needs `Viewer`. They are wrapped as `maplibregl.IControl`s so
+// `CesiumControlHost` positions and tears them down exactly like every other
+// control on the map.
+//
+// This module is reached only through a dynamic import inside `CesiumCanvas`'s
+// mount effect: `@cesium/widgets` is a static import below, and a static import
+// from `CesiumCanvas` would pull the widget chrome (and Knockout) onto the 2D
+// boot path instead of leaving it in the lazily fetched `cesium` chunk.
+
+import { HomeButton, SceneModePicker } from "@cesium/widgets";
+
+/**
+ * Scene-morph duration, in seconds. Cesium defaults to 2 s, which reads as a
+ * stall on a map the rest of the app animates in well under one; this matches
+ * `MapController.flyTo`'s 800 ms, the longest camera animation GeoLibre runs.
+ */
+const MORPH_SECONDS = 0.8;
+
+/**
+ * Marks the wrapper GeoLibre's stylesheet themes the Cesium chrome through.
+ *
+ * The widgets carry Cesium's own dark-blue toolbar look, which sits oddly beside
+ * GeoLibre's map controls in either theme. `index.css` restyles them under this
+ * class — scoped, so nothing else Cesium renders (its credit display, the
+ * render-error panel) is caught by the same rules.
+ */
+const CONTROL_CLASS = "geolibre-cesium-ctrl";
+
+/**
+ * Tooltips for the widgets, supplied by the app so they follow the UI language.
+ *
+ * The widgets hardcode English (`"View Home"`, `"2D"`, `"3D"`,
+ * `"Columbus View"`) and live outside React, so — like `MapController`'s compass
+ * and terrain labels — the translated strings are pushed in from the component
+ * that owns them rather than read from a hook here.
+ */
+export interface CesiumWidgetControlLabels {
+  /** Tooltip for the home button. */
+  home: string;
+  /** Tooltip for the 3D globe scene mode. */
+  sceneMode3D: string;
+  /** Tooltip for the flat 2D map scene mode. */
+  sceneMode2D: string;
+  /** Tooltip for Columbus view (the 2.5D projected map). */
+  sceneModeColumbus: string;
+}
+
+/** English fallbacks, used until the app pushes translated labels in. */
+export const DEFAULT_CESIUM_WIDGET_CONTROL_LABELS: CesiumWidgetControlLabels = Object.freeze({
+  home: "Reset view",
+  sceneMode3D: "3D globe",
+  sceneMode2D: "2D map",
+  sceneModeColumbus: "Columbus view",
+});
+
+/** The subset of a Cesium widget's lifecycle these wrappers depend on. */
+interface DestroyableWidget {
+  destroy: () => void;
+  isDestroyed: () => boolean;
+}
+
+/**
+ * A `maplibregl.IControl` wrapping one Cesium widget.
+ *
+ * The widget is built in `onAdd` rather than in the constructor because that is
+ * when a container element exists to build into, and destroyed in `onRemove`
+ * because Cesium widgets hold Knockout bindings that leak if the element is
+ * merely detached. Both halves tolerate a destroyed viewer:
+ * `CesiumControlHost.destroy()` runs during teardown and the order in which the
+ * host and the viewer die is not guaranteed.
+ */
+abstract class CesiumWidgetControl<T extends DestroyableWidget> implements maplibregl.IControl {
+  protected labels: CesiumWidgetControlLabels;
+  private container: HTMLDivElement | null = null;
+  private widget: T | null = null;
+
+  constructor(
+    protected readonly viewer: CesiumWidget,
+    labels: CesiumWidgetControlLabels,
+  ) {
+    this.labels = labels;
+  }
+
+  /** Build the widget into `container`. */
+  protected abstract create(container: HTMLElement): T;
+
+  /** Push {@link labels} onto an existing widget's view model. */
+  protected abstract applyLabels(widget: T): void;
+
+  onAdd(): HTMLElement {
+    const container = document.createElement("div");
+    // `maplibregl-ctrl` supplies the corner stacking and margins every control
+    // in the container shares. `maplibregl-ctrl-group` is deliberately absent:
+    // it draws MapLibre's own white button chrome, which would show as a frame
+    // around the Cesium button sitting inside it.
+    container.className = `maplibregl-ctrl ${CONTROL_CLASS}`;
+    this.container = container;
+    if (!this.viewer.isDestroyed()) {
+      this.widget = this.create(container);
+      this.applyLabels(this.widget);
+    }
+    return container;
+  }
+
+  onRemove(): void {
+    if (this.widget && !this.widget.isDestroyed()) this.widget.destroy();
+    this.widget = null;
+    this.container?.remove();
+    this.container = null;
+  }
+
+  /**
+   * Retranslate the tooltips in place.
+   *
+   * Cheaper and less disruptive than rebuilding the control on every language
+   * change: the widgets expose their tooltips as observables, so writing them
+   * updates the live DOM without touching the scene or the camera.
+   */
+  setLabels(labels: CesiumWidgetControlLabels): void {
+    this.labels = labels;
+    if (this.widget && !this.widget.isDestroyed()) this.applyLabels(this.widget);
+  }
+}
+
+/**
+ * Cesium's home button: fly back to a view of the whole Earth.
+ *
+ * The flight is Cesium's own (`camera.flyHome`), not one of the engine's
+ * animated moves, and that is deliberate — this is the "I am lost, show me
+ * everything" button, so it targets `Camera.DEFAULT_VIEW_RECTANGLE` rather than
+ * any project camera. The resulting move still reaches the store: it ends in a
+ * `moveEnd` like any other, which `CesiumEngine`'s camera publisher mirrors into
+ * `mapView` without marking the project dirty (no user input flagged it).
+ */
+class CesiumHomeControl extends CesiumWidgetControl<HomeButton> {
+  protected create(container: HTMLElement): HomeButton {
+    return new HomeButton(container, this.viewer.scene);
+  }
+
+  protected applyLabels(widget: HomeButton): void {
+    widget.viewModel.tooltip = this.labels.home;
+  }
+}
+
+/**
+ * Cesium's scene-mode picker: switch between the 3D globe, a flat 2D map, and
+ * Columbus view.
+ *
+ * This is the one control here with no GeoLibre counterpart at all. View →
+ * Rendering engine swaps *renderers* (MapLibre or Cesium draws the project);
+ * this swaps how the Cesium scene itself is projected, and 2D and Columbus view
+ * are reachable no other way.
+ *
+ * The morph is animated, and Cesium refuses camera reads and writes while one
+ * runs, so `CesiumEngine` stands its camera sync down for the duration and
+ * re-applies the stored view on `morphComplete`.
+ */
+class CesiumSceneModeControl extends CesiumWidgetControl<SceneModePicker> {
+  protected create(container: HTMLElement): SceneModePicker {
+    return new SceneModePicker(container, this.viewer.scene, MORPH_SECONDS);
+  }
+
+  protected applyLabels(widget: SceneModePicker): void {
+    widget.viewModel.tooltip3D = this.labels.sceneMode3D;
+    widget.viewModel.tooltip2D = this.labels.sceneMode2D;
+    widget.viewModel.tooltipColumbusView = this.labels.sceneModeColumbus;
+  }
+}
+
+/** A control built by {@link createCesiumWidgetControls}. */
+export type CesiumWidgetControlHandle = maplibregl.IControl & {
+  setLabels(labels: CesiumWidgetControlLabels): void;
+};
+
+/**
+ * Build the Cesium toolbar controls for a globe.
+ *
+ * Returned rather than mounted so the caller decides placement and keeps the
+ * handles it needs to retranslate and remove them; `CesiumCanvas` adds them to
+ * the primary globe's control host and drops them on unmount.
+ */
+export function createCesiumWidgetControls(
+  viewer: CesiumWidget,
+  labels: CesiumWidgetControlLabels = DEFAULT_CESIUM_WIDGET_CONTROL_LABELS,
+): CesiumWidgetControlHandle[] {
+  return [new CesiumHomeControl(viewer, labels), new CesiumSceneModeControl(viewer, labels)];
+}

--- a/packages/map/src/cesium-widget-controls.ts
+++ b/packages/map/src/cesium-widget-controls.ts
@@ -8,12 +8,13 @@ import type { CesiumWidget } from "@cesium/engine";
 // so it does not inherit the toolbar Cesium's full app wrapper constructs —
 // base-layer picker, geocoder, home button, scene-mode picker, help button,
 // timeline, animation dial, info box — most of which duplicate something
-// GeoLibre already owns. Two of them do not: nothing else in the app returns the
-// camera to a whole-Earth view, and nothing at all reaches Cesium's 2D and
-// Columbus scene modes.
+// GeoLibre already owns. Three of them do not: nothing else in the app returns
+// the camera to a whole-Earth view, nothing at all reaches Cesium's 2D and
+// Columbus scene modes, and MapLibre's fullscreen control is bound to a
+// `maplibregl.Map` the globe does not have.
 //
-// Each widget is constructible on its own against a container element, so
-// neither needs `Viewer`. They are wrapped as `maplibregl.IControl`s so
+// Each widget is constructible on its own against a container element, so none
+// needs `Viewer`. They are wrapped as `maplibregl.IControl`s so
 // `CesiumControlHost` positions and tears them down exactly like every other
 // control on the map.
 //
@@ -22,7 +23,7 @@ import type { CesiumWidget } from "@cesium/engine";
 // from `CesiumCanvas` would pull the widget chrome (and Knockout) onto the 2D
 // boot path instead of leaving it in the lazily fetched `cesium` chunk.
 
-import { HomeButton, SceneModePicker } from "@cesium/widgets";
+import { FullscreenButton, HomeButton, SceneModePicker } from "@cesium/widgets";
 
 /**
  * Scene-morph duration, in seconds. Cesium defaults to 2 s, which reads as a
@@ -58,6 +59,12 @@ export interface CesiumWidgetControlLabels {
   sceneMode2D: string;
   /** Tooltip for Columbus view (the 2.5D projected map). */
   sceneModeColumbus: string;
+  /** Tooltip for the fullscreen button while the map is windowed. */
+  fullscreenEnter: string;
+  /** Tooltip for the fullscreen button while the map fills the screen. */
+  fullscreenExit: string;
+  /** Tooltip for the fullscreen button when the browser forbids fullscreen. */
+  fullscreenUnavailable: string;
 }
 
 /** English fallbacks, used until the app pushes translated labels in. */
@@ -66,6 +73,9 @@ export const DEFAULT_CESIUM_WIDGET_CONTROL_LABELS: CesiumWidgetControlLabels = O
   sceneMode3D: "3D globe",
   sceneMode2D: "2D map",
   sceneModeColumbus: "Columbus view",
+  fullscreenEnter: "Enter fullscreen",
+  fullscreenExit: "Exit fullscreen",
+  fullscreenUnavailable: "Fullscreen unavailable",
 });
 
 /** The subset of a Cesium widget's lifecycle these wrappers depend on. */
@@ -102,13 +112,18 @@ abstract class CesiumWidgetControl<T extends DestroyableWidget> implements mapli
   /** Push {@link labels} onto an existing widget's view model. */
   protected abstract applyLabels(widget: T): void;
 
+  /** An extra class on the wrapper, for a control `index.css` treats specially. */
+  protected extraClass(): string {
+    return "";
+  }
+
   onAdd(): HTMLElement {
     const container = document.createElement("div");
     // `maplibregl-ctrl` supplies the corner stacking and margins every control
     // in the container shares. `maplibregl-ctrl-group` is deliberately absent:
     // it draws MapLibre's own white button chrome, which would show as a frame
     // around the Cesium button sitting inside it.
-    container.className = `maplibregl-ctrl ${CONTROL_CLASS}`;
+    container.className = `maplibregl-ctrl ${CONTROL_CLASS} ${this.extraClass()}`.trim();
     this.container = container;
     if (!this.viewer.isDestroyed()) {
       this.widget = this.create(container);
@@ -171,6 +186,19 @@ class CesiumHomeControl extends CesiumWidgetControl<HomeButton> {
  * re-applies the stored view on `morphComplete`.
  */
 class CesiumSceneModeControl extends CesiumWidgetControl<SceneModePicker> {
+  /**
+   * Marks this control as the one whose drop-down escapes its own box.
+   *
+   * The picker expands into a column of buttons that overflow the wrapper, so
+   * in a vertical toolbar they land on top of whichever control sits below —
+   * painting *behind* it, because later siblings win, and leaving the entries
+   * unclickable. `index.css` raises this one control so the drop-down covers
+   * its neighbours instead of hiding under them.
+   */
+  protected extraClass(): string {
+    return "geolibre-cesium-ctrl-expands";
+  }
+
   protected create(container: HTMLElement): SceneModePicker {
     return new SceneModePicker(container, this.viewer.scene, MORPH_SECONDS);
   }
@@ -182,10 +210,83 @@ class CesiumSceneModeControl extends CesiumWidgetControl<SceneModePicker> {
   }
 }
 
+/**
+ * Cesium's fullscreen button, taking the globe's own container full-screen.
+ *
+ * The 2D map's fullscreen control is MapLibre's, and it cannot be reused here:
+ * it reads `map.getContainer()`, `map.cooperativeGestures` and
+ * `map._getUIString()` off a real `maplibregl.Map`, and `CesiumControlHost`'s
+ * facade is not one. Cesium's widget needs nothing but a container and the
+ * element to expand, so it stands alone.
+ *
+ * Its tooltip is the one this module cannot set through a view model: Cesium
+ * derives it from the fullscreen state as a read-only computed. It is instead
+ * written onto the button after every state change — see {@link applyLabels}.
+ */
+class CesiumFullscreenControl extends CesiumWidgetControl<FullscreenButton> {
+  /** Removes the `fullscreenchange` listener the label shim installs. */
+  private stopWatching: (() => void) | null = null;
+
+  constructor(
+    viewer: CesiumWidget,
+    labels: CesiumWidgetControlLabels,
+    /** The element to expand — the globe's container, not the whole page. */
+    private readonly fullscreenElement: HTMLElement,
+  ) {
+    super(viewer, labels);
+  }
+
+  protected create(container: HTMLElement): FullscreenButton {
+    return new FullscreenButton(container, this.fullscreenElement);
+  }
+
+  protected applyLabels(widget: FullscreenButton): void {
+    const element = widget.container.querySelector("button");
+    if (!element) return;
+    const retitle = () => {
+      element.title = !widget.viewModel.isFullscreenEnabled
+        ? this.labels.fullscreenUnavailable
+        : widget.viewModel.isFullscreen
+          ? this.labels.fullscreenExit
+          : this.labels.fullscreenEnter;
+    };
+    retitle();
+    // Cesium binds `title` to a computed it recomputes when the document enters
+    // or leaves fullscreen, which would put the English string back. Listening
+    // for the same event and rewriting afterwards is enough: DOM listeners fire
+    // in registration order and the widget registered its own at construction,
+    // so this one always runs second. Re-registered on every label change, with
+    // the previous listener dropped, so a language switch cannot stack them.
+    this.stopWatching?.();
+    document.addEventListener("fullscreenchange", retitle);
+    this.stopWatching = () => document.removeEventListener("fullscreenchange", retitle);
+  }
+
+  onRemove(): void {
+    this.stopWatching?.();
+    this.stopWatching = null;
+    super.onRemove();
+  }
+}
+
 /** A control built by {@link createCesiumWidgetControls}. */
 export type CesiumWidgetControlHandle = maplibregl.IControl & {
   setLabels(labels: CesiumWidgetControlLabels): void;
 };
+
+/**
+ * The Cesium toolbar controls for one globe, in the order they are stacked.
+ *
+ * `fullscreen` is named separately because it is the one the app already has a
+ * toggle for — Controls → Fullscreen — so `CesiumEngine` needs a handle on it
+ * to answer `setBuiltInControlVisible`. The other two have no such counterpart
+ * and are simply always present.
+ */
+export interface CesiumWidgetControls {
+  /** Every control, in stacking order. */
+  all: CesiumWidgetControlHandle[];
+  fullscreen: CesiumWidgetControlHandle;
+}
 
 /**
  * Build the Cesium toolbar controls for a globe.
@@ -193,10 +294,23 @@ export type CesiumWidgetControlHandle = maplibregl.IControl & {
  * Returned rather than mounted so the caller decides placement and keeps the
  * handles it needs to retranslate and remove them; `CesiumCanvas` adds them to
  * the primary globe's control host and drops them on unmount.
+ *
+ * @param viewer - The globe the controls act on.
+ * @param fullscreenElement - The element the fullscreen button expands.
+ * @param labels - Translated tooltips; English defaults when omitted.
  */
 export function createCesiumWidgetControls(
   viewer: CesiumWidget,
+  fullscreenElement: HTMLElement,
   labels: CesiumWidgetControlLabels = DEFAULT_CESIUM_WIDGET_CONTROL_LABELS,
-): CesiumWidgetControlHandle[] {
-  return [new CesiumHomeControl(viewer, labels), new CesiumSceneModeControl(viewer, labels)];
+): CesiumWidgetControls {
+  const fullscreen = new CesiumFullscreenControl(viewer, labels, fullscreenElement);
+  return {
+    all: [
+      new CesiumHomeControl(viewer, labels),
+      new CesiumSceneModeControl(viewer, labels),
+      fullscreen,
+    ],
+    fullscreen,
+  };
 }

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -18,6 +18,10 @@ export { PANEL_RESIZE_END_EVENT, PANEL_RESIZE_START_EVENT } from "./map-resize";
 export { SecondaryMapCanvas, type SecondaryMapCanvasProps } from "./SecondaryMapCanvas";
 export { CesiumCanvas, type CesiumCanvasProps } from "./CesiumCanvas";
 export { getPrimaryCesiumControlHost } from "./cesium-control-host";
+// Type-only: `cesium-widget-controls` statically imports `@cesium/widgets`, so
+// a value export here would drag the widget chrome onto the 2D boot path that
+// `CesiumCanvas`'s dynamic import exists to keep it off.
+export type { CesiumWidgetControlLabels } from "./cesium-widget-controls";
 export { isCesiumSupportedLayerType } from "./cesium-layer-sync";
 export {
   CESIUM_CAPABILITIES,
@@ -29,14 +33,18 @@ export {
   applyMapViewToCamera,
   cameraFovy,
   canvasHeight,
+  canvasWidth,
   cesiumPitchToMapLibreDeg,
   groundResolution,
   isSameView,
   mapLibrePitchToCesiumDeg,
   normalizeBearing,
+  orthoWidthToZoom,
   rangeToZoom,
   readMapViewFromCamera,
+  zoomToOrthoWidth,
   zoomToRange,
+  zoomToSceneRange,
 } from "./cesium-camera";
 export {
   MAPLIBRE_CAPABILITIES,

--- a/tests/cesium-camera.test.ts
+++ b/tests/cesium-camera.test.ts
@@ -9,8 +9,12 @@ import {
   isSameView,
   mapLibrePitchToCesiumDeg,
   normalizeBearing,
+  orthoWidthToZoom,
   rangeToZoom,
+  readMapViewFromCamera,
+  zoomToOrthoWidth,
   zoomToRange,
+  zoomToSceneRange,
 } from "../packages/map/src/cesium-camera";
 
 // The pure camera math that keeps the Cesium 3D-globe view in step with the 2D
@@ -19,6 +23,7 @@ import {
 
 const FOVY = Math.PI / 3; // Cesium's default vertical field of view.
 const HEIGHT = 800; // a representative canvas height in px.
+const WIDTH = 600; // and its width, which the 2D (orthographic) math reads.
 const EARTH_CIRCUMFERENCE = 2 * Math.PI * 6378137;
 
 describe("groundResolution", () => {
@@ -153,16 +158,22 @@ describe("isSameView", () => {
 // under 640 m of Las Vegas put the camera 640 m closer to the surface than the
 // zoom asked for — a >2x scale mismatch against the 2D pane at zoom 15.
 
+/** Cesium's own `SceneMode` numbering, which the camera math branches on. */
+const SCENE_MODE = { MORPHING: 0, COLUMBUS_VIEW: 1, SCENE2D: 2, SCENE3D: 3 };
+
 /** A fake Cesium namespace + viewer recording what the camera was told to do. */
-function makeCameraFakes(terrainHeight: number | undefined) {
+function makeCameraFakes(terrainHeight: number | undefined, mode = SCENE_MODE.SCENE3D) {
   const calls = {
     target: null as { lng: number; lat: number; height?: number } | null,
     range: 0,
+    heading: 0,
+    pitch: 0,
   };
 
   const viewer = {
     scene: {
-      canvas: { clientWidth: 600, clientHeight: HEIGHT, width: 600, height: HEIGHT },
+      mode,
+      canvas: { clientWidth: WIDTH, clientHeight: HEIGHT, width: WIDTH, height: HEIGHT },
       globe: {
         // Cesium returns undefined until the tiles for the position have loaded.
         getHeight: () => terrainHeight,
@@ -170,8 +181,10 @@ function makeCameraFakes(terrainHeight: number | undefined) {
     },
     camera: {
       frustum: { fovy: FOVY },
-      lookAt: (_target: unknown, hpr: { range: number }) => {
+      lookAt: (_target: unknown, hpr: { heading: number; pitch: number; range: number }) => {
         calls.range = hpr.range;
+        calls.heading = hpr.heading;
+        calls.pitch = hpr.pitch;
       },
       lookAtTransform: () => {},
     },
@@ -187,12 +200,14 @@ function makeCameraFakes(terrainHeight: number | undefined) {
     },
     Cartographic: { fromDegrees: (lng: number, lat: number) => ({ lng, lat }) },
     HeadingPitchRange: class {
-      range: number;
-      constructor(_heading: number, _pitch: number, range: number) {
-        this.range = range;
-      }
+      constructor(
+        public heading: number,
+        public pitch: number,
+        public range: number,
+      ) {}
     },
     Matrix4: { IDENTITY: {} },
+    SceneMode: SCENE_MODE,
   };
 
   return {
@@ -251,5 +266,218 @@ describe("applyMapViewToCamera on terrain", () => {
     const { Cesium, viewer, calls } = makeCameraFakes(undefined);
     applyMapViewToCamera(Cesium, viewer, LAS_VEGAS);
     assert.equal(calls.target?.height, 0);
+  });
+});
+
+// --- scene modes ------------------------------------------------------------
+// Cesium's scene-mode picker (the globe's 2D/3D/Columbus button) swaps the
+// frustum out from under the camera, and with it the meaning of every number
+// the camera sync exchanges with the store. 2D is the sharp edge: the camera
+// stops having a usable distance at all — Cesium parks it at a fixed altitude
+// and expresses the view through the width of an orthographic box — so the
+// distance-based conversion above silently reports a constant zoom there.
+
+describe("zoomToOrthoWidth / orthoWidthToZoom", () => {
+  it("spans the whole world across the canvas at zoom 0", () => {
+    // MapLibre's definition: at zoom 0 the world is TILE_SIZE (512) px wide, so
+    // a 512 px canvas shows exactly one circumference.
+    assert.ok(Math.abs(zoomToOrthoWidth(0, 512) - EARTH_CIRCUMFERENCE) < 1e-6);
+  });
+
+  it("halves the extent for each zoom level", () => {
+    assert.ok(Math.abs(zoomToOrthoWidth(5, WIDTH) - zoomToOrthoWidth(4, WIDTH) / 2) < 1e-6);
+  });
+
+  it("is latitude-independent, unlike the 3D conversion", () => {
+    // The projected plane is what MapLibre's zoom is defined on; the cos(lat)
+    // correction belongs to ground distance, which 2D never measures.
+    assert.equal(zoomToOrthoWidth(8, WIDTH), zoomToOrthoWidth(8, WIDTH));
+    assert.notEqual(zoomToRange(8, 0, HEIGHT, FOVY), zoomToRange(8, 60, HEIGHT, FOVY));
+  });
+
+  it("round-trips zoom through the ortho width", () => {
+    for (const zoom of [0, 3.5, 7, 12, 18]) {
+      const back = orthoWidthToZoom(zoomToOrthoWidth(zoom, WIDTH), WIDTH);
+      assert.ok(Math.abs(back - zoom) < 1e-9, `zoom ${zoom} round-tripped to ${back}`);
+    }
+  });
+});
+
+describe("zoomToSceneRange", () => {
+  const view: MapViewState = { center: [0, 45], zoom: 8, bearing: 0, pitch: 0 };
+
+  it("is the perspective camera distance on the 3D globe", () => {
+    const { Cesium, viewer } = makeCameraFakes(0, SCENE_MODE.SCENE3D);
+    assert.equal(zoomToSceneRange(Cesium, viewer, view), zoomToRange(8, 45, HEIGHT, FOVY));
+  });
+
+  it("is the orthographic box width in 2D", () => {
+    // The whole point: the same stored zoom must resolve to a different number
+    // here, because Cesium reinterprets `range` as a width once the frustum is
+    // orthographic. Feeding it the 3D distance would render at the wrong scale.
+    const { Cesium, viewer } = makeCameraFakes(0, SCENE_MODE.SCENE2D);
+    assert.equal(zoomToSceneRange(Cesium, viewer, view), zoomToOrthoWidth(8, WIDTH));
+  });
+
+  it("treats Columbus view like 3D — it keeps the perspective frustum", () => {
+    const { Cesium, viewer } = makeCameraFakes(0, SCENE_MODE.COLUMBUS_VIEW);
+    assert.equal(zoomToSceneRange(Cesium, viewer, view), zoomToRange(8, 45, HEIGHT, FOVY));
+  });
+
+  it("never returns a range below 1 metre", () => {
+    // A degenerate canvas (0 px during layout) or an extreme zoom would
+    // otherwise hand Cesium a zero distance and put the camera in the ground.
+    const { Cesium, viewer } = makeCameraFakes(0, SCENE_MODE.SCENE2D);
+    const absurd: MapViewState = { ...view, zoom: 40 };
+    assert.ok(zoomToSceneRange(Cesium, viewer, absurd) >= 1);
+  });
+});
+
+/**
+ * A fake viewer for the *readback* direction, parameterised by scene mode.
+ *
+ * `makeCameraFakes` above only records what the camera was told; this one
+ * answers the questions `readMapViewFromCamera` asks — the frustum, the camera's
+ * cartographic position, and the globe pick under the screen centre.
+ */
+function makeReadbackFakes(options: {
+  mode: number;
+  /** Camera altitude, and in 2D the width of the orthographic box. */
+  height: number;
+  /** Cesium pitch in radians (−π/2 is nadir). */
+  pitch?: number;
+  lng?: number;
+  lat?: number;
+}) {
+  const { mode, height, pitch = -Math.PI / 2, lng = 0, lat = 0 } = options;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const viewer = {
+    scene: {
+      mode,
+      canvas: { clientWidth: WIDTH, clientHeight: HEIGHT, width: WIDTH, height: HEIGHT },
+      globe: {
+        ellipsoid: { name: "wgs84" },
+        // The ground under the screen centre, at height 0.
+        pick: () => ({ x: lng, y: lat, z: 0 }),
+      },
+    },
+    camera: {
+      frustum:
+        mode === SCENE_MODE.SCENE2D ? { left: -height / 2, right: height / 2 } : { fovy: FOVY },
+      positionWC: { x: lng, y: lat, z: height },
+      positionCartographic: { longitude: toRad(lng), latitude: toRad(lat), height },
+      heading: 0,
+      pitch,
+      getPickRay: () => ({ ray: true }),
+      pickEllipsoid: () => ({ x: lng, y: lat, z: 0 }),
+    },
+  };
+  const Cesium = {
+    Math: { toRadians: toRad, toDegrees: (rad: number) => (rad * 180) / Math.PI },
+    Cartesian2: class {
+      constructor(
+        public x: number,
+        public y: number,
+      ) {}
+    },
+    Cartesian3: {
+      distance: (a: { z: number }, b: { z: number }) => Math.abs(a.z - b.z),
+    },
+    Cartographic: {
+      fromCartesian: (c: { x: number; y: number; z: number }) => ({
+        longitude: toRad(c.x),
+        latitude: toRad(c.y),
+        height: c.z,
+      }),
+    },
+    Ellipsoid: { WGS84: { name: "wgs84" } },
+    SceneMode: SCENE_MODE,
+  };
+  return {
+    viewer: viewer as unknown as Parameters<typeof readMapViewFromCamera>[1],
+    Cesium: Cesium as unknown as Parameters<typeof readMapViewFromCamera>[0],
+  };
+}
+
+describe("readMapViewFromCamera across scene modes", () => {
+  it("reads the 2D zoom from the frustum width, not the camera distance", () => {
+    // Cesium holds the 2D camera at a fixed ~12,700 km whatever the view, so a
+    // distance-derived zoom would be pinned to one value; the frustum is the
+    // only thing that actually changes.
+    const width = zoomToOrthoWidth(9, WIDTH);
+    const { Cesium, viewer } = makeReadbackFakes({ mode: SCENE_MODE.SCENE2D, height: width });
+    const view = readMapViewFromCamera(Cesium, viewer);
+    assert.ok(Math.abs(view.zoom - 9) < 1e-6, `read back zoom ${view.zoom}`);
+  });
+
+  it("round-trips a 2D view through apply and read", () => {
+    const original: MapViewState = { center: [0, 0], zoom: 6, bearing: 0, pitch: 0 };
+    const applied = makeCameraFakes(0, SCENE_MODE.SCENE2D);
+    applyMapViewToCamera(applied.Cesium, applied.viewer, original);
+    const { Cesium, viewer } = makeReadbackFakes({
+      mode: SCENE_MODE.SCENE2D,
+      height: applied.calls.range,
+    });
+    assert.ok(isSameView(readMapViewFromCamera(Cesium, viewer), original));
+  });
+
+  it("reports 2D as north-up and untilted", () => {
+    // Cesium's default 2D map mode has no rotation, and `camera.heading` is
+    // derived by treating the camera position as Earth-centred — true in 3D,
+    // meaningless once the world is the flattened map.
+    const { Cesium, viewer } = makeReadbackFakes({
+      mode: SCENE_MODE.SCENE2D,
+      height: zoomToOrthoWidth(6, WIDTH),
+      pitch: -0.3,
+    });
+    const view = readMapViewFromCamera(Cesium, viewer);
+    assert.equal(view.bearing, 0);
+    assert.equal(view.pitch, 0);
+  });
+
+  it("derives the Columbus-view range from the camera's height and pitch", () => {
+    // Looking straight down, the drop to the ground *is* the range — so this
+    // must agree with what the same zoom would place in 3D.
+    const range = zoomToRange(10, 0, HEIGHT, FOVY);
+    const { Cesium, viewer } = makeReadbackFakes({
+      mode: SCENE_MODE.COLUMBUS_VIEW,
+      height: range,
+      pitch: -Math.PI / 2,
+    });
+    assert.ok(Math.abs(readMapViewFromCamera(Cesium, viewer).zoom - 10) < 1e-6);
+  });
+
+  it("falls back to the camera altitude near the horizon in Columbus view", () => {
+    // Dividing by sin(pitch) blows up as the camera levels off, so below the
+    // guard the altitude is used instead of a range several times too large.
+    const height = zoomToRange(10, 0, HEIGHT, FOVY);
+    const { Cesium, viewer } = makeReadbackFakes({
+      mode: SCENE_MODE.COLUMBUS_VIEW,
+      height,
+      pitch: -0.01,
+    });
+    const view = readMapViewFromCamera(Cesium, viewer);
+    assert.ok(Math.abs(view.zoom - 10) < 1e-6, `read back zoom ${view.zoom}`);
+  });
+});
+
+describe("applyMapViewToCamera in 2D", () => {
+  const rotated: MapViewState = { center: [0, 0], zoom: 6, bearing: 45, pitch: 60 };
+
+  it("flattens the camera to north-up and nadir", () => {
+    // The readback reports 2D as bearing 0 / pitch 0 because Cesium's heading
+    // getter is meaningless there. Applying the stored bearing anyway would
+    // leave a visibly rotated map under a status bar insisting it is north-up.
+    const { Cesium, viewer, calls } = makeCameraFakes(0, SCENE_MODE.SCENE2D);
+    applyMapViewToCamera(Cesium, viewer, rotated);
+    assert.equal(calls.heading, 0);
+    assert.equal(calls.pitch, mapLibrePitchToCesiumDeg(0) * (Math.PI / 180));
+  });
+
+  it("still carries bearing and pitch on the 3D globe", () => {
+    const { Cesium, viewer, calls } = makeCameraFakes(0, SCENE_MODE.SCENE3D);
+    applyMapViewToCamera(Cesium, viewer, rotated);
+    assert.ok(Math.abs(calls.heading - (45 * Math.PI) / 180) < 1e-12);
+    assert.ok(Math.abs(calls.pitch - (mapLibrePitchToCesiumDeg(60) * Math.PI) / 180) < 1e-12);
   });
 });

--- a/tests/cesium-camera.test.ts
+++ b/tests/cesium-camera.test.ts
@@ -501,3 +501,33 @@ describe("applyMapViewToCamera in 2D", () => {
     assert.ok(Math.abs(calls.pitch - (mapLibrePitchToCesiumDeg(60) * Math.PI) / 180) < 1e-12);
   });
 });
+
+// Flat Web Mercator scenes measure projected metres, not ground metres.
+class WebMercatorProjection {}
+function useMercator({ Cesium, viewer }: ReturnType<typeof makeCameraFakes>) {
+  Object.assign(Cesium, { WebMercatorProjection });
+  Object.assign(viewer.scene, { mapProjection: new WebMercatorProjection() });
+}
+
+describe("Web Mercator Columbus camera", () => {
+  it("matches the projected map scale at high latitude", () => {
+    const fakes = makeCameraFakes(0, SCENE_MODE.COLUMBUS_VIEW);
+    useMercator(fakes);
+    const view: MapViewState = { center: [12, 60], zoom: 2, bearing: 0, pitch: 0 };
+    assert.equal(
+      zoomToSceneRange(fakes.Cesium, fakes.viewer, view),
+      zoomToRange(2, 0, HEIGHT, FOVY),
+    );
+  });
+
+  it("reads projected scale without a latitude-dependent zoom jump", () => {
+    const fakes = makeReadbackFakes({
+      mode: SCENE_MODE.COLUMBUS_VIEW,
+      height: zoomToRange(2, 0, HEIGHT, FOVY),
+      lat: 60,
+    });
+    Object.assign(fakes.Cesium, { WebMercatorProjection });
+    Object.assign(fakes.viewer.scene, { mapProjection: new WebMercatorProjection() });
+    assert.ok(Math.abs(readMapViewFromCamera(fakes.Cesium, fakes.viewer).zoom - 2) < 1e-6);
+  });
+});

--- a/tests/cesium-camera.test.ts
+++ b/tests/cesium-camera.test.ts
@@ -447,6 +447,26 @@ describe("readMapViewFromCamera across scene modes", () => {
     assert.ok(Math.abs(readMapViewFromCamera(Cesium, viewer).zoom - 10) < 1e-6);
   });
 
+  it("round-trips a Columbus-view zoom at high latitude", () => {
+    // The latitude correction is the part of the 3D formula Columbus view
+    // inherits, and 60°+ is where `cos(lat)` diverges most from 1 (#2270
+    // review) — so if the apply and read sides disagreed about whether it
+    // belongs, the drift would show here first and nowhere at the equator.
+    for (const lat of [0, 60, -75]) {
+      const applied = makeCameraFakes(0, SCENE_MODE.COLUMBUS_VIEW);
+      const original: MapViewState = { center: [0, lat], zoom: 11, bearing: 0, pitch: 0 };
+      applyMapViewToCamera(applied.Cesium, applied.viewer, original);
+      const { Cesium, viewer } = makeReadbackFakes({
+        mode: SCENE_MODE.COLUMBUS_VIEW,
+        height: applied.calls.range,
+        pitch: -Math.PI / 2,
+        lat,
+      });
+      const back = readMapViewFromCamera(Cesium, viewer);
+      assert.ok(Math.abs(back.zoom - 11) < 1e-6, `lat ${lat} round-tripped to ${back.zoom}`);
+    }
+  });
+
   it("falls back to the camera altitude near the horizon in Columbus view", () => {
     // Dividing by sin(pitch) blows up as the camera levels off, so below the
     // guard the altitude is used instead of a range several times too large.

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -754,9 +754,8 @@ describe("CesiumEngine framing", () => {
 // its duration the camera is off limits. `Camera.lookAt` and `flyTo` throw
 // outright while `scene.mode` is MORPHING, `camera.heading` returns undefined,
 // and moveEnd fires repeatedly with intermediate poses. So both halves of the
-// camera sync have to stand down until it lands — and then put the camera back,
-// because the modes encode scale differently and Cesium's own idea of a faithful
-// morph is not the store's.
+// camera sync have to stand down until it lands, then publish the native endpoint
+// without a second camera move.
 
 const MORPHING = 0;
 const SCENE2D = 2;
@@ -806,21 +805,28 @@ describe("CesiumEngine scene-mode morphs", () => {
     engine.destroy();
   });
 
-  it("re-applies the stored camera once the morph completes", () => {
+  it("publishes the native morph endpoint without snapping back to the stored camera", () => {
+    const writes: MapViewState[] = [];
+    useAppStore.setState({ setMapView: ((view: MapViewState) => writes.push(view)) as never });
     const fakes = makeViewer();
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     engine.applyView(VIEW);
-    // The morph ends with the scene in its new mode and the camera wherever
-    // Cesium left it — here, somewhere else entirely.
     fakes.setSceneMode(SCENE2D);
     fakes.nudge(45);
+    const settled = engine.readView();
     const before = fakes.placements;
     fakes.morphComplete.emit();
-    assert.equal(fakes.placements, before + 1, "the stored view must be re-applied");
+    assert.equal(fakes.placements, before, "a native morph must not end with a camera placement");
+    assert.deepEqual(writes, [settled], "the project follows Cesium's final view");
+    assert.deepEqual(
+      engine.getLastAppliedView(),
+      settled,
+      "store echo must not reapply the camera",
+    );
     engine.destroy();
   });
 
-  it("stops re-applying once destroyed", () => {
+  it("stops publishing morphs once destroyed", () => {
     const fakes = makeViewer();
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);
     engine.destroy();

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -84,6 +84,8 @@ function makeCesium() {
     EllipsoidTerrainProvider: class {
       readonly kind = "ellipsoid";
     },
+    // Cesium's own numbering, which the engine compares `scene.mode` against.
+    SceneMode: { MORPHING: 0, COLUMBUS_VIEW: 1, SCENE2D: 2, SCENE3D: 3 },
     Math: {
       toRadians: toRad,
       toDegrees: (rad: number) => (rad * 180) / Math.PI,
@@ -120,6 +122,7 @@ function makeViewer(groundHeight = 0) {
   let height = groundHeight;
   const moveEnd = makeEvent();
   const tileLoadProgressEvent = makeEvent();
+  const morphComplete = makeEvent();
   const canvasListeners = new Map<string, Set<(event: unknown) => void>>();
   const canvas = {
     clientWidth: 800,
@@ -183,6 +186,10 @@ function makeViewer(groundHeight = 0) {
     },
     scene: {
       canvas,
+      // SCENE3D, matching the fake namespace above. Mutable so a test can put
+      // the scene mid-morph (or in 2D) the way the scene-mode picker does.
+      mode: 3,
+      morphComplete,
       verticalExaggeration: 1,
       screenSpaceCameraController: {
         minimumZoomDistance: 0,
@@ -215,6 +222,11 @@ function makeViewer(groundHeight = 0) {
     viewer: viewer as never,
     moveEnd,
     tileLoadProgressEvent,
+    morphComplete,
+    /** Put the scene in a scene mode, as the scene-mode picker's morph does. */
+    setSceneMode(mode: number) {
+      viewer.scene.mode = mode;
+    },
     flights,
     canvasListeners,
     /** Nudge the camera as if the user had navigated there. */
@@ -717,5 +729,88 @@ describe("CesiumEngine framing", () => {
     } as never);
     assert.equal(fakes.flights.length, 1);
     engine.destroy();
+  });
+});
+
+// --- scene-mode morphs -------------------------------------------------------
+// Cesium's scene-mode picker (the globe's 2D/3D/Columbus button, added in
+// #2270) does not swap the mode instantly: it runs an animated morph, and for
+// its duration the camera is off limits. `Camera.lookAt` and `flyTo` throw
+// outright while `scene.mode` is MORPHING, `camera.heading` returns undefined,
+// and moveEnd fires repeatedly with intermediate poses. So both halves of the
+// camera sync have to stand down until it lands — and then put the camera back,
+// because the modes encode scale differently and Cesium's own idea of a faithful
+// morph is not the store's.
+
+const MORPHING = 0;
+const SCENE2D = 2;
+
+describe("CesiumEngine scene-mode morphs", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      setMapView: (() => {}) as never,
+    } as never);
+  });
+
+  it("does not place the camera while the scene is morphing", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    const before = fakes.placements;
+    fakes.setSceneMode(MORPHING);
+    engine.applyView({ center: [10, 20], zoom: 8, bearing: 0, pitch: 0 });
+    assert.equal(fakes.placements, before, "lookAt throws mid-morph; it must not be called");
+    engine.destroy();
+  });
+
+  it("does not animate the camera while the scene is morphing", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    fakes.setSceneMode(MORPHING);
+    engine.zoomIn();
+    assert.equal(fakes.flights.length, 0, "flyTo throws mid-morph; it must not be called");
+    engine.destroy();
+  });
+
+  it("does not publish the intermediate poses a morph fires", () => {
+    // A morph raises moveEnd repeatedly on its way between modes. Publishing
+    // those would walk the stored camera through a series of half-projected
+    // poses, and each pane following mapView would jump with it.
+    const writes: MapViewState[] = [];
+    useAppStore.setState({
+      setMapView: ((view: MapViewState) => writes.push(view)) as never,
+    } as never);
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    fakes.setSceneMode(MORPHING);
+    fakes.nudge(30);
+    fakes.moveEnd.emit();
+    assert.deepEqual(writes, []);
+    engine.destroy();
+  });
+
+  it("re-applies the stored camera once the morph completes", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    // The morph ends with the scene in its new mode and the camera wherever
+    // Cesium left it — here, somewhere else entirely.
+    fakes.setSceneMode(SCENE2D);
+    fakes.nudge(45);
+    const before = fakes.placements;
+    fakes.morphComplete.emit();
+    assert.equal(fakes.placements, before + 1, "the stored view must be re-applied");
+    engine.destroy();
+  });
+
+  it("stops re-applying once destroyed", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.destroy();
+    const before = fakes.placements;
+    fakes.morphComplete.emit();
+    assert.equal(fakes.placements, before);
+    assert.equal(fakes.morphComplete.size, 0, "the listener must be removed on destroy");
   });
 });

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -88,7 +88,13 @@ function makeCesium() {
     SceneMode: { MORPHING: 0, COLUMBUS_VIEW: 1, SCENE2D: 2, SCENE3D: 3 },
     Math: {
       toRadians: toRad,
-      toDegrees: (rad: number) => (rad * 180) / Math.PI,
+      // Cesium's own `Math.toDegrees` throws `DeveloperError` on a missing
+      // value rather than returning NaN, which is what turns an unguarded
+      // mid-morph camera read into a thrown error instead of a bad number.
+      toDegrees: (rad: number) => {
+        if (typeof rad !== "number") throw new Error("DeveloperError: radians is required.");
+        return (rad * 180) / Math.PI;
+      },
     },
     createWorldTerrainAsync: () => Promise.resolve({ kind: "world-terrain" }),
   } as unknown as typeof import("@cesium/engine");
@@ -226,6 +232,16 @@ function makeViewer(groundHeight = 0) {
     /** Put the scene in a scene mode, as the scene-mode picker's morph does. */
     setSceneMode(mode: number) {
       viewer.scene.mode = mode;
+    },
+    /**
+     * Make the camera report what Cesium reports mid-morph: `heading` and
+     * `pitch` become `undefined`, and `Math.toDegrees` throws on them. Without
+     * this the fake would keep answering with numbers and a missing morph guard
+     * would pass the test it is supposed to fail.
+     */
+    breakCameraForMorph() {
+      state.heading = undefined as unknown as number;
+      state.pitch = undefined as unknown as number;
     },
     flights,
     canvasListeners,
@@ -812,5 +828,139 @@ describe("CesiumEngine scene-mode morphs", () => {
     fakes.morphComplete.emit();
     assert.equal(fakes.placements, before);
     assert.equal(fakes.morphComplete.size, 0, "the listener must be removed on destroy");
+  });
+});
+
+// --- built-in controls -------------------------------------------------------
+// The globe has no MapLibre map, so none of the built-in controls the Controls
+// menu offers exist on it — with one exception. `CesiumCanvas` builds a Cesium
+// fullscreen widget and hands it to the engine under the `fullscreen` id
+// (#2270), so that one menu row governs something here too. The distinction has
+// to be exact: answering `true` for an id the globe cannot honour would move the
+// menu's checkmark while nothing on the map changed, which is precisely what the
+// `false` return exists to prevent.
+
+describe("CesiumEngine built-in controls", () => {
+  /** A control host recording what was mounted and unmounted. */
+  function fakeHost() {
+    const calls = { added: [] as unknown[], removed: [] as unknown[] };
+    const host = {
+      addControl: (control: unknown) => {
+        calls.added.push(control);
+        return true;
+      },
+      removeControl: (control: unknown) => {
+        calls.removed.push(control);
+      },
+    } as unknown as CesiumControlHost;
+    return { calls, host };
+  }
+
+  it("refuses a built-in control nothing has registered", () => {
+    const { calls, host } = fakeHost();
+    setPrimaryCesiumControlHost(host);
+    try {
+      const fakes = makeViewer();
+      const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+      // Every MapLibre-only control: no globe counterpart, so the menu must be
+      // told the toggle did not take.
+      assert.equal(engine.setBuiltInControlVisible("navigation", true), false);
+      assert.equal(engine.setBuiltInControlVisible("fullscreen", true), false);
+      assert.deepEqual(calls.added, []);
+      engine.destroy();
+    } finally {
+      setPrimaryCesiumControlHost(null);
+    }
+  });
+
+  it("mounts and unmounts a registered control through the host", () => {
+    const { calls, host } = fakeHost();
+    setPrimaryCesiumControlHost(host);
+    try {
+      const fakes = makeViewer();
+      const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+      const control = { onAdd: () => document.createElement("div"), onRemove: () => {} };
+      engine.registerBuiltInControl("fullscreen", control as never);
+
+      assert.equal(engine.setBuiltInControlVisible("fullscreen", false), true);
+      assert.deepEqual(calls.removed, [control]);
+      assert.equal(engine.setBuiltInControlVisible("fullscreen", true), true);
+      assert.deepEqual(calls.added, [control]);
+      // Registering one control must not make the engine claim the others.
+      assert.equal(engine.setBuiltInControlVisible("compass", true), false);
+      engine.destroy();
+    } finally {
+      setPrimaryCesiumControlHost(null);
+    }
+  });
+
+  it("keeps a grid pane away from the primary globe's controls", () => {
+    const { calls, host } = fakeHost();
+    setPrimaryCesiumControlHost(host);
+    try {
+      const fakes = makeViewer();
+      const pane = new CesiumEngine(makeCesium(), fakes.viewer, { viewId: "pane-1" });
+      const control = { onAdd: () => document.createElement("div"), onRemove: () => {} };
+      pane.registerBuiltInControl("fullscreen", control as never);
+      // Same guard as `addControl`: the host belongs to the primary map area,
+      // so a pane acting on it would toggle a control on a different viewer.
+      assert.equal(pane.setBuiltInControlVisible("fullscreen", true), false);
+      assert.deepEqual(calls.added, []);
+      pane.destroy();
+    } finally {
+      setPrimaryCesiumControlHost(null);
+    }
+  });
+
+  it("forgets its registrations on destroy", () => {
+    const { calls, host } = fakeHost();
+    setPrimaryCesiumControlHost(host);
+    try {
+      const fakes = makeViewer();
+      const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+      const control = { onAdd: () => document.createElement("div"), onRemove: () => {} };
+      engine.registerBuiltInControl("fullscreen", control as never);
+      engine.destroy();
+      // A late toggle (the app replays control visibility on project load) must
+      // not re-mount a control onto a globe that is already gone.
+      assert.equal(engine.setBuiltInControlVisible("fullscreen", true), false);
+      assert.deepEqual(calls.added, []);
+    } finally {
+      setPrimaryCesiumControlHost(null);
+    }
+  });
+});
+
+describe("CesiumEngine camera reads during a morph", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      mapView: { center: [0, 0], zoom: 4, bearing: 0, pitch: 0 },
+      setMapView: (() => {}) as never,
+    } as never);
+  });
+
+  it("reports the last applied view instead of reading a half-morphed camera", () => {
+    // Not a nicety. `camera.heading` is `undefined` while the scene is
+    // MORPHING, and Cesium's `Math.toDegrees` throws on that rather than
+    // returning NaN — so an unguarded read takes its caller down. The callers
+    // are ordinary background work: the autosave snapshot, the View menu's
+    // zoom-limit check, the status bar.
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    engine.applyView(VIEW);
+    fakes.setSceneMode(MORPHING);
+    fakes.breakCameraForMorph();
+    assert.deepEqual(engine.readView(), VIEW);
+    assert.equal(engine.readCameraAltitude(), null);
+    engine.destroy();
+  });
+
+  it("falls back to the store when a morph starts before any view is applied", () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    fakes.setSceneMode(MORPHING);
+    fakes.breakCameraForMorph();
+    assert.deepEqual(engine.readView(), useAppStore.getState().mapView);
+    engine.destroy();
   });
 });


### PR DESCRIPTION
Adds Reset view, scene-mode, and fullscreen controls to the primary Cesium globe. The controls use the app's toolbar styling, translated tooltips, a clear blue hover highlight, and a scene-mode picker that opens beside the toolbar so it cannot intercept fullscreen clicks.

2D and Columbus views use Web Mercator to match the project map. Projection switches use Cesium's native duration and easing. The shared camera follows the native final view instead of snapping back to the pre-transition camera. Camera conversion handles 2D orthographic width and Columbus projected distances separately from globe ground distances, including high latitudes. The default flat view fills the canvas without the geographic projection's black polar band.

Controls → Fullscreen stays consistent across renderer swaps. View → Rendering engine uses MapLibre/Cesium labels and the Rendering engine and Split View submenus size to their contents. Cesium widgets remain in the lazy Cesium bundle.

Validation: production build, lint, frontend coverage, worker checks, backend coverage, Rust check, scoped pre-commit checks, and browser tests for renderer swaps, scene changes, camera preservation, and fullscreen in light/dark themes. Manual browser checks compared the native Sandcastle switcher and covered animated transitions and settled views in light and dark themes.

Known pre-existing limitation: wheel zoom at the default whole-Earth 3D camera can trigger a Cesium controller normalization error; this was previously reproduced on main and is outside this change.

