### PR TITLE
fix(map): safeguard CesiumControlHost control removal and element validation

### DIFF
--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -8,7 +8,7 @@ class CesiumMapFacade extends maplibregl.Evented {
 
   constructor(
     private host: CesiumControlHost,
-    private viewer: any,
+    private viewer: CesiumWidget,
   ) {
     super();
   }
@@ -187,13 +187,17 @@ export class CesiumControlHost {
     let el: HTMLElement;
     try {
       el = control.onAdd(this.facade as unknown as maplibregl.Map);
+      if (!el || typeof el.style === "undefined") {
+        console.warn("[GeoLibre] control onAdd did not return a valid DOM element");
+        return false;
+      }
     } catch (error) {
       console.warn("[GeoLibre] control could not mount on the globe", error);
       return false;
     }
     el.style.pointerEvents = "auto";
 
-    const corner = this.corners[position];
+    const corner = this.corners[position] ?? this.corners["top-right"];
     if (corner) {
       corner.appendChild(el);
     }
@@ -206,9 +210,6 @@ export class CesiumControlHost {
     if (!this.controls.has(control)) return;
 
     const el = this.controls.get(control)!;
-    if (el.parentElement) {
-      el.parentElement.removeChild(el);
-    }
 
     // Guarded for the same reason `addControl` guards `onAdd`, and it matters
     // more here: `destroy()` calls this in a loop, and `CesiumCanvas`'s unmount
@@ -216,14 +217,23 @@ export class CesiumControlHost {
     // `onRemove` trips one of the facade's deliberate throws would otherwise
     // escape the cleanup — leaving the remaining controls mounted, the
     // container attached, the primary-host registration stale, and the Cesium
-    // viewer never destroyed. The control is dropped from the registry either
-    // way: it is already detached from the DOM by this point.
+    // viewer never destroyed.
+    //
+    // The control's DOM element is intentionally kept in its container until
+    // after `onRemove` returns: many `IControl` implementations invoke
+    // `this._container.parentNode.removeChild(this._container)` directly, and
+    // detaching beforehand causes them to throw on null parentNode. The finally
+    // block guarantees DOM cleanup and registry removal regardless of outcome.
     try {
       control.onRemove(this.facade as unknown as maplibregl.Map);
     } catch (error) {
       console.warn("[GeoLibre] control failed to unmount cleanly from the globe", error);
+    } finally {
+      if (el.parentElement) {
+        el.parentElement.removeChild(el);
+      }
+      this.controls.delete(control);
     }
-    this.controls.delete(control);
   }
 }
 

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -173,6 +173,13 @@ export class CesiumControlHost {
     return this.container;
   }
 
+  /**
+   * Mounts a MapLibre control onto the Cesium viewer container in the requested corner.
+   *
+   * @param control - The MapLibre control instance to add.
+   * @param position - The target corner position ('top-left', 'top-right', 'bottom-left', 'bottom-right').
+   * @returns `true` if the control was successfully added, or `false` if addition failed or element was invalid.
+   */
   addControl(control: maplibregl.IControl, position: maplibregl.ControlPosition = "top-right") {
     if (this.controls.has(control)) return false;
 
@@ -187,13 +194,7 @@ export class CesiumControlHost {
     let el: HTMLElement;
     try {
       el = control.onAdd(this.facade as unknown as maplibregl.Map);
-      if (
-        !el ||
-        typeof el !== "object" ||
-        typeof (el as Node).nodeType !== "number" ||
-        typeof el.style !== "object" ||
-        el.style === null
-      ) {
+      if (!(el instanceof HTMLElement)) {
         console.warn("[GeoLibre] control onAdd did not return a valid DOM element");
         return false;
       }
@@ -217,6 +218,11 @@ export class CesiumControlHost {
     return true;
   }
 
+  /**
+   * Removes a MapLibre control from the Cesium viewer container and cleans up its DOM element.
+   *
+   * @param control - The MapLibre control instance to remove.
+   */
   removeControl(control: maplibregl.IControl) {
     if (!this.controls.has(control)) return;
 

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -187,7 +187,13 @@ export class CesiumControlHost {
     let el: HTMLElement;
     try {
       el = control.onAdd(this.facade as unknown as maplibregl.Map);
-      if (!el || typeof el.style === "undefined") {
+      if (
+        !el ||
+        typeof el !== "object" ||
+        typeof (el as Node).nodeType !== "number" ||
+        typeof el.style !== "object" ||
+        el.style === null
+      ) {
         console.warn("[GeoLibre] control onAdd did not return a valid DOM element");
         return false;
       }
@@ -197,10 +203,15 @@ export class CesiumControlHost {
     }
     el.style.pointerEvents = "auto";
 
-    const corner = this.corners[position] ?? this.corners["top-right"];
-    if (corner) {
-      corner.appendChild(el);
-    }
+    const VALID_POSITIONS: readonly maplibregl.ControlPosition[] = [
+      "top-left",
+      "top-right",
+      "bottom-left",
+      "bottom-right",
+    ];
+    const target = VALID_POSITIONS.includes(position) ? position : "top-right";
+    const corner = this.corners[target];
+    corner.appendChild(el);
 
     this.controls.set(control, el);
     return true;

--- a/tests/cesium-control-host.test.ts
+++ b/tests/cesium-control-host.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { parseHTML } from "linkedom";
+import { useAppStore } from "@geolibre/core";
+import type { IControl, Map as MapLibreMap } from "maplibre-gl";
+import {
+  CesiumControlHost,
+  getPrimaryCesiumControlHost,
+  setPrimaryCesiumControlHost,
+} from "../packages/map/src/cesium-control-host";
+
+const originalDocument = globalThis.document;
+const originalHTMLElement = globalThis.HTMLElement;
+
+afterEach(() => {
+  setPrimaryCesiumControlHost(null);
+  Object.assign(globalThis, {
+    document: originalDocument,
+    HTMLElement: originalHTMLElement,
+  });
+});
+
+function installDom() {
+  const { document, window } = parseHTML(
+    "<html><body><div id='cesium-parent'></div></body></html>",
+  );
+  Object.assign(globalThis, { document, HTMLElement: window.HTMLElement });
+  return document;
+}
+
+function makeFakeViewer(document: Document) {
+  const canvas = document.createElement("canvas");
+  return {
+    canvas,
+    scene: { canvas },
+    camera: { heading: 0, pitch: -Math.PI / 2 },
+  };
+}
+
+describe("CesiumControlHost", () => {
+  let doc: Document;
+  let parent: HTMLElement;
+  let viewer: ReturnType<typeof makeFakeViewer>;
+
+  beforeEach(() => {
+    doc = installDom();
+    parent = doc.getElementById("cesium-parent")!;
+    viewer = makeFakeViewer(doc);
+    useAppStore.setState({
+      mapView: { center: [-122.4, 37.7], zoom: 10, bearing: 15, pitch: 45 },
+    } as never);
+  });
+
+  it("creates corner containers with pointer-events: none over the parent", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const container = host.getContainer();
+    assert.ok(container);
+    assert.equal(container.className, "maplibregl-control-container");
+    assert.equal(container.parentElement, parent);
+
+    const corners = ["top-left", "top-right", "bottom-left", "bottom-right"];
+    for (const corner of corners) {
+      const el = container.querySelector(`.maplibregl-ctrl-${corner}`) as HTMLElement;
+      assert.ok(el, `missing corner ${corner}`);
+      assert.equal(el.style.pointerEvents, "none");
+      assert.equal(el.style.position, "absolute");
+      assert.equal(el.style.zIndex, "2");
+    }
+    host.destroy();
+  });
+
+  it("mounts controls with pointer-events: auto in the requested corner", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const ctrlEl = doc.createElement("div");
+    ctrlEl.className = "test-control";
+
+    let passedMap: MapLibreMap | null = null;
+    const control: IControl = {
+      onAdd: (map) => {
+        passedMap = map;
+        return ctrlEl;
+      },
+      onRemove: () => {},
+    };
+
+    const added = host.addControl(control, "bottom-left");
+    assert.equal(added, true);
+    assert.ok(passedMap, "control onAdd must receive map facade");
+    assert.equal(ctrlEl.style.pointerEvents, "auto");
+
+    const corner = host.getContainer().querySelector(".maplibregl-ctrl-bottom-left")!;
+    assert.ok(corner.contains(ctrlEl));
+
+    // Refuses duplicate control
+    assert.equal(host.addControl(control), false);
+
+    host.destroy();
+  });
+
+  it("falls back to top-right corner when position is not recognized", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const ctrlEl = doc.createElement("div");
+    const control: IControl = {
+      onAdd: () => ctrlEl,
+      onRemove: () => {},
+    };
+
+    const added = host.addControl(control, "unknown-corner" as never);
+    assert.equal(added, true);
+    const corner = host.getContainer().querySelector(".maplibregl-ctrl-top-right")!;
+    assert.ok(corner.contains(ctrlEl));
+    host.destroy();
+  });
+
+  it("handles throwing control.onAdd gracefully without adding to registry", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const control: IControl = {
+      onAdd: () => {
+        throw new Error("Plugin failed to construct DOM");
+      },
+      onRemove: () => {},
+    };
+
+    const added = host.addControl(control);
+    assert.equal(added, false);
+    host.destroy();
+  });
+
+  it("handles control whose onRemove detaches its container from parentNode directly", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const ctrlEl = doc.createElement("div");
+    let onRemoveCalled = false;
+
+    const control: IControl = {
+      onAdd: () => ctrlEl,
+      onRemove: () => {
+        onRemoveCalled = true;
+        // Classic MapLibre control pattern that throws if detached beforehand
+        ctrlEl.parentNode!.removeChild(ctrlEl);
+      },
+    };
+
+    host.addControl(control, "top-left");
+    assert.doesNotThrow(() => host.removeControl(control));
+    assert.equal(onRemoveCalled, true);
+    assert.equal(ctrlEl.parentElement, null);
+    host.destroy();
+  });
+
+  it("safeguards removeControl when control.onRemove throws", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const ctrlEl = doc.createElement("div");
+
+    const control: IControl = {
+      onAdd: () => ctrlEl,
+      onRemove: () => {
+        throw new Error("Teardown error in third-party control");
+      },
+    };
+
+    host.addControl(control, "top-right");
+    assert.doesNotThrow(() => host.removeControl(control));
+    assert.equal(ctrlEl.parentElement, null, "DOM element must still be detached");
+    host.destroy();
+  });
+
+  it("safely tears down all controls and container in destroy even if a control throws", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const el1 = doc.createElement("div");
+    const el2 = doc.createElement("div");
+    let c2Removed = false;
+
+    const c1: IControl = {
+      onAdd: () => el1,
+      onRemove: () => {
+        throw new Error("c1 explode");
+      },
+    };
+    const c2: IControl = {
+      onAdd: () => el2,
+      onRemove: () => {
+        c2Removed = true;
+      },
+    };
+
+    host.addControl(c1);
+    host.addControl(c2);
+    assert.doesNotThrow(() => host.destroy());
+
+    assert.equal(c2Removed, true, "subsequent controls must still be unmounted");
+    assert.equal(host.getContainer().parentElement, null, "container must be detached from parent");
+  });
+
+  it("provides active camera view getters on CesiumMapFacade", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    let facade: any = null;
+    const control: IControl = {
+      onAdd: (map) => {
+        facade = map;
+        return doc.createElement("div");
+      },
+      onRemove: () => {},
+    };
+
+    host.addControl(control);
+    assert.ok(facade);
+    assert.equal(facade.getCanvas(), viewer.canvas);
+    assert.equal(facade.isStyleLoaded(), true);
+    assert.equal(facade.getZoom(), 10);
+    assert.equal(facade.getBearing(), 15);
+    assert.equal(facade.getPitch(), 45);
+    assert.equal(facade.getCenter().lng, -122.4);
+    assert.equal(facade.getCenter().lat, 37.7);
+
+    // Unsupported style-spec mutations throw explicitly
+    assert.throws(() => facade.addLayer({}), /addLayer is not supported/);
+    assert.throws(() => facade.setPaintProperty(), /setPaintProperty is not supported/);
+    assert.throws(() => facade.setLayoutProperty(), /setLayoutProperty is not supported/);
+    assert.throws(() => facade.getStyle(), /getStyle is not supported/);
+    assert.throws(() => facade.getBounds(), /getBounds not implemented/);
+
+    // Source management works
+    facade.addSource("test-src", { type: "geojson" });
+    assert.deepEqual(facade.getSource("test-src"), { type: "geojson" });
+    facade.removeSource("test-src");
+    assert.equal(facade.getSource("test-src"), undefined);
+
+    host.destroy();
+  });
+
+  it("tracks primaryCesiumControlHost singleton", () => {
+    assert.equal(getPrimaryCesiumControlHost(), null);
+    const host = new CesiumControlHost(viewer as never, parent);
+    setPrimaryCesiumControlHost(host);
+    assert.equal(getPrimaryCesiumControlHost(), host);
+    setPrimaryCesiumControlHost(null);
+    assert.equal(getPrimaryCesiumControlHost(), null);
+    host.destroy();
+  });
+});

--- a/tests/cesium-control-host.test.ts
+++ b/tests/cesium-control-host.test.ts
@@ -126,6 +126,46 @@ describe("CesiumControlHost", () => {
     host.destroy();
   });
 
+  it("rejects controls returning invalid elements or duck-typed objects from onAdd", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+
+    const duckTypedObj = { style: {} };
+    const controlWithDuckType: IControl = {
+      onAdd: () => duckTypedObj as never,
+      onRemove: () => {},
+    };
+    assert.equal(host.addControl(controlWithDuckType), false);
+
+    const controlWithNull: IControl = {
+      onAdd: () => null as never,
+      onRemove: () => {},
+    };
+    assert.equal(host.addControl(controlWithNull), false);
+
+    const controlWithNumber: IControl = {
+      onAdd: () => 42 as never,
+      onRemove: () => {},
+    };
+    assert.equal(host.addControl(controlWithNumber), false);
+
+    host.destroy();
+  });
+
+  it("safely falls back to top-right on inherited prototype properties as position", () => {
+    const host = new CesiumControlHost(viewer as never, parent);
+    const ctrlEl = doc.createElement("div");
+    const control: IControl = {
+      onAdd: () => ctrlEl,
+      onRemove: () => {},
+    };
+
+    const added = host.addControl(control, "__proto__" as never);
+    assert.equal(added, true);
+    const corner = host.getContainer().querySelector(".maplibregl-ctrl-top-right")!;
+    assert.ok(corner.contains(ctrlEl));
+    host.destroy();
+  });
+
   it("handles control whose onRemove detaches its container from parentNode directly", () => {
     const host = new CesiumControlHost(viewer as never, parent);
     const ctrlEl = doc.createElement("div");

--- a/tests/cesium-control-host.test.ts
+++ b/tests/cesium-control-host.test.ts
@@ -136,6 +136,13 @@ describe("CesiumControlHost", () => {
     };
     assert.equal(host.addControl(controlWithDuckType), false);
 
+    const forgedNode = { nodeType: 1, style: {} };
+    const controlWithForgedNode: IControl = {
+      onAdd: () => forgedNode as never,
+      onRemove: () => {},
+    };
+    assert.equal(host.addControl(controlWithForgedNode), false);
+
     const controlWithNull: IControl = {
       onAdd: () => null as never,
       onRemove: () => {},


### PR DESCRIPTION
## Problem

In `CesiumControlHost`, `removeControl` detached the control's DOM element from its parent container before invoking `control.onRemove(facade)`. Many standard `IControl` implementations (such as typical MapLibre controls and external plugin controls) follow the idiom `this._container.parentNode.removeChild(this._container)` during teardown. Detaching beforehand leaves `parentNode` as `null`, causing unhandled `TypeError: Cannot read properties of null (reading 'removeChild')` exceptions inside `onRemove`. In addition, `addControl` did not validate that `onAdd` returned a valid DOM element.

## Root Cause

1. Pre-detaching `el` in `removeControl` stripped the DOM hierarchy prior to giving the control's `onRemove` method a chance to inspect or clean up its container.
2. In `addControl`, if a control returned an invalid or non-element value from `onAdd`, subsequent property assignments (`el.style.pointerEvents`) would throw without fallback protection.

## Solution

1. In `CesiumControlHost.removeControl`, invoke `control.onRemove(facade)` with the control element still attached to its corner container, within a `try...catch...finally` block. In `finally`, ensure any remaining attachment is safely removed via `if (el.parentElement) el.parentElement.removeChild(el)`, and delete the control from the internal registry.
2. In `CesiumControlHost.addControl`, validate that `el` returned from `onAdd` is a valid element with style properties, and ensure the target corner falls back safely to `top-right` if an unrecognized position is passed.
3. Clean up `CesiumMapFacade` constructor typing to use `CesiumWidget` instead of `any`.
4. Add comprehensive unit test coverage in `tests/cesium-control-host.test.ts` exercising mounting, position fallback, error resilience, direct `parentNode.removeChild` teardown handling, and facade camera getters.

## Testing

- Added 9 unit tests in `tests/cesium-control-host.test.ts` verifying:
  - Corner container creation and pointer-event CSS.
  - Correct corner placement and unrecognized position fallback.
  - Handling of throwing `onAdd` without polluting registry.
  - Safe teardown when `onRemove` detaches its container from `parentNode` directly.
  - Safe teardown when `onRemove` throws an error.
  - `destroy()` cleanly tears down multiple controls even if one throws.
  - `CesiumMapFacade` active camera orientation getters and unsupported style spec rejections.
  - Primary host singleton registration and retrieval.
- Ran `node --import tsx --test tests/cesium-control-host.test.ts tests/cesium-engine.test.ts` (39 tests pass).
- Passed `npx eslint packages/map/src/cesium-control-host.ts tests/cesium-control-host.test.ts`.

## Scope

Does not alter layer synchronization or MapEngine interfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved map control validation and handling of invalid or unsupported positions.
  - Ensured controls and containers are cleaned up reliably, even when lifecycle callbacks fail.
  - Prevented duplicate controls from being mounted.

- **Documentation**
  - Added guidance for mounting and removing map controls.

- **Tests**
  - Added coverage for control mounting, positioning, removal, error handling, teardown, camera and source APIs, and host tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->