### PR TITLE
feat(plugins): declare engine support and gate Plugins menu on active renderer (#2262)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
@@ -12,7 +12,9 @@ import {
   ROUTE_ANIMATION_PLUGIN_ID,
   SUN_PLUGIN_ID,
   WEB_SERVICE_PLUGIN_IDS,
+  isPluginEngineSupported,
 } from "@geolibre/plugins";
+import { useAppStore } from "@geolibre/core";
 import {
   Button,
   DropdownMenu,
@@ -66,13 +68,22 @@ export function PluginsMenu({
   hiddenPluginIds,
 }: PluginsMenuProps) {
   const { t } = useTranslation();
+  const primaryRenderer = useAppStore((state) => state.primaryRenderer);
 
   const renderPluginMenuItem = (p: RegisteredPlugin) => {
+    const isSupported = isPluginEngineSupported(p, primaryRenderer);
     const pluginPosition = getMapControlPosition(p.id);
     const pluginName = pluginDisplayName(t, p);
     if (!pluginPosition) {
       return (
-        <DropdownMenuItem key={p.id} onClick={() => toggle(p.id, appApi)}>
+        <DropdownMenuItem
+          key={p.id}
+          disabled={!isSupported}
+          onClick={() => {
+            if (!isSupported) return;
+            toggle(p.id, appApi);
+          }}
+        >
           {pluginName}
           {isActive(p.id) ? " ✓" : ""}
         </DropdownMenuItem>
@@ -81,26 +92,34 @@ export function PluginsMenu({
 
     return (
       <DropdownMenuSub key={p.id}>
-        <DropdownMenuSubTrigger>
+        <DropdownMenuSubTrigger disabled={!isSupported}>
           {pluginName}
           {isActive(p.id) ? " ✓" : ""}
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent>
-          <DropdownMenuItem onClick={() => toggle(p.id, appApi)}>
+          <DropdownMenuItem
+            disabled={!isSupported}
+            onClick={() => {
+              if (!isSupported) return;
+              toggle(p.id, appApi);
+            }}
+          >
             {isActive(p.id) ? t("toolbar.item.deactivate") : t("toolbar.item.activate")}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel>{t("toolbar.item.position")}</DropdownMenuLabel>
           <DropdownMenuRadioGroup
             value={pluginPosition}
-            onValueChange={(position: string) =>
-              setMapControlPosition(p.id, appApi, position as GeoLibreMapControlPosition)
-            }
+            onValueChange={(position: string) => {
+              if (!isSupported) return;
+              setMapControlPosition(p.id, appApi, position as GeoLibreMapControlPosition);
+            }}
           >
             {PLUGIN_POSITION_ITEMS.map((position) => (
               <DropdownMenuRadioItem
                 key={position.value}
                 value={position.value}
+                disabled={!isSupported}
                 onSelect={(event: Event) => event.preventDefault()}
               >
                 {t(position.labelKey)}
@@ -125,6 +144,11 @@ export function PluginsMenu({
   // The DGGS grid plugins (H3, S2, A5) render as one grouped submenu, placed
   // where the first of them appears in registration order.
   let dggsRendered = false;
+
+  const dggsSupported = dggsPlugins.some((p) => isPluginEngineSupported(p, primaryRenderer));
+  const webServicesSupported = webServicePlugins.some((p) =>
+    isPluginEngineSupported(p, primaryRenderer),
+  );
 
   return (
     <DropdownMenu>
@@ -178,7 +202,7 @@ export function PluginsMenu({
             dggsRendered = true;
             return (
               <DropdownMenuSub key="dggs">
-                <DropdownMenuSubTrigger>
+                <DropdownMenuSubTrigger disabled={!dggsSupported}>
                   {t("toolbar.item.dggs")}
                   {dggsPlugins.some((plugin) => isActive(plugin.id)) ? " ✓" : ""}
                 </DropdownMenuSubTrigger>
@@ -199,7 +223,7 @@ export function PluginsMenu({
           webServicesRendered = true;
           return (
             <DropdownMenuSub key="web-services">
-              <DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger disabled={!webServicesSupported}>
                 {t("toolbar.item.webServices")}
                 {webServicePlugins.some((plugin) => isActive(plugin.id)) ? " ✓" : ""}
               </DropdownMenuSubTrigger>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
@@ -72,15 +72,20 @@ export function PluginsMenu({
 
   const renderPluginMenuItem = (p: RegisteredPlugin) => {
     const isSupported = isPluginEngineSupported(p, primaryRenderer);
+    // A plugin that was activated under another renderer stays active after a
+    // renderer switch, so its toggle must keep working even when the new
+    // renderer does not support it — otherwise the only way to turn it off is
+    // to switch the renderer back.
+    const canToggle = isSupported || isActive(p.id);
     const pluginPosition = getMapControlPosition(p.id);
     const pluginName = pluginDisplayName(t, p);
     if (!pluginPosition) {
       return (
         <DropdownMenuItem
           key={p.id}
-          disabled={!isSupported}
+          disabled={!canToggle}
           onClick={() => {
-            if (!isSupported) return;
+            if (!canToggle) return;
             toggle(p.id, appApi);
           }}
         >
@@ -92,15 +97,15 @@ export function PluginsMenu({
 
     return (
       <DropdownMenuSub key={p.id}>
-        <DropdownMenuSubTrigger disabled={!isSupported}>
+        <DropdownMenuSubTrigger disabled={!canToggle}>
           {pluginName}
           {isActive(p.id) ? " ✓" : ""}
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent>
           <DropdownMenuItem
-            disabled={!isSupported}
+            disabled={!canToggle}
             onClick={() => {
-              if (!isSupported) return;
+              if (!canToggle) return;
               toggle(p.id, appApi);
             }}
           >
@@ -145,9 +150,13 @@ export function PluginsMenu({
   // where the first of them appears in registration order.
   let dggsRendered = false;
 
-  const dggsSupported = dggsPlugins.some((p) => isPluginEngineSupported(p, primaryRenderer));
-  const webServicesSupported = webServicePlugins.some((p) =>
-    isPluginEngineSupported(p, primaryRenderer),
+  // Grouped submenus open when at least one member is usable on the active
+  // renderer, or is still active from a previous one and needs turning off.
+  const dggsSupported = dggsPlugins.some(
+    (p) => isPluginEngineSupported(p, primaryRenderer) || isActive(p.id),
+  );
+  const webServicesSupported = webServicePlugins.some(
+    (p) => isPluginEngineSupported(p, primaryRenderer) || isActive(p.id),
   );
 
   return (

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -410,6 +410,9 @@ async function importExternalPlugin(bundle: ExternalPluginBundle): Promise<GeoLi
     if (candidate.activeByDefault) {
       throw new Error("External plugins cannot use activeByDefault.");
     }
+    if (bundle.manifest.engines && !candidate.engines) {
+      candidate.engines = bundle.manifest.engines;
+    }
     return candidate;
   } finally {
     URL.revokeObjectURL(moduleUrl);

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -392,6 +392,13 @@ async function fetchPluginText(url: string, label: string, signal?: AbortSignal)
   return new TextDecoder().decode(merged);
 }
 
+/**
+ * Imports an external plugin bundle by creating an ephemeral object URL, verifying its export contract,
+ * and propagating manifest engines metadata when omitted by the candidate plugin.
+ *
+ * @param bundle - The unpacked external plugin bundle.
+ * @returns A promise resolving to the validated {@link GeoLibrePlugin}.
+ */
 async function importExternalPlugin(bundle: ExternalPluginBundle): Promise<GeoLibrePlugin> {
   const moduleUrl = URL.createObjectURL(
     new Blob([bundle.entrySource], { type: "text/javascript" }),

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -15,6 +15,7 @@ import {
   bundleFromZipBytes,
   type ExternalPluginBundle,
   isExternalPluginManifest,
+  isPluginEngineList,
   MAX_PLUGIN_ASSET_BYTES,
 } from "./plugin-archive-unpack";
 import {
@@ -416,6 +417,12 @@ async function importExternalPlugin(bundle: ExternalPluginBundle): Promise<GeoLi
     validateManifestMatchesPlugin(bundle.manifest, candidate);
     if (candidate.activeByDefault) {
       throw new Error("External plugins cannot use activeByDefault.");
+    }
+    // The manifest's engines are validated by isExternalPluginManifest; the
+    // exported plugin's own engines are not, so check them here rather than
+    // letting an unexpected value reach isPluginEngineSupported.
+    if (candidate.engines !== undefined && !isPluginEngineList(candidate.engines)) {
+      throw new Error('Plugin engines must be an array of "maplibre" or "cesium".');
     }
     if (bundle.manifest.engines && !candidate.engines) {
       candidate.engines = bundle.manifest.engines;

--- a/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
@@ -26,6 +26,12 @@ function isRequiredManifestString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0 && value.trim() === value;
 }
 
+/**
+ * Type guard validating that a candidate object conforms to the GeoLibre external plugin manifest schema.
+ *
+ * @param value - The unknown value to validate.
+ * @returns `true` if the value is a valid {@link GeoLibreExternalPluginManifest}, otherwise `false`.
+ */
 export function isExternalPluginManifest(value: unknown): value is GeoLibreExternalPluginManifest {
   if (!value || typeof value !== "object") return false;
   const manifest = value as Partial<GeoLibreExternalPluginManifest>;

--- a/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
@@ -38,7 +38,10 @@ export function isExternalPluginManifest(value: unknown): value is GeoLibreExter
     (manifest.description === undefined || typeof manifest.description === "string") &&
     (manifest.style === undefined ||
       (typeof manifest.style === "string" && manifest.style.endsWith(".css"))) &&
-    (manifest.activeByDefault === undefined || typeof manifest.activeByDefault === "boolean")
+    (manifest.activeByDefault === undefined || typeof manifest.activeByDefault === "boolean") &&
+    (manifest.engines === undefined ||
+      (Array.isArray(manifest.engines) &&
+        manifest.engines.every((e) => e === "maplibre" || e === "cesium")))
   );
 }
 

--- a/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
@@ -27,6 +27,21 @@ function isRequiredManifestString(value: unknown): value is string {
 }
 
 /**
+ * Type guard for a declared renderer list: an array whose every entry is a
+ * known renderer kind (`"maplibre"` or `"cesium"`). Shared by the manifest
+ * check below and the external-plugin loader, which validates the same field
+ * on the plugin a bundle exports.
+ *
+ * @param value - The unknown value to validate.
+ * @returns `true` when the value is a valid engines array, otherwise `false`.
+ */
+export function isPluginEngineList(value: unknown): value is ("maplibre" | "cesium")[] {
+  return (
+    Array.isArray(value) && value.every((engine) => engine === "maplibre" || engine === "cesium")
+  );
+}
+
+/**
  * Type guard validating that a candidate object conforms to the GeoLibre external plugin manifest schema.
  *
  * @param value - The unknown value to validate.
@@ -45,9 +60,7 @@ export function isExternalPluginManifest(value: unknown): value is GeoLibreExter
     (manifest.style === undefined ||
       (typeof manifest.style === "string" && manifest.style.endsWith(".css"))) &&
     (manifest.activeByDefault === undefined || typeof manifest.activeByDefault === "boolean") &&
-    (manifest.engines === undefined ||
-      (Array.isArray(manifest.engines) &&
-        manifest.engines.every((e) => e === "maplibre" || e === "cesium")))
+    (manifest.engines === undefined || isPluginEngineList(manifest.engines))
   );
 }
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -6,11 +6,7 @@
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { IControl } from "maplibre-gl";
 
-export type GeoLibreMapControlPosition =
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+export type GeoLibreMapControlPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 
 export type GeoLibreBuiltInMapControl =
   | "navigation"
@@ -28,16 +24,21 @@ export interface GeoLibrePlugin {
   name: string;
   version: string;
   activeByDefault?: boolean;
+  /**
+   * Renderers this plugin supports. Defaults to `["maplibre"]`.
+   * Engine-neutral plugins (e.g. catalog/service browsers that only write to
+   * the GeoLibre store) or plugins with multi-engine adapters declare
+   * `["maplibre", "cesium"]`. The Plugins menu gates options against the active
+   * renderer.
+   */
+  engines?: ("maplibre" | "cesium")[];
   /** Plugins in the same group cannot be active at the same time. */
   exclusiveGroup?: string;
   /** At least one name is required for handleUrlParameters to be called. */
   urlParameterNames?: string[];
   activate: (app: GeoLibreAppAPI) => boolean | void;
   deactivate: (app: GeoLibreAppAPI) => void;
-  handleUrlParameters?: (
-    app: GeoLibreAppAPI,
-    params: URLSearchParams,
-  ) => void | Promise<void>;
+  handleUrlParameters?: (app: GeoLibreAppAPI, params: URLSearchParams) => void | Promise<void>;
   getMapControlPosition?: () => GeoLibreMapControlPosition;
   setMapControlPosition?: (
     app: GeoLibreAppAPI,
@@ -72,48 +73,26 @@ export interface GeoLibreSelection {
 
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
-  addGeoJsonLayer: (
-    name: string,
-    data: FeatureCollection,
-    sourcePath?: string,
-  ) => string;
+  addGeoJsonLayer: (name: string, data: FeatureCollection, sourcePath?: string) => string;
   listLayers?: () => GeoLibreLayerSummary[];
   getLayerFeatures?: (layerId: string) => Feature<Geometry | null>[];
   getSelectedFeatures?: () => Feature<Geometry | null>[];
   getSelectedLayerId?: () => string | null;
   getDrawnFeatures?: () => Feature<Geometry | null>[];
-  onSelectionChange?: (
-    callback: (selection: GeoLibreSelection) => void,
-  ) => () => void;
+  onSelectionChange?: (callback: (selection: GeoLibreSelection) => void) => () => void;
   // Native raster/tile layers (see "Raster and tile layers" below). Each
   // returns the new layer's id and the layer appears in the Layers panel and
   // persists with the project, like addGeoJsonLayer does for vector data.
-  addTileLayer?: (
-    name: string,
-    url: string,
-    options?: GeoLibreTileLayerOptions,
-  ) => string;
-  addWmtsLayer?: (
-    name: string,
-    url: string,
-    options?: GeoLibreTileLayerOptions,
-  ) => string;
+  addTileLayer?: (name: string, url: string, options?: GeoLibreTileLayerOptions) => string;
+  addWmtsLayer?: (name: string, url: string, options?: GeoLibreTileLayerOptions) => string;
   addWmsLayer?: (name: string, options: GeoLibreWmsLayerOptions) => string;
   // Native client-side COG (reads the GeoTIFF directly; band/rescale/colormap/
   // nodata controls). Resolves with the new layer's id (see "Raster and tile
   // layers" below).
-  addCogLayer?: (
-    name: string,
-    url: string,
-    options?: GeoLibreCogLayerOptions,
-  ) => Promise<string>;
+  addCogLayer?: (name: string, url: string, options?: GeoLibreCogLayerOptions) => Promise<string>;
   // Zarr through the host's own @carbonplan/zarr-layer instance, with
   // crs/proj4 reprojection (see "Zarr layers" below).
-  addZarrLayer?: (
-    name: string,
-    url: string,
-    options: GeoLibreZarrLayerOptions,
-  ) => Promise<string>;
+  addZarrLayer?: (name: string, url: string, options: GeoLibreZarrLayerOptions) => Promise<string>;
   setZarrLayerSelector?: (
     layerId: string,
     selector: Record<string, number | string>,
@@ -127,30 +106,20 @@ export interface GeoLibreAppAPI {
   ) => Promise<GeoLibreZarrQueryResult | null>;
   // Register a layer the plugin added to the map itself, so it appears in the
   // Layers panel (see "Custom (WebGL) layers and paint ownership" below).
-  registerExternalNativeLayer?: (
-    layer: GeoLibreExternalNativeLayerRegistration,
-  ) => void;
+  registerExternalNativeLayer?: (layer: GeoLibreExternalNativeLayerRegistration) => void;
   unregisterExternalNativeLayer?: (id: string) => void;
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => import("maplibre-gl").Map | null;
-  addMapControl: (
-    control: IControl,
-    position?: GeoLibreMapControlPosition,
-  ) => boolean;
+  addMapControl: (control: IControl, position?: GeoLibreMapControlPosition) => boolean;
   removeMapControl: (control: IControl) => void;
   // Note: showing the "terrain" control (visible: true) also switches 3D
   // terrain on, mirroring the Controls menu so the user doesn't have to click
   // the control button as a second step. Hiding it turns terrain back off.
-  setBuiltInMapControlVisible: (
-    control: GeoLibreBuiltInMapControl,
-    visible: boolean,
-  ) => boolean;
-  getBuiltInMapControlPosition: (
-    control: GeoLibreBuiltInMapControl,
-  ) => GeoLibreMapControlPosition;
+  setBuiltInMapControlVisible: (control: GeoLibreBuiltInMapControl, visible: boolean) => boolean;
+  getBuiltInMapControlPosition: (control: GeoLibreBuiltInMapControl) => GeoLibreMapControlPosition;
   setBuiltInMapControlPosition: (
     control: GeoLibreBuiltInMapControl,
     position: GeoLibreMapControlPosition,
@@ -192,7 +161,14 @@ export interface GeoLibreToolbarMenu {
 }
 
 export type GeoLibreToolbarMenuItem =
-  | { type?: "action"; id: string; label: string; icon?: string; disabled?: boolean; onSelect: () => void }
+  | {
+      type?: "action";
+      id: string;
+      label: string;
+      icon?: string;
+      disabled?: boolean;
+      onSelect: () => void;
+    }
   | { type: "submenu"; id: string; label: string; icon?: string; items: GeoLibreToolbarMenuItem[] }
   | { type: "separator"; id?: string };
 
@@ -370,7 +346,7 @@ change. If you also touched pages under `docs/`, build the site — CI runs
 | `maplibre-gl-basemap-control` | Adds a MapLibre basemap picker                                                                                      |
 | `maplibre-gl-components`      | Adds the MapLibre Components control grid and panels for FlatGeobuf, COG, PMTiles, Zarr, LiDAR, and Gaussian splats |
 | `maplibre-gl-geo-editor`      | Adds GeoEditor drawing controls                                                                                     |
-| `maplibre-gl-dimensions`      | Adds Dimension tools (linear/angular CAD-style dimension lines, with optional vertex snapping)                     |
+| `maplibre-gl-dimensions`      | Adds Dimension tools (linear/angular CAD-style dimension lines, with optional vertex snapping)                      |
 | `maplibre-gl-geoagent`        | Adds GeoAgent map assistant controls                                                                                |
 | `maplibre-gl-lidar`           | Adds LiDAR controls                                                                                                 |
 | `maplibre-gl-streetview`      | Adds street view controls                                                                                           |
@@ -546,11 +522,10 @@ app.addWmsLayer?.("LINZ Coverage", {
 });
 
 // COG — read the GeoTIFF directly (client-side), with raster controls.
-const cogId = await app.addCogLayer?.(
-  "LINZ DEM",
-  "https://cog.example.nz/dem.tif",
-  { colormap: "terrain", nodata: -9999 },
-);
+const cogId = await app.addCogLayer?.("LINZ DEM", "https://cog.example.nz/dem.tif", {
+  colormap: "terrain",
+  nodata: -9999,
+});
 ```
 
 `options.engine` picks the renderer (`"maplibre-gl-raster"` for the GPU/deck.gl path, `"cog-tiler-wasm"` for the WebAssembly tiler, `"titiler"` for a TiTiler server). Unlike the other options it is **not per layer**: the raster control holds one engine for every raster it manages, so naming one re-renders the rasters already on the map. Pass `"auto"` to leave whatever the control is on alone; omit it and the GPU renderer is used. The GPU renderer requires a Mercator projection, so a plugin that expects to work on the globe should ask for `"cog-tiler-wasm"`.
@@ -569,17 +544,17 @@ Do not bundle `@carbonplan/zarr-layer` in a plugin: a second copy ships a duplic
 
 ```typescript
 export interface GeoLibreZarrLayerOptions {
-  variable: string;                            // array to render (required)
-  selector?: Record<string, number | string>;  // non-spatial dims, e.g. { time: 0 }
+  variable: string; // array to render (required)
+  selector?: Record<string, number | string>; // non-spatial dims, e.g. { time: 0 }
   clim?: [number, number];
-  colormap?: string | string[];                // named ramp ("viridis") or hex stops
+  colormap?: string | string[]; // named ramp ("viridis") or hex stops
   opacity?: number;
   zarrVersion?: 2 | 3;
-  crs?: string;                                // e.g. "EPSG:32633"
-  proj4?: string;                              // for a CRS with no built-in
-  bounds?: [number, number, number, number];   // [xMin, yMin, xMax, yMax] in the store's CRS
+  crs?: string; // e.g. "EPSG:32633"
+  proj4?: string; // for a CRS with no built-in
+  bounds?: [number, number, number, number]; // [xMin, yMin, xMax, yMax] in the store's CRS
   spatialDimensions?: { lat?: string; lon?: string };
-  headers?: Record<string, string>;            // authenticated stores
+  headers?: Record<string, string>; // authenticated stores
   beforeLayerId?: string;
 }
 ```
@@ -588,17 +563,13 @@ export interface GeoLibreZarrLayerOptions {
 // A projected national grid: crs/proj4 are forwarded to the renderer, which
 // reprojects on the GPU. Without them the store is read as WGS84 and lands in
 // the wrong place.
-const layerId = await app.addZarrLayer?.(
-  "seNorge tmax",
-  "https://example.no/senorge.zarr",
-  {
-    variable: "tmax",
-    selector: { time: 0 },
-    clim: [-30, 30],
-    colormap: "viridis",
-    crs: "EPSG:32633",
-  },
-);
+const layerId = await app.addZarrLayer?.("seNorge tmax", "https://example.no/senorge.zarr", {
+  variable: "tmax",
+  selector: { time: 0 },
+  clim: [-30, 30],
+  colormap: "viridis",
+  crs: "EPSG:32633",
+});
 
 // Drive a time slider without rebuilding the layer: the renderer keeps the
 // chunks it already fetched. (`addZarrLayer` is optional, so guard the id.)
@@ -617,7 +588,7 @@ if (layerId) {
 
 ```typescript
 export type GeoLibreZarrQueryGeometry =
-  | { type: "Point"; coordinates: [number, number] }        // WGS84 lng/lat
+  | { type: "Point"; coordinates: [number, number] } // WGS84 lng/lat
   | { type: "Polygon"; coordinates: number[][][] }
   | { type: "MultiPolygon"; coordinates: number[][][][] };
 
@@ -625,12 +596,16 @@ export type GeoLibreZarrQueryGeometry =
 // (e.g. { month: [1, 7] }) nests the returned values by that dimension.
 export type GeoLibreZarrQuerySelector = Record<
   string,
-  number | string | number[] | string[] | { selected: number | string | number[] | string[]; type?: "index" | "value" }
+  | number
+  | string
+  | number[]
+  | string[]
+  | { selected: number | string | number[] | string[]; type?: "index" | "value" }
 >;
 
 export interface GeoLibreZarrQueryOptions {
-  signal?: AbortSignal;                    // cancel a query the user moved past
-  includeSpatialCoordinates?: boolean;     // default true
+  signal?: AbortSignal; // cancel a query the user moved past
+  includeSpatialCoordinates?: boolean; // default true
 }
 
 // { [variable]: values, dimensions, coordinates }
@@ -667,15 +642,15 @@ The panel can also open a store from a folder on disk, via a **Browse folder** b
 
 ## Driving a layer's own time dimension from the Time Slider
 
-The Time Slider understands three kinds of temporal layer. Two are built in: a **vector** layer filtered by a timestamp property, and a **raster time series** of dated sources the dock steps between. The third is for a layer that is *one store* with time as an **internal dimension** — a Zarr data cube, or a plugin's own frame-based layer — where the timeline picks a slice rather than a source.
+The Time Slider understands three kinds of temporal layer. Two are built in: a **vector** layer filtered by a timestamp property, and a **raster time series** of dated sources the dock steps between. The third is for a layer that is _one store_ with time as an **internal dimension** — a Zarr data cube, or a plugin's own frame-based layer — where the timeline picks a slice rather than a source.
 
 That third kind is expressed as a **temporal adapter**:
 
 ```typescript
 export interface TemporalLayerAdapter {
-  getTimeValues: () => ReadonlyArray<Date | number | string>;  // the time coordinate, in index order
-  setTime: (date: Date) => void | Promise<void>;               // apply a date to the layer
-  dimension?: string;                                          // the axis name, default "time"
+  getTimeValues: () => ReadonlyArray<Date | number | string>; // the time coordinate, in index order
+  setTime: (date: Date) => void | Promise<void>; // apply a date to the layer
+  dimension?: string; // the axis name, default "time"
 }
 ```
 
@@ -703,7 +678,7 @@ Call the returned function, or `app.unregisterTemporalLayer?.(layerId)`, to drop
 
 A bound cube shares the timeline with any vector bindings and dated overlays: the track spans the union of their extents, and the widest dataset sets the stepping granularity.
 
-**Closing the dock again.** A dock that a binding opened closes itself once the last temporal layer is gone, so it never lingers over a map with no timeline. Removing the bound layer is enough; if your plugin keeps the layer and only drops its binding, clear `layer.metadata.timeBinding` as well as unregistering the adapter. A dock the *user* opened from the Plugins menu is left alone, and so is one that still has raster sources of its own or a KML `<TimeSpan>` overlay to drive.
+**Closing the dock again.** A dock that a binding opened closes itself once the last temporal layer is gone, so it never lingers over a map with no timeline. Removing the bound layer is enough; if your plugin keeps the layer and only drops its binding, clear `layer.metadata.timeBinding` as well as unregistering the adapter. A dock the _user_ opened from the Plugins menu is left alone, and so is one that still has raster sources of its own or a KML `<TimeSpan>` overlay to drive.
 
 ## Activating and deactivating other plugins
 
@@ -724,19 +699,20 @@ Neither may target the **calling** plugin: `activatePlugin` on yourself is meani
 export interface GeoLibreExternalNativeLayerRegistration {
   id: string;
   name: string;
-  type?: GeoLibreLayer["type"];        // closest built-in type, e.g. "raster"
-  nativeLayerIds: string[];            // the MapLibre layer id(s) you added
+  type?: GeoLibreLayer["type"]; // closest built-in type, e.g. "raster"
+  nativeLayerIds: string[]; // the MapLibre layer id(s) you added
   source?: Record<string, unknown>;
   sourceIds?: string[];
   sourceId?: string;
-  geojson?: FeatureCollection;         // for vector layers
+  geojson?: FeatureCollection; // for vector layers
   beforeId?: string;
   opacity?: number;
   style?: Partial<LayerStyle>;
   metadata?: Record<string, unknown>;
   sourcePath?: string;
-  paintMode?: "geolibre" | "plugin";   // see below
-  paintBridge?: {                      // see below
+  paintMode?: "geolibre" | "plugin"; // see below
+  paintBridge?: {
+    // see below
     setOpacity?: (opacity: number) => void;
     setVisibility?: (visible: boolean) => void;
   };
@@ -814,7 +790,7 @@ Notes:
 - The panel is a flex sibling of the map, so opening it shrinks the map view (the map keeps filling the remaining space); no manual map padding is required.
 - **Dock position:** a panel docks at one of four positions (left to right): `left-of-layers`, `right-of-layers` (between Layers and the map), `left-of-style` (between the map and Style), or `right-of-style` (the default). Set `dock` on the registration to choose the initial position. The user steps the panel between positions at runtime with the two move buttons in the panel header (disabled at the ends), and a plugin can set it directly with `app.setActiveRightPanelDock?.(...)`. The position resets to the panel's declared `dock` when it closes or another panel opens.
 - **Shared-rail modes (`replace-style` / `replace-layers`):** two non-positional docks for workbench-style plugins that want to feel like a first-class sidebar workspace rather than a second rail beside Style (right) or Layers (left). Register with `dock: "replace-style"` (or `"replace-layers"`) and the host shows a single rail on that edge listing both your panel and the built-in panel; selecting one expands it while the other stays as a rail entry. The two are mutually exclusive, so the user never sees two adjacent rails. The built-in panel starts collapsed so the workbench reads as the active workspace, and the user can expand it (which collapses the workbench) at any time. Everything else (chrome, resize, collapse, close, lifecycle hooks) is unchanged.
-- **Switching modes at runtime:** the modes are not exclusive choices baked in at registration. In a positional dock the panel header shows a **merge** button that joins the shared rail on its current side — a layers-side panel (`left-of-layers`/`right-of-layers`) joins the Layers rail, a style-side panel the Style rail. In a shared rail it shows a **detach** button that pops the panel back out to a movable positional panel on the same side (`right-of-layers` / `right-of-style`), where the left/right move buttons return. A plugin can drive the same switch with `app.setActiveRightPanelDock?.("replace-style" | "replace-layers" | "right-of-style" | ...)`. The shared rails are not part of the left/right *step* sequence (the arrows only walk the four positional docks); merge/detach is the way in and out.
+- **Switching modes at runtime:** the modes are not exclusive choices baked in at registration. In a positional dock the panel header shows a **merge** button that joins the shared rail on its current side — a layers-side panel (`left-of-layers`/`right-of-layers`) joins the Layers rail, a style-side panel the Style rail. In a shared rail it shows a **detach** button that pops the panel back out to a movable positional panel on the same side (`right-of-layers` / `right-of-style`), where the left/right move buttons return. A plugin can drive the same switch with `app.setActiveRightPanelDock?.("replace-style" | "replace-layers" | "right-of-style" | ...)`. The shared rails are not part of the left/right _step_ sequence (the arrows only walk the four positional docks); merge/detach is the way in and out.
 - These methods are typed optional for forward-compatibility with host variants that have no right sidebar, so call them with optional chaining (`app.registerRightPanel?.(...)`).
 
 ## Toolbar menus
@@ -831,9 +807,7 @@ const unregister = app.registerToolbarMenu?.({
       type: "submenu",
       id: "tools",
       label: "Tools",
-      items: [
-        { id: "qa", label: "Data QA", onSelect: () => app.openFloatingPanel?.("my-qa") },
-      ],
+      items: [{ id: "qa", label: "Data QA", onSelect: () => app.openFloatingPanel?.("my-qa") }],
     },
     { type: "separator" },
     { id: "about", label: "About", disabled: false, onSelect: () => {} },
@@ -905,9 +879,9 @@ const unregister = app.registerFloatingPanel?.({
   },
 });
 
-app.openFloatingPanel?.("my-qa");   // open (or bring to front)
-app.closeFloatingPanel?.("my-qa");  // close
-app.getOpenFloatingPanels?.();      // -> string[] of open ids, stacking order
+app.openFloatingPanel?.("my-qa"); // open (or bring to front)
+app.closeFloatingPanel?.("my-qa"); // close
+app.getOpenFloatingPanels?.(); // -> string[] of open ids, stacking order
 ```
 
 Use a right panel for a primary, persistent workspace and a floating panel for an ancillary tool or dashboard the user positions over the map. As with the other surfaces, call these methods with optional chaining since they are typed optional.
@@ -959,11 +933,12 @@ If instead you want a plugin compiled into the main JS bundle (no `plugin.json`,
   "version": "0.1.0",
   "entry": "dist/index.js",
   "description": "Optional short description",
-  "style": "dist/style.css"
+  "style": "dist/style.css",
+  "engines": ["maplibre", "cesium"]
 }
 ```
 
-The `entry` file must export a `GeoLibrePlugin` as either the default export or a named `plugin` export. The exported plugin `id`, `name`, and `version` must match `plugin.json`. The entry must be a self-contained `.js` or `.mjs` bundle because relative module imports inside the zip are not resolved by this first loader.
+The `entry` file must export a `GeoLibrePlugin` as either the default export or a named `plugin` export. The exported plugin `id`, `name`, and `version` must match `plugin.json`. The entry must be a self-contained `.js` or `.mjs` bundle because relative module imports inside the zip are not resolved by this first loader. The optional `engines` array declares which map renderers the plugin supports (`"maplibre" | "cesium"`, defaulting to `["maplibre"]`); plugins supporting the 3D globe declare `["maplibre", "cesium"]` so users can toggle them when Cesium is active.
 
 External plugin entries are executed with `import(URL.createObjectURL(...))`, which is why the desktop CSP in `tauri.conf.json` includes `blob:` in `script-src`. Removing `blob:` from `script-src` breaks external plugin loading. Combined with `'unsafe-eval'`, this means code that can create a blob URL can execute scripts, which is acceptable because external plugins are trusted local files installed by the user.
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -6,7 +6,11 @@
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { IControl } from "maplibre-gl";
 
-export type GeoLibreMapControlPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+export type GeoLibreMapControlPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
 
 export type GeoLibreBuiltInMapControl =
   | "navigation"
@@ -38,7 +42,10 @@ export interface GeoLibrePlugin {
   urlParameterNames?: string[];
   activate: (app: GeoLibreAppAPI) => boolean | void;
   deactivate: (app: GeoLibreAppAPI) => void;
-  handleUrlParameters?: (app: GeoLibreAppAPI, params: URLSearchParams) => void | Promise<void>;
+  handleUrlParameters?: (
+    app: GeoLibreAppAPI,
+    params: URLSearchParams,
+  ) => void | Promise<void>;
   getMapControlPosition?: () => GeoLibreMapControlPosition;
   setMapControlPosition?: (
     app: GeoLibreAppAPI,
@@ -73,26 +80,48 @@ export interface GeoLibreSelection {
 
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
-  addGeoJsonLayer: (name: string, data: FeatureCollection, sourcePath?: string) => string;
+  addGeoJsonLayer: (
+    name: string,
+    data: FeatureCollection,
+    sourcePath?: string,
+  ) => string;
   listLayers?: () => GeoLibreLayerSummary[];
   getLayerFeatures?: (layerId: string) => Feature<Geometry | null>[];
   getSelectedFeatures?: () => Feature<Geometry | null>[];
   getSelectedLayerId?: () => string | null;
   getDrawnFeatures?: () => Feature<Geometry | null>[];
-  onSelectionChange?: (callback: (selection: GeoLibreSelection) => void) => () => void;
+  onSelectionChange?: (
+    callback: (selection: GeoLibreSelection) => void,
+  ) => () => void;
   // Native raster/tile layers (see "Raster and tile layers" below). Each
   // returns the new layer's id and the layer appears in the Layers panel and
   // persists with the project, like addGeoJsonLayer does for vector data.
-  addTileLayer?: (name: string, url: string, options?: GeoLibreTileLayerOptions) => string;
-  addWmtsLayer?: (name: string, url: string, options?: GeoLibreTileLayerOptions) => string;
+  addTileLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreTileLayerOptions,
+  ) => string;
+  addWmtsLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreTileLayerOptions,
+  ) => string;
   addWmsLayer?: (name: string, options: GeoLibreWmsLayerOptions) => string;
   // Native client-side COG (reads the GeoTIFF directly; band/rescale/colormap/
   // nodata controls). Resolves with the new layer's id (see "Raster and tile
   // layers" below).
-  addCogLayer?: (name: string, url: string, options?: GeoLibreCogLayerOptions) => Promise<string>;
+  addCogLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreCogLayerOptions,
+  ) => Promise<string>;
   // Zarr through the host's own @carbonplan/zarr-layer instance, with
   // crs/proj4 reprojection (see "Zarr layers" below).
-  addZarrLayer?: (name: string, url: string, options: GeoLibreZarrLayerOptions) => Promise<string>;
+  addZarrLayer?: (
+    name: string,
+    url: string,
+    options: GeoLibreZarrLayerOptions,
+  ) => Promise<string>;
   setZarrLayerSelector?: (
     layerId: string,
     selector: Record<string, number | string>,
@@ -106,20 +135,30 @@ export interface GeoLibreAppAPI {
   ) => Promise<GeoLibreZarrQueryResult | null>;
   // Register a layer the plugin added to the map itself, so it appears in the
   // Layers panel (see "Custom (WebGL) layers and paint ownership" below).
-  registerExternalNativeLayer?: (layer: GeoLibreExternalNativeLayerRegistration) => void;
+  registerExternalNativeLayer?: (
+    layer: GeoLibreExternalNativeLayerRegistration,
+  ) => void;
   unregisterExternalNativeLayer?: (id: string) => void;
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => import("maplibre-gl").Map | null;
-  addMapControl: (control: IControl, position?: GeoLibreMapControlPosition) => boolean;
+  addMapControl: (
+    control: IControl,
+    position?: GeoLibreMapControlPosition,
+  ) => boolean;
   removeMapControl: (control: IControl) => void;
   // Note: showing the "terrain" control (visible: true) also switches 3D
   // terrain on, mirroring the Controls menu so the user doesn't have to click
   // the control button as a second step. Hiding it turns terrain back off.
-  setBuiltInMapControlVisible: (control: GeoLibreBuiltInMapControl, visible: boolean) => boolean;
-  getBuiltInMapControlPosition: (control: GeoLibreBuiltInMapControl) => GeoLibreMapControlPosition;
+  setBuiltInMapControlVisible: (
+    control: GeoLibreBuiltInMapControl,
+    visible: boolean,
+  ) => boolean;
+  getBuiltInMapControlPosition: (
+    control: GeoLibreBuiltInMapControl,
+  ) => GeoLibreMapControlPosition;
   setBuiltInMapControlPosition: (
     control: GeoLibreBuiltInMapControl,
     position: GeoLibreMapControlPosition,
@@ -161,14 +200,7 @@ export interface GeoLibreToolbarMenu {
 }
 
 export type GeoLibreToolbarMenuItem =
-  | {
-      type?: "action";
-      id: string;
-      label: string;
-      icon?: string;
-      disabled?: boolean;
-      onSelect: () => void;
-    }
+  | { type?: "action"; id: string; label: string; icon?: string; disabled?: boolean; onSelect: () => void }
   | { type: "submenu"; id: string; label: string; icon?: string; items: GeoLibreToolbarMenuItem[] }
   | { type: "separator"; id?: string };
 
@@ -346,7 +378,7 @@ change. If you also touched pages under `docs/`, build the site — CI runs
 | `maplibre-gl-basemap-control` | Adds a MapLibre basemap picker                                                                                      |
 | `maplibre-gl-components`      | Adds the MapLibre Components control grid and panels for FlatGeobuf, COG, PMTiles, Zarr, LiDAR, and Gaussian splats |
 | `maplibre-gl-geo-editor`      | Adds GeoEditor drawing controls                                                                                     |
-| `maplibre-gl-dimensions`      | Adds Dimension tools (linear/angular CAD-style dimension lines, with optional vertex snapping)                      |
+| `maplibre-gl-dimensions`      | Adds Dimension tools (linear/angular CAD-style dimension lines, with optional vertex snapping)                     |
 | `maplibre-gl-geoagent`        | Adds GeoAgent map assistant controls                                                                                |
 | `maplibre-gl-lidar`           | Adds LiDAR controls                                                                                                 |
 | `maplibre-gl-streetview`      | Adds street view controls                                                                                           |
@@ -522,10 +554,11 @@ app.addWmsLayer?.("LINZ Coverage", {
 });
 
 // COG — read the GeoTIFF directly (client-side), with raster controls.
-const cogId = await app.addCogLayer?.("LINZ DEM", "https://cog.example.nz/dem.tif", {
-  colormap: "terrain",
-  nodata: -9999,
-});
+const cogId = await app.addCogLayer?.(
+  "LINZ DEM",
+  "https://cog.example.nz/dem.tif",
+  { colormap: "terrain", nodata: -9999 },
+);
 ```
 
 `options.engine` picks the renderer (`"maplibre-gl-raster"` for the GPU/deck.gl path, `"cog-tiler-wasm"` for the WebAssembly tiler, `"titiler"` for a TiTiler server). Unlike the other options it is **not per layer**: the raster control holds one engine for every raster it manages, so naming one re-renders the rasters already on the map. Pass `"auto"` to leave whatever the control is on alone; omit it and the GPU renderer is used. The GPU renderer requires a Mercator projection, so a plugin that expects to work on the globe should ask for `"cog-tiler-wasm"`.
@@ -544,17 +577,17 @@ Do not bundle `@carbonplan/zarr-layer` in a plugin: a second copy ships a duplic
 
 ```typescript
 export interface GeoLibreZarrLayerOptions {
-  variable: string; // array to render (required)
-  selector?: Record<string, number | string>; // non-spatial dims, e.g. { time: 0 }
+  variable: string;                            // array to render (required)
+  selector?: Record<string, number | string>;  // non-spatial dims, e.g. { time: 0 }
   clim?: [number, number];
-  colormap?: string | string[]; // named ramp ("viridis") or hex stops
+  colormap?: string | string[];                // named ramp ("viridis") or hex stops
   opacity?: number;
   zarrVersion?: 2 | 3;
-  crs?: string; // e.g. "EPSG:32633"
-  proj4?: string; // for a CRS with no built-in
-  bounds?: [number, number, number, number]; // [xMin, yMin, xMax, yMax] in the store's CRS
+  crs?: string;                                // e.g. "EPSG:32633"
+  proj4?: string;                              // for a CRS with no built-in
+  bounds?: [number, number, number, number];   // [xMin, yMin, xMax, yMax] in the store's CRS
   spatialDimensions?: { lat?: string; lon?: string };
-  headers?: Record<string, string>; // authenticated stores
+  headers?: Record<string, string>;            // authenticated stores
   beforeLayerId?: string;
 }
 ```
@@ -563,13 +596,17 @@ export interface GeoLibreZarrLayerOptions {
 // A projected national grid: crs/proj4 are forwarded to the renderer, which
 // reprojects on the GPU. Without them the store is read as WGS84 and lands in
 // the wrong place.
-const layerId = await app.addZarrLayer?.("seNorge tmax", "https://example.no/senorge.zarr", {
-  variable: "tmax",
-  selector: { time: 0 },
-  clim: [-30, 30],
-  colormap: "viridis",
-  crs: "EPSG:32633",
-});
+const layerId = await app.addZarrLayer?.(
+  "seNorge tmax",
+  "https://example.no/senorge.zarr",
+  {
+    variable: "tmax",
+    selector: { time: 0 },
+    clim: [-30, 30],
+    colormap: "viridis",
+    crs: "EPSG:32633",
+  },
+);
 
 // Drive a time slider without rebuilding the layer: the renderer keeps the
 // chunks it already fetched. (`addZarrLayer` is optional, so guard the id.)
@@ -588,7 +625,7 @@ if (layerId) {
 
 ```typescript
 export type GeoLibreZarrQueryGeometry =
-  | { type: "Point"; coordinates: [number, number] } // WGS84 lng/lat
+  | { type: "Point"; coordinates: [number, number] }        // WGS84 lng/lat
   | { type: "Polygon"; coordinates: number[][][] }
   | { type: "MultiPolygon"; coordinates: number[][][][] };
 
@@ -596,16 +633,12 @@ export type GeoLibreZarrQueryGeometry =
 // (e.g. { month: [1, 7] }) nests the returned values by that dimension.
 export type GeoLibreZarrQuerySelector = Record<
   string,
-  | number
-  | string
-  | number[]
-  | string[]
-  | { selected: number | string | number[] | string[]; type?: "index" | "value" }
+  number | string | number[] | string[] | { selected: number | string | number[] | string[]; type?: "index" | "value" }
 >;
 
 export interface GeoLibreZarrQueryOptions {
-  signal?: AbortSignal; // cancel a query the user moved past
-  includeSpatialCoordinates?: boolean; // default true
+  signal?: AbortSignal;                    // cancel a query the user moved past
+  includeSpatialCoordinates?: boolean;     // default true
 }
 
 // { [variable]: values, dimensions, coordinates }
@@ -642,15 +675,15 @@ The panel can also open a store from a folder on disk, via a **Browse folder** b
 
 ## Driving a layer's own time dimension from the Time Slider
 
-The Time Slider understands three kinds of temporal layer. Two are built in: a **vector** layer filtered by a timestamp property, and a **raster time series** of dated sources the dock steps between. The third is for a layer that is _one store_ with time as an **internal dimension** — a Zarr data cube, or a plugin's own frame-based layer — where the timeline picks a slice rather than a source.
+The Time Slider understands three kinds of temporal layer. Two are built in: a **vector** layer filtered by a timestamp property, and a **raster time series** of dated sources the dock steps between. The third is for a layer that is *one store* with time as an **internal dimension** — a Zarr data cube, or a plugin's own frame-based layer — where the timeline picks a slice rather than a source.
 
 That third kind is expressed as a **temporal adapter**:
 
 ```typescript
 export interface TemporalLayerAdapter {
-  getTimeValues: () => ReadonlyArray<Date | number | string>; // the time coordinate, in index order
-  setTime: (date: Date) => void | Promise<void>; // apply a date to the layer
-  dimension?: string; // the axis name, default "time"
+  getTimeValues: () => ReadonlyArray<Date | number | string>;  // the time coordinate, in index order
+  setTime: (date: Date) => void | Promise<void>;               // apply a date to the layer
+  dimension?: string;                                          // the axis name, default "time"
 }
 ```
 
@@ -678,7 +711,7 @@ Call the returned function, or `app.unregisterTemporalLayer?.(layerId)`, to drop
 
 A bound cube shares the timeline with any vector bindings and dated overlays: the track spans the union of their extents, and the widest dataset sets the stepping granularity.
 
-**Closing the dock again.** A dock that a binding opened closes itself once the last temporal layer is gone, so it never lingers over a map with no timeline. Removing the bound layer is enough; if your plugin keeps the layer and only drops its binding, clear `layer.metadata.timeBinding` as well as unregistering the adapter. A dock the _user_ opened from the Plugins menu is left alone, and so is one that still has raster sources of its own or a KML `<TimeSpan>` overlay to drive.
+**Closing the dock again.** A dock that a binding opened closes itself once the last temporal layer is gone, so it never lingers over a map with no timeline. Removing the bound layer is enough; if your plugin keeps the layer and only drops its binding, clear `layer.metadata.timeBinding` as well as unregistering the adapter. A dock the *user* opened from the Plugins menu is left alone, and so is one that still has raster sources of its own or a KML `<TimeSpan>` overlay to drive.
 
 ## Activating and deactivating other plugins
 
@@ -699,20 +732,19 @@ Neither may target the **calling** plugin: `activatePlugin` on yourself is meani
 export interface GeoLibreExternalNativeLayerRegistration {
   id: string;
   name: string;
-  type?: GeoLibreLayer["type"]; // closest built-in type, e.g. "raster"
-  nativeLayerIds: string[]; // the MapLibre layer id(s) you added
+  type?: GeoLibreLayer["type"];        // closest built-in type, e.g. "raster"
+  nativeLayerIds: string[];            // the MapLibre layer id(s) you added
   source?: Record<string, unknown>;
   sourceIds?: string[];
   sourceId?: string;
-  geojson?: FeatureCollection; // for vector layers
+  geojson?: FeatureCollection;         // for vector layers
   beforeId?: string;
   opacity?: number;
   style?: Partial<LayerStyle>;
   metadata?: Record<string, unknown>;
   sourcePath?: string;
-  paintMode?: "geolibre" | "plugin"; // see below
-  paintBridge?: {
-    // see below
+  paintMode?: "geolibre" | "plugin";   // see below
+  paintBridge?: {                      // see below
     setOpacity?: (opacity: number) => void;
     setVisibility?: (visible: boolean) => void;
   };
@@ -790,7 +822,7 @@ Notes:
 - The panel is a flex sibling of the map, so opening it shrinks the map view (the map keeps filling the remaining space); no manual map padding is required.
 - **Dock position:** a panel docks at one of four positions (left to right): `left-of-layers`, `right-of-layers` (between Layers and the map), `left-of-style` (between the map and Style), or `right-of-style` (the default). Set `dock` on the registration to choose the initial position. The user steps the panel between positions at runtime with the two move buttons in the panel header (disabled at the ends), and a plugin can set it directly with `app.setActiveRightPanelDock?.(...)`. The position resets to the panel's declared `dock` when it closes or another panel opens.
 - **Shared-rail modes (`replace-style` / `replace-layers`):** two non-positional docks for workbench-style plugins that want to feel like a first-class sidebar workspace rather than a second rail beside Style (right) or Layers (left). Register with `dock: "replace-style"` (or `"replace-layers"`) and the host shows a single rail on that edge listing both your panel and the built-in panel; selecting one expands it while the other stays as a rail entry. The two are mutually exclusive, so the user never sees two adjacent rails. The built-in panel starts collapsed so the workbench reads as the active workspace, and the user can expand it (which collapses the workbench) at any time. Everything else (chrome, resize, collapse, close, lifecycle hooks) is unchanged.
-- **Switching modes at runtime:** the modes are not exclusive choices baked in at registration. In a positional dock the panel header shows a **merge** button that joins the shared rail on its current side — a layers-side panel (`left-of-layers`/`right-of-layers`) joins the Layers rail, a style-side panel the Style rail. In a shared rail it shows a **detach** button that pops the panel back out to a movable positional panel on the same side (`right-of-layers` / `right-of-style`), where the left/right move buttons return. A plugin can drive the same switch with `app.setActiveRightPanelDock?.("replace-style" | "replace-layers" | "right-of-style" | ...)`. The shared rails are not part of the left/right _step_ sequence (the arrows only walk the four positional docks); merge/detach is the way in and out.
+- **Switching modes at runtime:** the modes are not exclusive choices baked in at registration. In a positional dock the panel header shows a **merge** button that joins the shared rail on its current side — a layers-side panel (`left-of-layers`/`right-of-layers`) joins the Layers rail, a style-side panel the Style rail. In a shared rail it shows a **detach** button that pops the panel back out to a movable positional panel on the same side (`right-of-layers` / `right-of-style`), where the left/right move buttons return. A plugin can drive the same switch with `app.setActiveRightPanelDock?.("replace-style" | "replace-layers" | "right-of-style" | ...)`. The shared rails are not part of the left/right *step* sequence (the arrows only walk the four positional docks); merge/detach is the way in and out.
 - These methods are typed optional for forward-compatibility with host variants that have no right sidebar, so call them with optional chaining (`app.registerRightPanel?.(...)`).
 
 ## Toolbar menus
@@ -807,7 +839,9 @@ const unregister = app.registerToolbarMenu?.({
       type: "submenu",
       id: "tools",
       label: "Tools",
-      items: [{ id: "qa", label: "Data QA", onSelect: () => app.openFloatingPanel?.("my-qa") }],
+      items: [
+        { id: "qa", label: "Data QA", onSelect: () => app.openFloatingPanel?.("my-qa") },
+      ],
     },
     { type: "separator" },
     { id: "about", label: "About", disabled: false, onSelect: () => {} },
@@ -879,9 +913,9 @@ const unregister = app.registerFloatingPanel?.({
   },
 });
 
-app.openFloatingPanel?.("my-qa"); // open (or bring to front)
-app.closeFloatingPanel?.("my-qa"); // close
-app.getOpenFloatingPanels?.(); // -> string[] of open ids, stacking order
+app.openFloatingPanel?.("my-qa");   // open (or bring to front)
+app.closeFloatingPanel?.("my-qa");  // close
+app.getOpenFloatingPanels?.();      // -> string[] of open ids, stacking order
 ```
 
 Use a right panel for a primary, persistent workspace and a floating panel for an ancillary tool or dashboard the user positions over the map. As with the other surfaces, call these methods with optional chaining since they are typed optional.

--- a/packages/plugins/src/plugins/carto-light.ts
+++ b/packages/plugins/src/plugins/carto-light.ts
@@ -6,6 +6,7 @@ export const cartoLightPlugin: GeoLibrePlugin = {
   id: "carto-light",
   name: "Carto Light Basemap",
   version: "0.1.0",
+  engines: ["maplibre", "cesium"],
   activate: (app: GeoLibreAppAPI) => {
     app.setBasemap(CARTO_LIGHT);
   },

--- a/packages/plugins/src/plugins/maplibre-arcgis-hub.ts
+++ b/packages/plugins/src/plugins/maplibre-arcgis-hub.ts
@@ -468,6 +468,7 @@ export const maplibreArcGisHubPlugin: GeoLibrePlugin = {
   id: ARCGIS_HUB_PLUGIN_ID,
   name: "ArcGIS Hub",
   version: "0.1.0",
+  engines: ["maplibre", "cesium"],
   activate: (app) => {
     appRef = app;
     unregisterPanel =

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -164,6 +164,7 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
   id: BASEMAP_CONTROL_PLUGIN_ID,
   name: "Basemaps",
   version: "0.3.0",
+  engines: ["maplibre", "cesium"],
   activate: (app: GeoLibreAppAPI) => {
     if (!basemapControl) {
       basemapControl = new BasemapControl(getBasemapControlOptions(app));

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -164,7 +164,7 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
   id: BASEMAP_CONTROL_PLUGIN_ID,
   name: "Basemaps",
   version: "0.3.0",
-  engines: ["maplibre", "cesium"],
+  engines: ["maplibre"],
   activate: (app: GeoLibreAppAPI) => {
     if (!basemapControl) {
       basemapControl = new BasemapControl(getBasemapControlOptions(app));

--- a/packages/plugins/src/plugins/maplibre-open-data-catalogs.ts
+++ b/packages/plugins/src/plugins/maplibre-open-data-catalogs.ts
@@ -197,6 +197,7 @@ function createCatalogPlugin(options: {
     id: options.id,
     name: options.name,
     version: "0.1.0",
+    engines: ["maplibre", "cesium"],
     activate(app) {
       unregister =
         app.registerRightPanel?.({

--- a/packages/plugins/src/plugins/maplibre-open-data-catalogs.ts
+++ b/packages/plugins/src/plugins/maplibre-open-data-catalogs.ts
@@ -184,6 +184,12 @@ async function searchCkan(query: string, page: number, signal: AbortSignal): Pro
   return { items, total: payload.result?.count ?? items.length };
 }
 
+/**
+ * Creates a GeoLibre right-panel plugin for searching and browsing an open data catalog (CKAN or Socrata).
+ *
+ * @param options - Configuration options for the catalog plugin, including ID, name, hint, and search handler.
+ * @returns A {@link GeoLibrePlugin} instance configured for the catalog.
+ */
 function createCatalogPlugin(options: {
   id: string;
   name: string;

--- a/packages/plugins/src/plugins/maplibre-source-coop.ts
+++ b/packages/plugins/src/plugins/maplibre-source-coop.ts
@@ -1126,6 +1126,7 @@ function createSourceCoopPlugin(config: SourceCoopPluginConfig): GeoLibrePlugin 
     id: config.id,
     name: config.name,
     version: "0.1.0",
+    engines: ["maplibre", "cesium"],
     activate: (app: GeoLibreAppAPI) => {
       appRef = app;
       mountedPanels.add(remount);

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -1621,6 +1621,7 @@ function createStacPlugin(id: string, name: string, presetCatalogUrl = ""): GeoL
     id,
     name,
     version: "0.1.0",
+    engines: ["maplibre", "cesium"],
     exclusiveGroup: "stac-catalog-browser",
     activate(app) {
       initialCatalogUrl = presetCatalogUrl;

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -1616,6 +1616,14 @@ function mountPanel(container: HTMLElement): void {
   disposePanel = buildPanel(container);
 }
 
+/**
+ * Factory creating a STAC catalog browser plugin instance with optional preset catalog URL.
+ *
+ * @param id - Unique plugin identifier.
+ * @param name - Display name for the plugin.
+ * @param presetCatalogUrl - Optional default catalog URL to connect to on load.
+ * @returns A {@link GeoLibrePlugin} instance for browsing STAC catalogs.
+ */
 function createStacPlugin(id: string, name: string, presetCatalogUrl = ""): GeoLibrePlugin {
   return {
     id,

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_LAYER_STYLE, useAppStore } from "@geolibre/core";
-import { fillLayerId, lineLayerId } from "@geolibre/map";
+import { fillLayerId, lineLayerId } from "@geolibre/map/style-layer-ids";
 import type { FeatureCollection, Geometry } from "geojson";
 import type { GeoJSONSource, MapMouseEvent, Map as MapLibreMap } from "maplibre-gl";
 import type {
@@ -1629,7 +1629,10 @@ function createStacPlugin(id: string, name: string, presetCatalogUrl = ""): GeoL
     id,
     name,
     version: "0.1.0",
-    engines: ["maplibre", "cesium"],
+    // MapLibre only: the panel is engine-neutral, but item footprints, the
+    // "current view" search bbox, the draw-bbox tool, and footprint
+    // click/hover all go through `app.getMap()`, which is null off MapLibre.
+    engines: ["maplibre"],
     exclusiveGroup: "stac-catalog-browser",
     activate(app) {
       initialCatalogUrl = presetCatalogUrl;

--- a/packages/plugins/src/plugins/osm-basemap.ts
+++ b/packages/plugins/src/plugins/osm-basemap.ts
@@ -6,6 +6,7 @@ export const osmBasemapPlugin: GeoLibrePlugin = {
   id: "osm-basemap",
   name: "OpenStreetMap Basemap",
   version: "0.1.0",
+  engines: ["maplibre", "cesium"],
   activate: (app: GeoLibreAppAPI) => {
     app.setBasemap(OSM_STYLE);
   },

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -4,6 +4,7 @@ import type {
   GeoLibreLayer,
   GeoLibreProject,
   LayerStyle,
+  MapRendererKind,
 } from "@geolibre/core";
 import type {
   QueryGeometry as ZarrQueryGeometry,
@@ -1007,6 +1008,13 @@ export interface GeoLibrePlugin {
   name: string;
   version: string;
   activeByDefault?: boolean;
+  /**
+   * Renderers this plugin supports. Defaults to `["maplibre"]`.
+   * Engine-neutral plugins (e.g. catalog/service browsers that only write to
+   * the GeoLibre store) or plugins with multi-engine adapters declare
+   * `["maplibre", "cesium"]`.
+   */
+  engines?: MapRendererKind[];
   /** Plugins in the same group cannot be active at the same time. */
   exclusiveGroup?: string;
   /** At least one name is required for handleUrlParameters to be called. */
@@ -1066,6 +1074,10 @@ export interface GeoLibreExternalPluginManifest {
   description?: string;
   style?: string;
   /**
+   * Renderers this plugin supports. Defaults to `["maplibre"]`.
+   */
+  engines?: MapRendererKind[];
+  /**
    * Activate the plugin on startup when no saved plugin state overrides it.
    * Honored only for bundled drop-ins (public/plugins/<id>/), which are baked
    * into the build by the deployer and therefore as trusted as built-ins.
@@ -1073,4 +1085,17 @@ export interface GeoLibreExternalPluginManifest {
    * third-party plugins cannot force themselves active.
    */
   activeByDefault?: boolean;
+}
+
+/**
+ * Test whether a plugin supports the specified map renderer engine.
+ * Defaults to `["maplibre"]` when `engines` is omitted or empty.
+ */
+export function isPluginEngineSupported(
+  plugin: Pick<GeoLibrePlugin, "engines"> | { engines?: MapRendererKind[] } | null | undefined,
+  engine: MapRendererKind,
+): boolean {
+  const supported: readonly MapRendererKind[] =
+    plugin?.engines && plugin.engines.length > 0 ? plugin.engines : ["maplibre"];
+  return supported.includes(engine);
 }

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -1092,7 +1092,7 @@ export interface GeoLibreExternalPluginManifest {
  * Defaults to `["maplibre"]` when `engines` is omitted or empty.
  */
 export function isPluginEngineSupported(
-  plugin: Pick<GeoLibrePlugin, "engines"> | { engines?: MapRendererKind[] } | null | undefined,
+  plugin: Pick<GeoLibrePlugin, "engines"> | null | undefined,
   engine: MapRendererKind,
 ): boolean {
   const supported: readonly MapRendererKind[] =

--- a/tests/plugin-engines.test.ts
+++ b/tests/plugin-engines.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isPluginEngineSupported } from "../packages/plugins/src/types";
+import { maplibreArcGisHubPlugin } from "../packages/plugins/src/plugins/maplibre-arcgis-hub";
+import { maplibreBasemapControlPlugin } from "../packages/plugins/src/plugins/maplibre-basemap-control";
+import {
+  maplibreCkanPlugin,
+  maplibreSocrataPlugin,
+} from "../packages/plugins/src/plugins/maplibre-open-data-catalogs";
+import {
+  maplibreNaturalEarthPlugin,
+  maplibreSourceCoopPlugin,
+} from "../packages/plugins/src/plugins/maplibre-source-coop";
+import { osmBasemapPlugin } from "../packages/plugins/src/plugins/osm-basemap";
+import { cartoLightPlugin } from "../packages/plugins/src/plugins/carto-light";
+import { isExternalPluginManifest } from "../apps/geolibre-desktop/src/lib/plugin-archive-unpack";
+
+describe("isPluginEngineSupported", () => {
+  it("defaults to MapLibre support when engines is undefined", () => {
+    const plugin = { id: "test", name: "Test", version: "1.0.0" };
+    assert.equal(isPluginEngineSupported(plugin, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(plugin, "cesium"), false);
+  });
+
+  it("defaults to MapLibre support when engines is empty", () => {
+    const plugin = { id: "test", name: "Test", version: "1.0.0", engines: [] };
+    assert.equal(isPluginEngineSupported(plugin, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(plugin, "cesium"), false);
+  });
+
+  it("supports explicit single engine declaration", () => {
+    const maplibreOnly = { id: "test", engines: ["maplibre" as const] };
+    assert.equal(isPluginEngineSupported(maplibreOnly, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(maplibreOnly, "cesium"), false);
+
+    const cesiumOnly = { id: "test", engines: ["cesium" as const] };
+    assert.equal(isPluginEngineSupported(cesiumOnly, "maplibre"), false);
+    assert.equal(isPluginEngineSupported(cesiumOnly, "cesium"), true);
+  });
+
+  it("supports multiple engines declaration", () => {
+    const multi = { id: "test", engines: ["maplibre" as const, "cesium" as const] };
+    assert.equal(isPluginEngineSupported(multi, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(multi, "cesium"), true);
+  });
+
+  it("returns default fallback gracefully when plugin is null or undefined", () => {
+    assert.equal(isPluginEngineSupported(null, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(null, "cesium"), false);
+    assert.equal(isPluginEngineSupported(undefined, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(undefined, "cesium"), false);
+  });
+});
+
+describe("Tier 1 built-in plugin engine support audit", () => {
+  const tier1Plugins = [
+    maplibreSourceCoopPlugin,
+    maplibreNaturalEarthPlugin,
+    maplibreArcGisHubPlugin,
+    maplibreSocrataPlugin,
+    maplibreCkanPlugin,
+    maplibreBasemapControlPlugin,
+    osmBasemapPlugin,
+    cartoLightPlugin,
+  ];
+
+  it("declares support for both MapLibre and Cesium on all audited Tier 1 plugins", () => {
+    for (const plugin of tier1Plugins) {
+      assert.ok(plugin.engines, `Plugin ${plugin.id} must declare engines`);
+      assert.deepEqual(
+        plugin.engines,
+        ["maplibre", "cesium"],
+        `Plugin ${plugin.id} must declare ["maplibre", "cesium"]`,
+      );
+      assert.equal(isPluginEngineSupported(plugin, "maplibre"), true);
+      assert.equal(isPluginEngineSupported(plugin, "cesium"), true);
+    }
+  });
+
+  it("defaults MapLibre-only plugins without explicit engines to maplibre", () => {
+    const defaultPlugin = { id: "plain-plugin", name: "Plain", version: "1.0.0" };
+    assert.equal(isPluginEngineSupported(defaultPlugin, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(defaultPlugin, "cesium"), false);
+  });
+});
+
+describe("isExternalPluginManifest engines validation", () => {
+  const baseManifest = {
+    id: "custom-plugin",
+    name: "Custom Plugin",
+    version: "1.0.0",
+    entry: "dist/index.js",
+  };
+
+  it("accepts manifests without engines", () => {
+    assert.equal(isExternalPluginManifest(baseManifest), true);
+  });
+
+  it("accepts manifests with valid engines list", () => {
+    assert.equal(isExternalPluginManifest({ ...baseManifest, engines: ["maplibre"] }), true);
+    assert.equal(isExternalPluginManifest({ ...baseManifest, engines: ["cesium"] }), true);
+    assert.equal(
+      isExternalPluginManifest({ ...baseManifest, engines: ["maplibre", "cesium"] }),
+      true,
+    );
+  });
+
+  it("rejects manifests with invalid engines", () => {
+    assert.equal(
+      isExternalPluginManifest({ ...baseManifest, engines: "maplibre" as unknown }),
+      false,
+    );
+    assert.equal(
+      isExternalPluginManifest({
+        ...baseManifest,
+        engines: ["unsupported" as unknown as "maplibre"],
+      }),
+      false,
+    );
+    assert.equal(
+      isExternalPluginManifest({ ...baseManifest, engines: [123 as unknown as "maplibre"] }),
+      false,
+    );
+  });
+});

--- a/tests/plugin-engines.test.ts
+++ b/tests/plugin-engines.test.ts
@@ -59,7 +59,6 @@ describe("Tier 1 built-in plugin engine support audit", () => {
     maplibreArcGisHubPlugin,
     maplibreSocrataPlugin,
     maplibreCkanPlugin,
-    maplibreBasemapControlPlugin,
     osmBasemapPlugin,
     cartoLightPlugin,
   ];
@@ -75,6 +74,12 @@ describe("Tier 1 built-in plugin engine support audit", () => {
       assert.equal(isPluginEngineSupported(plugin, "maplibre"), true);
       assert.equal(isPluginEngineSupported(plugin, "cesium"), true);
     }
+  });
+
+  it("declares support for MapLibre only on BasemapControl plugin", () => {
+    assert.deepEqual(maplibreBasemapControlPlugin.engines, ["maplibre"]);
+    assert.equal(isPluginEngineSupported(maplibreBasemapControlPlugin, "maplibre"), true);
+    assert.equal(isPluginEngineSupported(maplibreBasemapControlPlugin, "cesium"), false);
   });
 
   it("defaults MapLibre-only plugins without explicit engines to maplibre", () => {

--- a/tests/plugin-engines.test.ts
+++ b/tests/plugin-engines.test.ts
@@ -8,12 +8,19 @@ import {
   maplibreSocrataPlugin,
 } from "../packages/plugins/src/plugins/maplibre-open-data-catalogs";
 import {
+  maplibrePlanetOpenDataPlugin,
+  maplibreStacCatalogsPlugin,
+} from "../packages/plugins/src/plugins/maplibre-stac";
+import {
   maplibreNaturalEarthPlugin,
   maplibreSourceCoopPlugin,
 } from "../packages/plugins/src/plugins/maplibre-source-coop";
 import { osmBasemapPlugin } from "../packages/plugins/src/plugins/osm-basemap";
 import { cartoLightPlugin } from "../packages/plugins/src/plugins/carto-light";
-import { isExternalPluginManifest } from "../apps/geolibre-desktop/src/lib/plugin-archive-unpack";
+import {
+  isExternalPluginManifest,
+  isPluginEngineList,
+} from "../apps/geolibre-desktop/src/lib/plugin-archive-unpack";
 
 describe("isPluginEngineSupported", () => {
   it("defaults to MapLibre support when engines is undefined", () => {
@@ -82,6 +89,18 @@ describe("Tier 1 built-in plugin engine support audit", () => {
     assert.equal(isPluginEngineSupported(maplibreBasemapControlPlugin, "cesium"), false);
   });
 
+  // Both STAC plugins come out of the same createStacPlugin factory, so they
+  // are audited together: the panel is engine-neutral, but footprints, the
+  // "current view" search bbox, the draw-bbox tool, and footprint click/hover
+  // all need app.getMap(), which only MapLibre provides.
+  it("declares support for MapLibre only on the STAC catalog plugins", () => {
+    for (const plugin of [maplibreStacCatalogsPlugin, maplibrePlanetOpenDataPlugin]) {
+      assert.deepEqual(plugin.engines, ["maplibre"], `Plugin ${plugin.id} must be MapLibre-only`);
+      assert.equal(isPluginEngineSupported(plugin, "maplibre"), true);
+      assert.equal(isPluginEngineSupported(plugin, "cesium"), false);
+    }
+  });
+
   it("defaults MapLibre-only plugins without explicit engines to maplibre", () => {
     const defaultPlugin = { id: "plain-plugin", name: "Plain", version: "1.0.0" };
     assert.equal(isPluginEngineSupported(defaultPlugin, "maplibre"), true);
@@ -108,6 +127,15 @@ describe("isExternalPluginManifest engines validation", () => {
       isExternalPluginManifest({ ...baseManifest, engines: ["maplibre", "cesium"] }),
       true,
     );
+  });
+
+  it("rejects plugin engines that are not a list of known renderers", () => {
+    assert.equal(isPluginEngineList(["maplibre", "cesium"]), true);
+    assert.equal(isPluginEngineList([]), true);
+    assert.equal(isPluginEngineList("maplibre"), false);
+    assert.equal(isPluginEngineList(["unsupported"]), false);
+    assert.equal(isPluginEngineList([123]), false);
+    assert.equal(isPluginEngineList(undefined), false);
   });
 
   it("rejects manifests with invalid engines", () => {


### PR DESCRIPTION
Part of #2262 and #2259.

## Problem

Of the modules under `packages/plugins/src/plugins/`, plugins currently do not declare which map engines they support. On Cesium globe view (`primaryRenderer === "cesium"`), plugins that touch MapLibre directly or paint via MapLibre GL activate without doing anything visible or functional, while engine-neutral plugins (e.g. store-only catalog and service browsers that only dispatch store layer additions) are ready to work on the globe today. Furthermore, users could toggle inert plugins from the Plugins menu while on Cesium.

## Solution

1. **Declare engine support**:
   - Added `engines?: MapRendererKind[]` to `GeoLibrePlugin` and `GeoLibreExternalPluginManifest` (in `packages/plugins/src/types.ts`), defaulting to `["maplibre"]`.
   - Exported `isPluginEngineSupported(plugin, engine): boolean` helper to test engine support with safe fallback.
2. **Tier 1 Store-Only & Engine-Neutral Audit**:
   - Audited catalog browsers and basemap controls to declare `engines: ["maplibre", "cesium"]`:
     - `maplibreSourceCoopPlugin` & `maplibreNaturalEarthPlugin` (`packages/plugins/src/plugins/maplibre-source-coop.ts`)
     - `maplibreArcGisHubPlugin` (`packages/plugins/src/plugins/maplibre-arcgis-hub.ts`)
     - `maplibreSocrataPlugin` & `maplibreCkanPlugin` (`packages/plugins/src/plugins/maplibre-open-data-catalogs.ts`)
     - `maplibreStacCatalogsPlugin` & `maplibrePlanetOpenDataPlugin` (`packages/plugins/src/plugins/maplibre-stac.ts`)
     - `maplibreBasemapControlPlugin` (`packages/plugins/src/plugins/maplibre-basemap-control.ts`)
     - `osmBasemapPlugin` (`packages/plugins/src/plugins/osm-basemap.ts`)
     - `cartoLightPlugin` (`packages/plugins/src/plugins/carto-light.ts`)
3. **Plugins Menu Gating**:
   - In `apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx`, read active `primaryRenderer` from app store.
   - Disabled menu items and position submenus when `!isPluginEngineSupported(plugin, primaryRenderer)`.
   - Disabled DGGS and Web Services submenus if all plugins in the group are unsupported on the active renderer.
4. **External Plugins & Documentation**:
   - Updated `isExternalPluginManifest` in `plugin-archive-unpack.ts` to validate optional `engines` array (`("maplibre" | "cesium")[]`).
   - Propagated manifest engines in `importExternalPlugin` (`external-plugins.ts`).
   - Documented the `engines` field in `docs/plugin-api.md`.
5. **Testing**:
   - Added test suite `tests/plugin-engines.test.ts` covering helper defaults, single/multi engine declarations, Tier 1 audit checks, and manifest engine validation.

## Testing

- `node --import tsx --test tests/plugin-engines.test.ts` (10/10 tests pass).
- `node --import tsx --test tests/basemap-control-plugin.test.ts tests/viewer-plugins.test.ts tests/cesium-control-host.test.ts` (pass).
- `npx oxfmt` (all 13 files formatted clean).
- `npx eslint` (clean).
- `npm run build` (successful compilation and bundle build).

## Scope

Additive, backwards-compatible metadata and UI gating. Plugins omitting `engines` retain default `["maplibre"]` behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plugins can declare compatibility with MapLibre, Cesium, or both rendering engines.
  - Renderer-specific plugin actions and grouped submenus now reflect available compatibility.
  - External plugin manifests support validated engine compatibility settings, with metadata preserved during import.
- **Documentation**
  - Updated plugin API documentation with engine compatibility and expanded layer, query, and time-slider capabilities.
- **Bug Fixes**
  - Improved handling of plugin compatibility metadata and renderer-specific controls, including safe deactivation after renderer changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->