### PR TITLE
feat(map): add native Cesium basemap and terrain picker

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
@@ -40,8 +40,8 @@ export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumC
   // identity changes.
   const controlLabels = useMemo<CesiumWidgetControlLabels>(
     () => ({
-      basemap: t("newProject.basemapLabel"),
-      imagery: t("earthdataGis.filterImage"),
+      basemap: t("renderer.basemap"),
+      imagery: t("renderer.imagery"),
       terrain: t("toolbar.mapControl.terrain"),
       projectBasemap: t("renderer.projectBasemap"),
       home: t("renderer.resetView"),

--- a/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
@@ -40,6 +40,10 @@ export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumC
   // identity changes.
   const controlLabels = useMemo<CesiumWidgetControlLabels>(
     () => ({
+      basemap: t("newProject.basemapLabel"),
+      imagery: t("earthdataGis.filterImage"),
+      terrain: t("toolbar.mapControl.terrain"),
+      projectBasemap: t("renderer.projectBasemap"),
       home: t("renderer.resetView"),
       sceneMode3D: t("renderer.scene3D"),
       sceneMode2D: t("renderer.scene2D"),

--- a/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
@@ -42,6 +42,7 @@ export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumC
     () => ({
       basemap: t("renderer.basemap"),
       imagery: t("renderer.imagery"),
+      other: t("newProject.sectionOther"),
       terrain: t("toolbar.mapControl.terrain"),
       projectBasemap: t("renderer.projectBasemap"),
       home: t("renderer.resetView"),

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -2050,6 +2050,8 @@
     "cesiumTokenHint": "أضف رمز Cesium Ion من الإعدادات للحصول على التضاريس وصور Ion"
   },
   "renderer": {
+    "basemap": "خريطة الأساس",
+    "imagery": "الصور",
     "projectBasemap": "خريطة أساس المشروع",
     "layerUnsupported": "لا تُعرَض على الكرة الأرضية ثلاثية الأبعاد",
     "resetView": "إعادة تعيين العرض",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -2050,6 +2050,7 @@
     "cesiumTokenHint": "أضف رمز Cesium Ion من الإعدادات للحصول على التضاريس وصور Ion"
   },
   "renderer": {
+    "projectBasemap": "خريطة أساس المشروع",
     "layerUnsupported": "لا تُعرَض على الكرة الأرضية ثلاثية الأبعاد",
     "resetView": "إعادة تعيين العرض",
     "scene3D": "كرة أرضية ثلاثية الأبعاد",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "Fügen Sie in den Einstellungen ein Cesium-Ion-Token für Gelände und Ion-Bilder hinzu"
   },
   "renderer": {
+    "basemap": "Hintergrundkarte",
+    "imagery": "Bilddaten",
     "projectBasemap": "Hintergrundkarte des Projekts",
     "layerUnsupported": "Wird vom 3D-Globus nicht dargestellt",
     "resetView": "Ansicht zurücksetzen",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "Fügen Sie in den Einstellungen ein Cesium-Ion-Token für Gelände und Ion-Bilder hinzu"
   },
   "renderer": {
+    "projectBasemap": "Hintergrundkarte des Projekts",
     "layerUnsupported": "Wird vom 3D-Globus nicht dargestellt",
     "resetView": "Ansicht zurücksetzen",
     "scene3D": "3D-Globus",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1880,6 +1880,7 @@
     "cesiumTokenHint": "Add a Cesium Ion token in Settings for terrain and Ion imagery"
   },
   "renderer": {
+    "projectBasemap": "Project basemap",
     "layerUnsupported": "Not rendered by the 3D globe",
     "resetView": "Reset view",
     "scene3D": "3D globe",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1880,6 +1880,8 @@
     "cesiumTokenHint": "Add a Cesium Ion token in Settings for terrain and Ion imagery"
   },
   "renderer": {
+    "basemap": "Basemap",
+    "imagery": "Imagery",
     "projectBasemap": "Project basemap",
     "layerUnsupported": "Not rendered by the 3D globe",
     "resetView": "Reset view",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "Añada un token de Cesium Ion en Configuración para el terreno y las imágenes de Ion"
   },
   "renderer": {
+    "basemap": "Mapa base",
+    "imagery": "Imágenes",
     "projectBasemap": "Mapa base del proyecto",
     "layerUnsupported": "No se representa en el globo 3D",
     "resetView": "Restablecer vista",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "Añada un token de Cesium Ion en Configuración para el terreno y las imágenes de Ion"
   },
   "renderer": {
+    "projectBasemap": "Mapa base del proyecto",
     "layerUnsupported": "No se representa en el globo 3D",
     "resetView": "Restablecer vista",
     "scene3D": "Globo 3D",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "برای زمین و تصاویر Ion، یک توکن Cesium Ion در تنظیمات بیفزایید"
   },
   "renderer": {
+    "basemap": "نقشهٔ پایه",
+    "imagery": "تصاویر",
     "projectBasemap": "نقشهٔ پایهٔ پروژه",
     "layerUnsupported": "روی کرهٔ سه‌بعدی ترسیم نمی‌شود",
     "resetView": "بازنشانی نما",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "برای زمین و تصاویر Ion، یک توکن Cesium Ion در تنظیمات بیفزایید"
   },
   "renderer": {
+    "projectBasemap": "نقشهٔ پایهٔ پروژه",
     "layerUnsupported": "روی کرهٔ سه‌بعدی ترسیم نمی‌شود",
     "resetView": "بازنشانی نما",
     "scene3D": "کرهٔ سه‌بعدی",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "Ajoutez un jeton Cesium Ion dans les Paramètres pour le relief et l'imagerie Ion"
   },
   "renderer": {
+    "projectBasemap": "Fond de carte du projet",
     "layerUnsupported": "Non rendu par le globe 3D",
     "resetView": "Réinitialiser la vue",
     "scene3D": "Globe 3D",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "Ajoutez un jeton Cesium Ion dans les Paramètres pour le relief et l'imagerie Ion"
   },
   "renderer": {
+    "basemap": "Fond de carte",
+    "imagery": "Imagerie",
     "projectBasemap": "Fond de carte du projet",
     "layerUnsupported": "Non rendu par le globe 3D",
     "resetView": "Réinitialiser la vue",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "टेरेन और Ion इमेजरी के लिए सेटिंग्स में Cesium Ion टोकन जोड़ें"
   },
   "renderer": {
+    "basemap": "बेसमैप",
+    "imagery": "इमेजरी",
     "projectBasemap": "प्रोजेक्ट बेसमैप",
     "layerUnsupported": "3D ग्लोब द्वारा रेंडर नहीं किया गया",
     "resetView": "दृश्य रीसेट करें",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "टेरेन और Ion इमेजरी के लिए सेटिंग्स में Cesium Ion टोकन जोड़ें"
   },
   "renderer": {
+    "projectBasemap": "प्रोजेक्ट बेसमैप",
     "layerUnsupported": "3D ग्लोब द्वारा रेंडर नहीं किया गया",
     "resetView": "दृश्य रीसेट करें",
     "scene3D": "3D ग्लोब",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1826,6 +1826,8 @@
     "cesiumTokenHint": "Tambahkan token Cesium Ion di Pengaturan untuk medan dan citra Ion"
   },
   "renderer": {
+    "basemap": "Peta dasar",
+    "imagery": "Citra",
     "projectBasemap": "Peta dasar proyek",
     "layerUnsupported": "Tidak dirender oleh bola dunia 3D",
     "resetView": "Atur Ulang Tampilan",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1826,6 +1826,7 @@
     "cesiumTokenHint": "Tambahkan token Cesium Ion di Pengaturan untuk medan dan citra Ion"
   },
   "renderer": {
+    "projectBasemap": "Peta dasar proyek",
     "layerUnsupported": "Tidak dirender oleh bola dunia 3D",
     "resetView": "Atur Ulang Tampilan",
     "scene3D": "Bola dunia 3D",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "Aggiungi un token Cesium Ion nelle Impostazioni per il terreno e le immagini Ion"
   },
   "renderer": {
+    "projectBasemap": "Mappa di base del progetto",
     "layerUnsupported": "Non visualizzato dal globo 3D",
     "resetView": "Ripristina vista",
     "scene3D": "Globo 3D",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "Aggiungi un token Cesium Ion nelle Impostazioni per il terreno e le immagini Ion"
   },
   "renderer": {
+    "basemap": "Mappa di base",
+    "imagery": "Immagini",
     "projectBasemap": "Mappa di base del progetto",
     "layerUnsupported": "Non visualizzato dal globo 3D",
     "resetView": "Ripristina vista",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1826,6 +1826,7 @@
     "cesiumTokenHint": "地形とIon衛星画像を使うには、設定でCesium Ionトークンを追加してください"
   },
   "renderer": {
+    "projectBasemap": "プロジェクトのベースマップ",
     "layerUnsupported": "3D地球儀では描画されません",
     "resetView": "表示をリセット",
     "scene3D": "3D地球儀",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1826,6 +1826,8 @@
     "cesiumTokenHint": "地形とIon衛星画像を使うには、設定でCesium Ionトークンを追加してください"
   },
   "renderer": {
+    "basemap": "ベースマップ",
+    "imagery": "画像",
     "projectBasemap": "プロジェクトのベースマップ",
     "layerUnsupported": "3D地球儀では描画されません",
     "resetView": "表示をリセット",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "რელიეფისა და Ion-ის სურათებისთვის დაამატეთ Cesium Ion-ის token პარამეტრებში"
   },
   "renderer": {
+    "projectBasemap": "პროექტის საბაზისო რუკა",
     "layerUnsupported": "3D გლობუსზე არ ისახება",
     "resetView": "ხედის საწყისზე დაბრუნება",
     "scene3D": "3D გლობუსი",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "რელიეფისა და Ion-ის სურათებისთვის დაამატეთ Cesium Ion-ის token პარამეტრებში"
   },
   "renderer": {
+    "basemap": "საბაზისო რუკა",
+    "imagery": "სურათები",
     "projectBasemap": "პროექტის საბაზისო რუკა",
     "layerUnsupported": "3D გლობუსზე არ ისახება",
     "resetView": "ხედის საწყისზე დაბრუნება",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1826,6 +1826,8 @@
     "cesiumTokenHint": "지형과 Ion 영상을 사용하려면 설정에서 Cesium Ion 토큰을 추가하세요"
   },
   "renderer": {
+    "basemap": "배경지도",
+    "imagery": "영상",
     "projectBasemap": "프로젝트 배경지도",
     "layerUnsupported": "3D 지구본에서는 렌더링되지 않음",
     "resetView": "보기 재설정",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1826,6 +1826,7 @@
     "cesiumTokenHint": "지형과 Ion 영상을 사용하려면 설정에서 Cesium Ion 토큰을 추가하세요"
   },
   "renderer": {
+    "projectBasemap": "프로젝트 배경지도",
     "layerUnsupported": "3D 지구본에서는 렌더링되지 않음",
     "resetView": "보기 재설정",
     "scene3D": "3D 지구본",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "Voeg in Instellingen een Cesium Ion-token toe voor terrein en Ion-beelden"
   },
   "renderer": {
+    "basemap": "Achtergrondkaart",
+    "imagery": "Beelden",
     "projectBasemap": "Achtergrondkaart van het project",
     "layerUnsupported": "Niet weergegeven door de 3D-globe",
     "resetView": "Weergave herstellen",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "Voeg in Instellingen een Cesium Ion-token toe voor terrein en Ion-beelden"
   },
   "renderer": {
+    "projectBasemap": "Achtergrondkaart van het project",
     "layerUnsupported": "Niet weergegeven door de 3D-globe",
     "resetView": "Weergave herstellen",
     "scene3D": "3D-globe",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "Adicione um token do Cesium Ion em Configurações para terreno e imagens do Ion"
   },
   "renderer": {
+    "projectBasemap": "Mapa base do projeto",
     "layerUnsupported": "Não renderizado pelo globo 3D",
     "resetView": "Redefinir vista",
     "scene3D": "Globo 3D",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "Adicione um token do Cesium Ion em Configurações para terreno e imagens do Ion"
   },
   "renderer": {
+    "basemap": "Mapa base",
+    "imagery": "Imagens",
     "projectBasemap": "Mapa base do projeto",
     "layerUnsupported": "Não renderizado pelo globo 3D",
     "resetView": "Redefinir vista",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1961,6 +1961,7 @@
     "cesiumTokenHint": "Добавьте токен Cesium Ion в настройках, чтобы получить рельеф и снимки Ion"
   },
   "renderer": {
+    "projectBasemap": "Базовая карта проекта",
     "layerUnsupported": "Не отображается на 3D-глобусе",
     "resetView": "Сбросить вид",
     "scene3D": "3D-глобус",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1961,6 +1961,8 @@
     "cesiumTokenHint": "Добавьте токен Cesium Ion в настройках, чтобы получить рельеф и снимки Ion"
   },
   "renderer": {
+    "basemap": "Базовая карта",
+    "imagery": "Изображения",
     "projectBasemap": "Базовая карта проекта",
     "layerUnsupported": "Не отображается на 3D-глобусе",
     "resetView": "Сбросить вид",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1826,6 +1826,7 @@
     "cesiumTokenHint": "เพิ่มโทเค็น Cesium Ion ในการตั้งค่าเพื่อใช้ข้อมูลภูมิประเทศและภาพถ่ายจาก Ion"
   },
   "renderer": {
+    "projectBasemap": "แผนที่ฐานของโครงการ",
     "layerUnsupported": "ไม่แสดงผลบนลูกโลก 3 มิติ",
     "resetView": "รีเซ็ตมุมมอง",
     "scene3D": "ลูกโลก 3 มิติ",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1826,6 +1826,8 @@
     "cesiumTokenHint": "เพิ่มโทเค็น Cesium Ion ในการตั้งค่าเพื่อใช้ข้อมูลภูมิประเทศและภาพถ่ายจาก Ion"
   },
   "renderer": {
+    "basemap": "แผนที่ฐาน",
+    "imagery": "ภาพถ่าย",
     "projectBasemap": "แผนที่ฐานของโครงการ",
     "layerUnsupported": "ไม่แสดงผลบนลูกโลก 3 มิติ",
     "resetView": "รีเซ็ตมุมมอง",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1871,6 +1871,7 @@
     "cesiumTokenHint": "Arazi ve Ion görüntüleri için Ayarlar'dan bir Cesium Ion belirteci ekleyin"
   },
   "renderer": {
+    "projectBasemap": "Proje altlık haritası",
     "layerUnsupported": "3D küre tarafından çizilmiyor",
     "resetView": "Görünümü Sıfırla",
     "scene3D": "3B küre",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1871,6 +1871,8 @@
     "cesiumTokenHint": "Arazi ve Ion görüntüleri için Ayarlar'dan bir Cesium Ion belirteci ekleyin"
   },
   "renderer": {
+    "basemap": "Altlık harita",
+    "imagery": "Görüntü",
     "projectBasemap": "Proje altlık haritası",
     "layerUnsupported": "3D küre tarafından çizilmiyor",
     "resetView": "Görünümü Sıfırla",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -1826,6 +1826,8 @@
     "cesiumTokenHint": "Thêm mã thông báo Cesium Ion trong Cài đặt để dùng địa hình và ảnh vệ tinh Ion"
   },
   "renderer": {
+    "basemap": "Sơ đồ cơ sở",
+    "imagery": "Hình ảnh",
     "projectBasemap": "Sơ đồ cơ sở của dự án",
     "layerUnsupported": "Không được kết xuất trên quả địa cầu 3D",
     "resetView": "Đặt lại chế độ xem",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -1826,6 +1826,7 @@
     "cesiumTokenHint": "Thêm mã thông báo Cesium Ion trong Cài đặt để dùng địa hình và ảnh vệ tinh Ion"
   },
   "renderer": {
+    "projectBasemap": "Sơ đồ cơ sở của dự án",
     "layerUnsupported": "Không được kết xuất trên quả địa cầu 3D",
     "resetView": "Đặt lại chế độ xem",
     "scene3D": "Quả địa cầu 3D",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1826,6 +1826,8 @@
     "cesiumTokenHint": "在设置中添加 Cesium Ion 令牌即可使用地形和 Ion 影像"
   },
   "renderer": {
+    "basemap": "底图",
+    "imagery": "影像",
     "projectBasemap": "项目底图",
     "layerUnsupported": "3D 地球不渲染此图层",
     "resetView": "重置视图",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1826,6 +1826,7 @@
     "cesiumTokenHint": "在设置中添加 Cesium Ion 令牌即可使用地形和 Ion 影像"
   },
   "renderer": {
+    "projectBasemap": "项目底图",
     "layerUnsupported": "3D 地球不渲染此图层",
     "resetView": "重置视图",
     "scene3D": "3D 地球",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -4454,3 +4454,75 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 .geolibre-cesium-ctrl .cesium-sceneModePicker-hidden {
   display: none;
 }
+
+/* The native basemap gallery opens beside the Cesium toolbar and stays inside
+   the map, including short split panes and fullscreen layouts. */
+.geolibre-cesium-basemap-picker {
+  position: relative;
+  z-index: 3;
+}
+
+.geolibre-cesium-basemap-picker button.cesium-button {
+  position: relative;
+  overflow: hidden;
+}
+
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-dropDown {
+  top: 0;
+  right: 39px;
+  margin-top: 0;
+  width: min(320px, calc(100vw - 90px));
+  max-height: min(500px, var(--cesium-picker-height, 60vh));
+  background: hsl(var(--popover) / 0.97);
+  font-family: var(--font-sans);
+  line-height: 1.35;
+  color: hsl(var(--popover-foreground));
+  border-color: hsl(var(--border));
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.2);
+}
+
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-sectionTitle,
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-categoryTitle,
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-itemLabel {
+  color: inherit;
+  font-family: inherit;
+}
+
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-choices {
+  border-color: hsl(var(--border));
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  padding: 8px;
+}
+
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-item {
+  width: 100%;
+  margin: 0;
+}
+
+.geolibre-cesium-basemap-picker
+  .cesium-baseLayerPicker-selectedItem
+  .cesium-baseLayerPicker-itemIcon {
+  border-color: hsl(var(--primary));
+}
+
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-item:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.geolibre-cesium-basemap-picker .cesium-baseLayerPicker-itemIcon {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+}
+
+.geolibre-cesium-basemap-picker
+  .cesium-baseLayerPicker-selectedItem
+  .cesium-baseLayerPicker-itemLabel {
+  color: hsl(var(--primary));
+  font-weight: 600;
+}

--- a/packages/core/src/cesium-imagery.ts
+++ b/packages/core/src/cesium-imagery.ts
@@ -28,7 +28,6 @@ import { BLANK_BASEMAP, DEFAULT_BASEMAP } from "./types";
 /** Stable project IDs and the corresponding Cesium bundled thumbnails / ion assets. */
 export const CESIUM_BASEMAPS = [
   { id: "project", name: "Project basemap", icon: "naturalEarthII.png" },
-  { id: "osm", name: "OpenStreetMap", icon: "openStreetMap.png" },
   { id: "natural-earth", name: "Natural Earth II", icon: "naturalEarthII.png" },
   { id: "bing-aerial", name: "Bing Maps Aerial", icon: "bingAerial.png", assetId: 2 },
   {
@@ -62,6 +61,64 @@ export const CESIUM_BASEMAPS = [
   },
   { id: "azure-aerial", name: "Azure Maps Aerial", icon: "azureAerial.png", assetId: 3891168 },
   { id: "azure-roads", name: "Azure Maps Roads", icon: "azureRoads.png", assetId: 3891169 },
+  {
+    id: "esri-imagery",
+    name: "ArcGIS World Imagery",
+    icon: "ArcGisMapServiceWorldImagery.png",
+    category: "Other",
+    service: "World_Imagery",
+  },
+  {
+    id: "esri-hillshade",
+    name: "ArcGIS World Hillshade",
+    icon: "ArcGisMapServiceWorldHillshade.png",
+    category: "Other",
+    service: "Elevation/World_Hillshade",
+  },
+  {
+    id: "esri-ocean",
+    name: "Esri World Ocean",
+    icon: "ArcGisMapServiceWorldOcean.png",
+    category: "Other",
+    service: "Ocean/World_Ocean_Base",
+  },
+  { id: "osm", name: "OpenStreetMap", icon: "openStreetMap.png", category: "Other" },
+  {
+    id: "stadia-watercolor",
+    name: "Stadia x Stamen Watercolor",
+    icon: "stamenWatercolor.png",
+    category: "Other",
+    stadiaStyle: "stamen_watercolor",
+    maximumLevel: 16,
+    extension: "jpg",
+  },
+  {
+    id: "stadia-toner",
+    name: "Stadia x Stamen Toner",
+    icon: "stamenToner.png",
+    category: "Other",
+    stadiaStyle: "stamen_toner",
+    maximumLevel: 20,
+    extension: "png",
+  },
+  {
+    id: "stadia-smooth",
+    name: "Stadia Alidade Smooth",
+    icon: "stadiaAlidadeSmooth.png",
+    category: "Other",
+    stadiaStyle: "alidade_smooth",
+    maximumLevel: 20,
+    extension: "png",
+  },
+  {
+    id: "stadia-dark",
+    name: "Stadia Alidade Smooth Dark",
+    icon: "stadiaAlidadeSmoothDark.png",
+    category: "Other",
+    stadiaStyle: "alidade_smooth_dark",
+    maximumLevel: 20,
+    extension: "png",
+  },
 ] as const;
 
 export type CesiumBasemapId = (typeof CESIUM_BASEMAPS)[number]["id"];
@@ -92,10 +149,13 @@ export type CesiumBasemapImagery =
   | { kind: "default" }
   | { kind: "ion"; assetId: number }
   | { kind: "natural-earth" }
+  | { kind: "arcgis"; url: string }
   | {
       kind: "xyz";
       /** Tile template with `{z}`/`{x}`/`{y}` placeholders. */
       template: string;
+      /** Credentials are resolved at render time, never embedded in the descriptor. */
+      apiKeyProvider?: "stadia";
       /** Credit to show on the globe, as the HTML the 2D map already uses. */
       attribution: string;
       /** Max native zoom of the source, so the globe overzooms rather than 404s. */
@@ -207,11 +267,13 @@ function toImagery(analogue: RasterAnalogue): CesiumBasemapImagery {
  */
 export function sameCesiumImagery(a: CesiumBasemapImagery, b: CesiumBasemapImagery): boolean {
   if (a.kind !== b.kind) return false;
+  if (a.kind === "arcgis" && b.kind === "arcgis") return a.url === b.url;
   if (a.kind === "ion" && b.kind === "ion") return a.assetId === b.assetId;
   // `none` and `default` carry no fields, so matching kinds is the whole test.
   if (a.kind !== "xyz" || b.kind !== "xyz") return true;
   return (
     a.template === b.template &&
+    a.apiKeyProvider === b.apiKeyProvider &&
     a.attribution === b.attribution &&
     a.maximumLevel === b.maximumLevel &&
     a.scheme === b.scheme &&
@@ -284,6 +346,27 @@ export function basemapToCesiumImagery(
   cesiumBasemap: CesiumBasemapId = "project",
 ): CesiumBasemapImagery {
   const entry = CESIUM_BASEMAPS.find((entry) => entry.id === cesiumBasemap);
+  if (entry && "service" in entry) {
+    return {
+      kind: "arcgis",
+      url: `https://services.arcgisonline.com/ArcGIS/rest/services/${entry.service}/MapServer`,
+    };
+  }
+  if (entry && "stadiaStyle" in entry) {
+    return {
+      kind: "xyz",
+      template: `https://tiles.stadiamaps.com/tiles/${entry.stadiaStyle}/{z}/{x}/{y}.${entry.extension}`,
+      maximumLevel: entry.maximumLevel,
+      apiKeyProvider: "stadia",
+      attribution:
+        '<a href="https://stadiamaps.com/">© Stadia Maps</a> ' +
+        (entry.stadiaStyle.startsWith("stamen_")
+          ? '<a href="https://stamen.com/">© Stamen Design</a> '
+          : "") +
+        '<a href="https://openmaptiles.org/">© OpenMapTiles</a> ' +
+        '<a href="https://www.openstreetmap.org/copyright">© OpenStreetMap contributors</a>',
+    };
+  }
   if (entry && "assetId" in entry) return { kind: "ion", assetId: entry.assetId };
   if (cesiumBasemap === "natural-earth") return { kind: "natural-earth" };
   if (cesiumBasemap === "osm") return toImagery(STREETS);

--- a/packages/core/src/cesium-imagery.ts
+++ b/packages/core/src/cesium-imagery.ts
@@ -25,6 +25,57 @@ import { getPlanetaryBasemapByStyleUrl } from "./ellipsoids";
 import { getRegionalBasemapByStyleUrl } from "./regional-basemaps";
 import { BLANK_BASEMAP, DEFAULT_BASEMAP } from "./types";
 
+/** Stable project IDs and the corresponding Cesium bundled thumbnails / ion assets. */
+export const CESIUM_BASEMAPS = [
+  { id: "project", name: "Project basemap", icon: "naturalEarthII.png" },
+  { id: "osm", name: "OpenStreetMap", icon: "openStreetMap.png" },
+  { id: "natural-earth", name: "Natural Earth II", icon: "naturalEarthII.png" },
+  { id: "bing-aerial", name: "Bing Maps Aerial", icon: "bingAerial.png", assetId: 2 },
+  {
+    id: "bing-labels",
+    name: "Bing Maps Aerial with Labels",
+    icon: "bingAerialLabels.png",
+    assetId: 3,
+  },
+  { id: "bing-roads", name: "Bing Maps Roads", icon: "bingRoads.png", assetId: 4 },
+  { id: "sentinel-2", name: "Sentinel-2", icon: "sentinel-2.png", assetId: 3954 },
+  { id: "blue-marble", name: "Blue Marble", icon: "blueMarble.png", assetId: 3845 },
+  { id: "earth-at-night", name: "Earth at night", icon: "earthAtNight.png", assetId: 3812 },
+  {
+    id: "google-satellite",
+    name: "Google Maps Satellite",
+    icon: "googleSatellite.png",
+    assetId: 3830182,
+  },
+  {
+    id: "google-labels",
+    name: "Google Maps Satellite with Labels",
+    icon: "googleSatelliteLabels.png",
+    assetId: 3830183,
+  },
+  { id: "google-roads", name: "Google Maps Roadmap", icon: "googleRoadmap.png", assetId: 3830184 },
+  {
+    id: "google-contour",
+    name: "Google Maps Contour",
+    icon: "googleContour.png",
+    assetId: 3830186,
+  },
+  { id: "azure-aerial", name: "Azure Maps Aerial", icon: "azureAerial.png", assetId: 3891168 },
+  { id: "azure-roads", name: "Azure Maps Roads", icon: "azureRoads.png", assetId: 3891169 },
+] as const;
+
+export type CesiumBasemapId = (typeof CESIUM_BASEMAPS)[number]["id"];
+
+export function normalizeCesiumBasemap(value: unknown): CesiumBasemapId {
+  return CESIUM_BASEMAPS.find((entry) => entry.id === value)?.id ?? "project";
+}
+
+/** Missing credentials fall back to the project background without changing the saved choice. */
+export function availableCesiumBasemap(value: unknown, hasIonToken: boolean): CesiumBasemapId {
+  const entry = CESIUM_BASEMAPS.find((entry) => entry.id === value);
+  return entry && (!("assetId" in entry) || hasIonToken) ? entry.id : "project";
+}
+
 /**
  * What the globe should draw underneath the project's data layers.
  *
@@ -39,6 +90,8 @@ import { BLANK_BASEMAP, DEFAULT_BASEMAP } from "./types";
 export type CesiumBasemapImagery =
   | { kind: "none" }
   | { kind: "default" }
+  | { kind: "ion"; assetId: number }
+  | { kind: "natural-earth" }
   | {
       kind: "xyz";
       /** Tile template with `{z}`/`{x}`/`{y}` placeholders. */
@@ -154,6 +207,7 @@ function toImagery(analogue: RasterAnalogue): CesiumBasemapImagery {
  */
 export function sameCesiumImagery(a: CesiumBasemapImagery, b: CesiumBasemapImagery): boolean {
   if (a.kind !== b.kind) return false;
+  if (a.kind === "ion" && b.kind === "ion") return a.assetId === b.assetId;
   // `none` and `default` carry no fields, so matching kinds is the whole test.
   if (a.kind !== "xyz" || b.kind !== "xyz") return true;
   return (
@@ -225,7 +279,14 @@ function vectorStyleAnalogue(styleUrl: string): RasterAnalogue | undefined {
  * @param styleUrl - The project's `basemapStyleUrl`.
  * @returns What the globe should draw beneath the data layers.
  */
-export function basemapToCesiumImagery(styleUrl: string | undefined): CesiumBasemapImagery {
+export function basemapToCesiumImagery(
+  styleUrl: string | undefined,
+  cesiumBasemap: CesiumBasemapId = "project",
+): CesiumBasemapImagery {
+  const entry = CESIUM_BASEMAPS.find((entry) => entry.id === cesiumBasemap);
+  if (entry && "assetId" in entry) return { kind: "ion", assetId: entry.assetId };
+  if (cesiumBasemap === "natural-earth") return { kind: "natural-earth" };
+  if (cesiumBasemap === "osm") return toImagery(STREETS);
   if (styleUrl === BLANK_BASEMAP) return { kind: "none" };
   const url = styleUrl ?? DEFAULT_BASEMAP;
 

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1,3 +1,4 @@
+import { normalizeCesiumBasemap } from "./cesium-imagery";
 import { v4 as uuidv4 } from "uuid";
 import {
   DEFAULT_BASEMAP,
@@ -1219,6 +1220,9 @@ function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
       showPointerElevation: normalizeBoolean(
         (map as Partial<ProjectPreferences["map"]>).showPointerElevation,
         DEFAULT_PROJECT_PREFERENCES.map.showPointerElevation,
+      ),
+      cesiumBasemap: normalizeCesiumBasemap(
+        (map as Partial<ProjectPreferences["map"]>).cesiumBasemap,
       ),
       // Older projects omit this field and continue to open with terrain off.
       terrainEnabled: normalizeBoolean(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1584,6 +1584,8 @@ export interface MapPreferences {
   showPointerElevation: boolean;
   /** Whether the built-in 3D terrain control and terrain surface are enabled. */
   terrainEnabled: boolean;
+  /** Cesium imagery override; absent follows the shared project basemap. */
+  cesiumBasemap?: import("./cesium-imagery").CesiumBasemapId;
   /**
    * Notation the status bar reports the pointer coordinate in: `"dd"` decimal
    * degrees (default), `"dms"` degrees/minutes/seconds, `"ddm"` degrees and

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -10,7 +10,7 @@ import {
 } from "@geolibre/core";
 import type { CesiumWidget, ImageryLayer } from "@cesium/engine";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
-import { applyBasemapAppearance, applyBasemapImagery } from "./cesium-basemap";
+import { applyBasemapAppearance, applyBasemapImagery, getStadiaApiKey } from "./cesium-basemap";
 import { isSameView } from "./cesium-camera";
 import { CesiumEngine } from "./cesium-engine";
 import type { MapEngine } from "./map-engine";
@@ -353,6 +353,11 @@ export const CesiumCanvas = memo(function CesiumCanvas({
         cesiumRef.current = Cesium;
         viewerRef.current = viewer;
 
+        // Match the pale globe and dark space used by the MapLibre view while
+        // retaining Cesium's native stars and atmospheric glow.
+        viewer.scene.globe.baseColor = Cesium.Color.fromCssColorString("#cae2f8");
+        viewer.scene.backgroundColor = Cesium.Color.fromCssColorString("#0c1b33");
+
         // Note for anyone reintroducing `Viewer`: it installs a double-click
         // "track entity" gesture that flies to and camera-locks a picked
         // feature, which fights the store-driven camera sync and isn't wired to
@@ -491,6 +496,25 @@ export const CesiumCanvas = memo(function CesiumCanvas({
     applyBasemap();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, basemapImagery]);
+
+  // Stadia can authenticate through a registered domain or a runtime API key.
+  // Rebuild only its active provider when that key changes in Settings.
+  useEffect(() => {
+    if (!ready) return;
+    let key = getStadiaApiKey();
+    const refresh = () => {
+      const next = getStadiaApiKey();
+      if (next === key) return;
+      key = next;
+      const imagery = basemapImageryRef.current;
+      if (imagery.kind !== "xyz" || imagery.apiKeyProvider !== "stadia") return;
+      appliedImageryRef.current = null;
+      applyBasemap();
+    };
+    window.addEventListener("geolibre:runtime-env-change", refresh);
+    return () => window.removeEventListener("geolibre:runtime-env-change", refresh);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready]);
 
   // Terrain selection uses the same saved preference as Controls → Terrain,
   // including globe panes that do not host a toolbar.

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -1,5 +1,6 @@
 import {
   applyGroupEffects,
+  availableCesiumBasemap,
   basemapToCesiumImagery,
   sameCesiumImagery,
   useAppStore,
@@ -39,7 +40,7 @@ const CESIUM_CSS_LINK_ID = "cesium-widgets-css";
  * The Cesium stylesheets this pane actually needs, in cascade order.
  *
  * Not the full `Widgets/widgets.css` (32 KB), which also carries the chrome for
- * the base-layer picker, geocoder, timeline, animation dial and info box — none
+ * the geocoder, timeline, animation dial and info box — none
  * of which this pane creates. All of them are staged by copy-cesium-assets, so
  * narrowing the links costs nothing and keeps unused rules out of the document.
  *
@@ -60,6 +61,7 @@ const CESIUM_CSS_PATHS = [
   "/Widgets/shared.css",
   "/Widgets/SceneModePicker/SceneModePicker.css",
   "/Widgets/FullscreenButton/FullscreenButton.css",
+  "/Widgets/BaseLayerPicker/BaseLayerPicker.css",
 ] as const;
 
 export interface CesiumCanvasProps {
@@ -224,7 +226,16 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   // shares the primary map's basemap, so this is read straight from the store
   // the way `layers` is.
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
-  const basemapImagery = useMemo(() => basemapToCesiumImagery(basemapStyleUrl), [basemapStyleUrl]);
+  const cesiumBasemap = useAppStore((s) => s.preferences.map.cesiumBasemap);
+  const terrainEnabled = useAppStore((s) => s.preferences.map.terrainEnabled);
+  const basemapImagery = useMemo(
+    () =>
+      basemapToCesiumImagery(
+        basemapStyleUrl,
+        availableCesiumBasemap(cesiumBasemap, Boolean(ionToken?.trim())),
+      ),
+    [basemapStyleUrl, cesiumBasemap, ionToken],
+  );
   // Read from the mount effect's initial draw without making that
   // dependency-free effect re-run, mirroring paneLayersRef above.
   const basemapImageryRef = useRef(basemapImagery);
@@ -355,14 +366,18 @@ export const CesiumCanvas = memo(function CesiumCanvas({
         // tracking, publishing moves back to the store, and layer sync. It is
         // constructed before the terrain await below so its listeners are armed
         // for the whole mount, exactly as the hand-rolled versions were.
-        const engine = new CesiumEngine(Cesium, viewer, { viewId: viewIdRef.current });
+        const engine = new CesiumEngine(Cesium, viewer, {
+          viewId: viewIdRef.current,
+          worldTerrainAvailable: Boolean(token),
+        });
         engineInstanceRef.current = engine;
 
-        // With a token, add Cesium World Terrain so tilted views show relief.
+        // Restore the saved terrain preference when credentials are available.
         // Awaited before the camera is seeded: ground height is what turns
         // MapLibre's zoom into a camera distance, so seeding first would place
         // the first frame against the ellipsoid.
-        if (token) await engine.enableWorldTerrain();
+        if (token && useAppStore.getState().preferences.map.terrainEnabled)
+          await engine.enableWorldTerrain();
         // The unmount cleanup may have run during the terrain await (destroying
         // the viewer); re-check before touching it, mirroring the guard after the
         // dynamic import above and CesiumLayerSync's post-await checks. Otherwise
@@ -374,7 +389,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({
           const host = new CesiumControlHost(viewer, container);
           controlHostRef.current = host;
           setPrimaryCesiumControlHost(host);
-          // Cesium's own home and scene-mode buttons (issue #2270). Imported
+          // Cesium's native toolbar widgets. Imported
           // here rather than at module scope so `@cesium/widgets` stays in the
           // lazily fetched `cesium` chunk instead of joining the 2D boot path.
           const { createCesiumWidgetControls } = await import("./cesium-widget-controls");
@@ -387,13 +402,14 @@ export const CesiumCanvas = memo(function CesiumCanvas({
               viewer,
               container,
               controlLabelsRef.current,
+              Boolean(token),
             );
             widgetControlsRef.current = controls;
             // Top-right, above MapLibre's navigation control on the 2D map, so
             // the toolbar reads the same whichever renderer is drawing.
             for (const control of controls.all) host.addControl(control, "top-right");
             // Hand the fullscreen button to the engine so Controls → Fullscreen
-            // governs it here as it does on the 2D map. The other two have no
+            // governs it here as it does on the 2D map. The other widgets have no
             // menu counterpart and stay unconditional.
             engine.registerBuiltInControl("fullscreen", controls.fullscreen);
           }
@@ -475,6 +491,15 @@ export const CesiumCanvas = memo(function CesiumCanvas({
     applyBasemap();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, basemapImagery]);
+
+  // Terrain selection uses the same saved preference as Controls → Terrain,
+  // including globe panes that do not host a toolbar.
+  useEffect(() => {
+    const engine = engineInstanceRef.current;
+    if (!ready || !engine) return;
+    const enabled = terrainEnabled && Boolean(ionToken?.trim());
+    if (engine.isTerrainEnabled() !== enabled) engine.setTerrainEnabled(enabled);
+  }, [ready, terrainEnabled, ionToken]);
 
   // Hiding or fading the background is a live appearance change, so it re-styles
   // the existing layers rather than rebuilding them.

--- a/packages/map/src/cesium-base-layer-picker.ts
+++ b/packages/map/src/cesium-base-layer-picker.ts
@@ -1,0 +1,203 @@
+import {
+  availableCesiumBasemap,
+  CESIUM_BASEMAPS,
+  useAppStore,
+  type CesiumBasemapId,
+} from "@geolibre/core";
+import { buildModuleUrl, type CesiumWidget } from "@cesium/engine";
+import { BaseLayerPicker, ProviderViewModel } from "@cesium/widgets";
+import type {
+  CesiumWidgetControlHandle,
+  CesiumWidgetControlLabels,
+} from "./cesium-widget-controls";
+
+/**
+ * Native Cesium picker chrome with GeoLibre retaining ownership of the scene.
+ * Imagery commands return an empty provider array and terrain commands are
+ * cancelled through beforeExecute, so BaseLayerPicker only changes its selection.
+ * The saved settings drive CesiumCanvas, which preserves background opacity and data-layer order.
+ * Programmatic selection updates are guarded so opening a project never dirties it.
+ */
+export class CesiumBaseLayerPickerControl implements CesiumWidgetControlHandle {
+  private container: HTMLDivElement | null = null;
+  private picker: BaseLayerPicker | null = null;
+  private stopWatching: (() => void) | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  private syncing = false;
+  private imagery = new Map<CesiumBasemapId, ProviderViewModel>();
+  private terrain = new Map<boolean, ProviderViewModel>();
+
+  constructor(
+    private readonly viewer: CesiumWidget,
+    private labels: CesiumWidgetControlLabels,
+    private readonly hasIonToken: boolean,
+  ) {}
+
+  onAdd(): HTMLElement {
+    const container = document.createElement("div");
+    container.className = "maplibregl-ctrl geolibre-cesium-ctrl geolibre-cesium-basemap-picker";
+    this.container = container;
+    if (this.viewer.isDestroyed()) return container;
+
+    for (const entry of CESIUM_BASEMAPS) {
+      if ("assetId" in entry && !this.hasIonToken) continue;
+      this.imagery.set(
+        entry.id,
+        new ProviderViewModel({
+          name: entry.name,
+          tooltip: entry.name,
+          iconUrl: buildModuleUrl(`Widgets/Images/ImageryProviders/${entry.icon}`),
+          category: "assetId" in entry ? "Cesium ion" : "GeoLibre",
+          creationFunction: () => {
+            if (!this.syncing) this.selectImagery(entry.id);
+            return [];
+          },
+        }),
+      );
+    }
+    for (const enabled of [false, true]) {
+      if (enabled && !this.hasIonToken) continue;
+      const name = enabled ? "Cesium World Terrain" : "WGS84 Ellipsoid";
+      const model = new ProviderViewModel({
+        name,
+        tooltip: name,
+        iconUrl: buildModuleUrl(
+          `Widgets/Images/TerrainProviders/${enabled ? "CesiumWorldTerrain" : "Ellipsoid"}.png`,
+        ),
+        category: "",
+        creationFunction: () => this.viewer.terrainProvider,
+      });
+      model.creationCommand.beforeExecute.addEventListener((event) => {
+        // A cancelled command returns undefined, telling the picker to leave
+        // the provider alone. The engine applies the saved terrain preference.
+        event.cancel = true;
+        if (!this.syncing) {
+          const { preferences, setPreferences } = useAppStore.getState();
+          if (preferences.map.terrainEnabled !== enabled) {
+            setPreferences({
+              ...preferences,
+              map: { ...preferences.map, terrainEnabled: enabled },
+            });
+          }
+        }
+      });
+      this.terrain.set(enabled, model);
+    }
+
+    // Start empty: Cesium otherwise executes the first imagery command during
+    // construction, which would overwrite a saved selection.
+    const picker = new BaseLayerPicker(container, { globe: this.viewer.scene.globe });
+    this.picker = picker;
+    picker.viewModel.imageryProviderViewModels = [...this.imagery.values()];
+    picker.viewModel.terrainProviderViewModels = [...this.terrain.values()];
+    this.syncSelection();
+    this.setLabels(this.labels);
+    this.stopWatching = useAppStore.subscribe((state, previous) => {
+      if (
+        state.preferences.map.cesiumBasemap !== previous.preferences.map.cesiumBasemap ||
+        state.preferences.map.terrainEnabled !== previous.preferences.map.terrainEnabled
+      ) {
+        // The native setter publishes its observable *after* creationCommand.
+        // Synchronize after that setter returns, avoiding reentrant selection.
+        queueMicrotask(() => {
+          if (this.picker === picker) this.syncSelection();
+        });
+      }
+    });
+
+    const button = container.querySelector("button")!;
+    for (const item of container.querySelectorAll<HTMLElement>(".cesium-baseLayerPicker-item")) {
+      item.tabIndex = 0;
+      item.setAttribute("role", "radio");
+    }
+    container.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        picker.viewModel.dropDownVisible = false;
+        button.focus();
+        event.stopPropagation();
+      } else if (
+        (event.key === "Enter" || event.key === " ") &&
+        event.target instanceof HTMLElement &&
+        event.target.classList.contains("cesium-baseLayerPicker-item")
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.target.click();
+        button.focus();
+      }
+    });
+    const resize = () => {
+      const available =
+        this.viewer.container.getBoundingClientRect().bottom -
+        container.getBoundingClientRect().top -
+        12;
+      container.style.setProperty("--cesium-picker-height", `${Math.max(80, available)}px`);
+    };
+    this.resizeObserver = new ResizeObserver(resize);
+    this.resizeObserver.observe(this.viewer.container);
+    this.updateAccessibility();
+    return container;
+  }
+
+  private selectImagery(id: CesiumBasemapId): void {
+    const { preferences, setPreferences } = useAppStore.getState();
+    if ((preferences.map.cesiumBasemap ?? "project") !== id) {
+      setPreferences({ ...preferences, map: { ...preferences.map, cesiumBasemap: id } });
+    }
+  }
+
+  private syncSelection(): void {
+    if (!this.picker) return;
+    const { map } = useAppStore.getState().preferences;
+    this.syncing = true;
+    try {
+      const vm = this.picker.viewModel;
+      const imagery = this.imagery.get(
+        availableCesiumBasemap(map.cesiumBasemap, this.hasIonToken),
+      )!;
+      const terrain = this.terrain.get(map.terrainEnabled && this.hasIonToken)!;
+      if (vm.selectedImagery !== imagery) vm.selectedImagery = imagery;
+      if (vm.selectedTerrain !== terrain) vm.selectedTerrain = terrain;
+    } finally {
+      this.syncing = false;
+    }
+    this.updateAccessibility();
+  }
+
+  private updateAccessibility(): void {
+    for (const item of this.container?.querySelectorAll(".cesium-baseLayerPicker-item") ?? []) {
+      item.setAttribute(
+        "aria-checked",
+        String(item.classList.contains("cesium-baseLayerPicker-selectedItem")),
+      );
+    }
+  }
+
+  setLabels(labels: CesiumWidgetControlLabels): void {
+    this.labels = labels;
+    const project = this.imagery.get("project");
+    if (project) {
+      project.name = labels.projectBasemap ?? "Project basemap";
+      project.tooltip = project.name;
+    }
+    const titles = this.container?.querySelectorAll(".cesium-baseLayerPicker-sectionTitle");
+    if (titles?.[0]) titles[0].textContent = labels.imagery ?? "Imagery";
+    if (titles?.[1]) titles[1].textContent = labels.terrain ?? "Terrain";
+    this.container
+      ?.querySelector("button")
+      ?.setAttribute("aria-label", labels.basemap ?? "Basemap");
+  }
+
+  onRemove(): void {
+    this.stopWatching?.();
+    this.stopWatching = null;
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    if (this.picker && !this.picker.isDestroyed()) this.picker.destroy();
+    this.picker = null;
+    this.imagery.clear();
+    this.terrain.clear();
+    this.container?.remove();
+    this.container = null;
+  }
+}

--- a/packages/map/src/cesium-base-layer-picker.ts
+++ b/packages/map/src/cesium-base-layer-picker.ts
@@ -47,7 +47,8 @@ export class CesiumBaseLayerPickerControl implements CesiumWidgetControlHandle {
           name: entry.name,
           tooltip: entry.name,
           iconUrl: buildModuleUrl(`Widgets/Images/ImageryProviders/${entry.icon}`),
-          category: "assetId" in entry ? "Cesium ion" : "GeoLibre",
+          category:
+            "category" in entry ? entry.category : "assetId" in entry ? "Cesium ion" : "GeoLibre",
           creationFunction: () => {
             if (!this.syncing) this.selectImagery(entry.id);
             return [];
@@ -179,6 +180,14 @@ export class CesiumBaseLayerPickerControl implements CesiumWidgetControlHandle {
     if (project) {
       project.name = labels.projectBasemap ?? "Project basemap";
       project.tooltip = project.name;
+    }
+    for (const title of this.container?.querySelectorAll<HTMLElement>(
+      ".cesium-baseLayerPicker-categoryTitle",
+    ) ?? []) {
+      if (title.textContent === "Other" || title.dataset.otherCategory) {
+        title.dataset.otherCategory = "true";
+        title.textContent = labels.other ?? "Other";
+      }
     }
     const titles = this.container?.querySelectorAll(".cesium-baseLayerPicker-sectionTitle");
     if (titles?.[0]) titles[0].textContent = labels.imagery ?? "Imagery";

--- a/packages/map/src/cesium-basemap.ts
+++ b/packages/map/src/cesium-basemap.ts
@@ -92,6 +92,18 @@ export function applyBasemapImagery(
   // ellipsoid bare, as the 2D panes leave their canvas empty.
   if (imagery.kind === "none") return [];
 
+  if (imagery.kind === "ion" || imagery.kind === "natural-earth") {
+    const provider =
+      imagery.kind === "ion"
+        ? Cesium.IonImageryProvider.fromAssetId(imagery.assetId, { accessToken: ionToken })
+        : Cesium.TileMapServiceImageryProvider.fromUrl(
+            Cesium.buildModuleUrl("Assets/Textures/NaturalEarthII"),
+          );
+    const layer = Cesium.ImageryLayer.fromProviderAsync(provider);
+    viewer.imageryLayers.add(layer, 0);
+    return [layer];
+  }
+
   if (imagery.kind === "default") {
     // No raster equivalent for this basemap (a provider style, a custom URL).
     // Ion World Imagery when a token is configured — the globe's historical

--- a/packages/map/src/cesium-basemap.ts
+++ b/packages/map/src/cesium-basemap.ts
@@ -1,4 +1,4 @@
-import type { CesiumBasemapImagery } from "@geolibre/core";
+import { getRuntimeEnvironment, type CesiumBasemapImagery } from "@geolibre/core";
 import type { CesiumWidget, ImageryLayer, ImageryProvider } from "@cesium/engine";
 
 // Draws the project basemap on the Cesium globe. `@geolibre/core`'s
@@ -17,6 +17,11 @@ type CesiumNs = typeof import("@cesium/engine");
 /** Keyless imagery for a basemap with no raster form when no Ion token is set. */
 const KEYLESS_FALLBACK_URL = "https://tile.openstreetmap.org/";
 
+/** Read the live key so Settings changes do not require a new project. */
+export function getStadiaApiKey(env = getRuntimeEnvironment()): string | undefined {
+  return env.VITE_STADIA_API_KEY?.trim() || env.STADIA_API_KEY?.trim() || undefined;
+}
+
 /**
  * An imagery provider for one tile template. TMS row ordering is expressed by
  * swapping `{y}` for Cesium's `{reverseY}` placeholder: Cesium has no `scheme`
@@ -26,10 +31,18 @@ const KEYLESS_FALLBACK_URL = "https://tile.openstreetmap.org/";
 function templateProvider(
   Cesium: CesiumNs,
   template: string,
-  options: { attribution?: string; maximumLevel?: number; scheme?: "tms" },
+  options: {
+    attribution?: string;
+    maximumLevel?: number;
+    scheme?: "tms";
+    apiKeyProvider?: "stadia";
+  },
 ): ImageryProvider {
+  let url = options.scheme === "tms" ? template.replace("{y}", "{reverseY}") : template;
+  const key = options.apiKeyProvider === "stadia" ? getStadiaApiKey() : undefined;
+  if (key) url += `?api_key=${encodeURIComponent(key)}`;
   return new Cesium.UrlTemplateImageryProvider({
-    url: options.scheme === "tms" ? template.replace("{y}", "{reverseY}") : template,
+    url,
     maximumLevel: options.maximumLevel,
     // Cesium shows this in its own credit display, keeping the keyless raster
     // basemaps licence-clean the way the 2D map's attribution control does.
@@ -92,6 +105,16 @@ export function applyBasemapImagery(
   // ellipsoid bare, as the 2D panes leave their canvas empty.
   if (imagery.kind === "none") return [];
 
+  if (imagery.kind === "arcgis") {
+    // Public ArcGIS services supply their own attribution and tile-level limits.
+    // Avoid Cesium's bundled evaluation token for the authenticated basemap API.
+    const layer = Cesium.ImageryLayer.fromProviderAsync(
+      Cesium.ArcGisMapServerImageryProvider.fromUrl(imagery.url, { enablePickFeatures: false }),
+    );
+    viewer.imageryLayers.add(layer, 0);
+    return [layer];
+  }
+
   if (imagery.kind === "ion" || imagery.kind === "natural-earth") {
     const provider =
       imagery.kind === "ion"
@@ -119,10 +142,10 @@ export function applyBasemapImagery(
     return [layer];
   }
 
-  const { template, attribution, maximumLevel, scheme, overlayTemplate } = imagery;
+  const { template, attribution, maximumLevel, scheme, overlayTemplate, apiKeyProvider } = imagery;
   const added = [
     viewer.imageryLayers.addImageryProvider(
-      templateProvider(Cesium, template, { attribution, maximumLevel, scheme }),
+      templateProvider(Cesium, template, { attribution, maximumLevel, scheme, apiKeyProvider }),
       0,
     ),
   ];

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -111,6 +111,8 @@ const FLY_SECONDS = 0.8;
 const POINT_FIT_ZOOM = 14;
 
 export interface CesiumEngineOptions {
+  /** Whether this canvas has credentials for Cesium World Terrain. */
+  worldTerrainAvailable?: boolean;
   /**
    * Id of the `secondaryMapViews` record this globe draws, or `undefined` when
    * it *is* the primary map area. Decides which camera the engine publishes to
@@ -198,6 +200,7 @@ export class CesiumEngine implements MapEngine {
   private minZoom = 0;
   private maxZoom = 24;
 
+  private readonly worldTerrainAvailable: boolean;
   private terrainEnabled = false;
   private terrainExaggeration = 1;
   private disposers: Array<() => void> = [];
@@ -211,6 +214,7 @@ export class CesiumEngine implements MapEngine {
     this.Cesium = Cesium;
     this.viewer = viewer;
     this.viewId = options.viewId;
+    this.worldTerrainAvailable = options.worldTerrainAvailable ?? true;
     this.capabilities =
       options.viewId === undefined ? CESIUM_CAPABILITIES : CESIUM_PANE_CAPABILITIES;
     this.layerSync = new CesiumLayerSync(Cesium, viewer);
@@ -576,6 +580,9 @@ export class CesiumEngine implements MapEngine {
   }
 
   setBuiltInControlVisible(control: BuiltInMapControl, visible: boolean): boolean {
+    // Terrain is a scene setting; unlike fullscreen it has no separate control
+    // instance. The menu and project restore must still reach the engine.
+    if (control === "terrain" && this.isPrimary) return this.setTerrainEnabled(visible);
     const instance = this.builtInControls.get(control);
     if (!instance || !this.isPrimary) return false;
     const host = getPrimaryCesiumControlHost();
@@ -620,7 +627,8 @@ export class CesiumEngine implements MapEngine {
    */
   setTerrainEnabled(enabled: boolean): boolean {
     const viewer = this.live();
-    if (!viewer) return false;
+    if (!viewer || (enabled && !this.worldTerrainAvailable)) return false;
+    if (this.terrainEnabled === enabled) return true;
     if (!enabled) {
       this.terrainEnabled = false;
       viewer.terrainProvider = new this.Cesium.EllipsoidTerrainProvider();
@@ -641,6 +649,7 @@ export class CesiumEngine implements MapEngine {
    * to it fire-and-forget.
    */
   async enableWorldTerrain(): Promise<void> {
+    if (!this.worldTerrainAvailable) return;
     this.terrainEnabled = true;
     try {
       const provider = await this.Cesium.createWorldTerrainAsync();

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -202,6 +202,7 @@ export class CesiumEngine implements MapEngine {
 
   private readonly worldTerrainAvailable: boolean;
   private terrainEnabled = false;
+  private terrainRequest = 0;
   private terrainExaggeration = 1;
   private disposers: Array<() => void> = [];
   /**
@@ -631,6 +632,7 @@ export class CesiumEngine implements MapEngine {
     if (this.terrainEnabled === enabled) return true;
     if (!enabled) {
       this.terrainEnabled = false;
+      this.terrainRequest++;
       viewer.terrainProvider = new this.Cesium.EllipsoidTerrainProvider();
       return true;
     }
@@ -651,15 +653,19 @@ export class CesiumEngine implements MapEngine {
   async enableWorldTerrain(): Promise<void> {
     if (!this.worldTerrainAvailable) return;
     this.terrainEnabled = true;
+    const request = ++this.terrainRequest;
     try {
       const provider = await this.Cesium.createWorldTerrainAsync();
       const viewer = this.live();
       // The toggle may have been reversed, or the viewer destroyed, while the
       // provider loaded; applying it then would resurrect terrain the user just
       // turned off.
-      if (viewer && this.terrainEnabled) viewer.terrainProvider = provider;
+      if (viewer && this.terrainEnabled && request === this.terrainRequest) {
+        viewer.terrainProvider = provider;
+      }
     } catch {
-      // Terrain is best-effort; the globe still renders without it.
+      // Allow a subsequent enable to retry, without resetting a newer request.
+      if (request === this.terrainRequest) this.terrainEnabled = false;
     }
   }
 

--- a/packages/map/src/cesium-widget-controls.ts
+++ b/packages/map/src/cesium-widget-controls.ts
@@ -43,6 +43,7 @@ const CONTROL_CLASS = "geolibre-cesium-ctrl";
 export interface CesiumWidgetControlLabels {
   basemap?: string;
   imagery?: string;
+  other?: string;
   terrain?: string;
   projectBasemap?: string;
   /** Tooltip for the home button. */

--- a/packages/map/src/cesium-widget-controls.ts
+++ b/packages/map/src/cesium-widget-controls.ts
@@ -4,14 +4,9 @@ import type { CesiumWidget } from "@cesium/engine";
 // Cesium's own toolbar widgets, mounted on GeoLibre's map as regular map
 // controls (issue #2270).
 //
-// `CesiumCanvas` builds a bare `CesiumWidget` rather than a `Viewer`, precisely
-// so it does not inherit the toolbar Cesium's full app wrapper constructs —
-// base-layer picker, geocoder, home button, scene-mode picker, help button,
-// timeline, animation dial, info box — most of which duplicate something
-// GeoLibre already owns. Three of them do not: nothing else in the app returns
-// the camera to a whole-Earth view, nothing at all reaches Cesium's 2D and
-// Columbus scene modes, and MapLibre's fullscreen control is bound to a
-// `maplibregl.Map` the globe does not have.
+// `CesiumCanvas` builds a bare `CesiumWidget` and mounts the home, scene-mode,
+// basemap and fullscreen widgets individually. The basemap picker writes to
+// project preferences; CesiumCanvas remains the owner of the imagery stack.
 //
 // Each widget is constructible on its own against a container element, so none
 // needs `Viewer`. They are wrapped as `maplibregl.IControl`s so
@@ -22,6 +17,8 @@ import type { CesiumWidget } from "@cesium/engine";
 // mount effect: `@cesium/widgets` is a static import below, and a static import
 // from `CesiumCanvas` would pull the widget chrome (and Knockout) onto the 2D
 // boot path instead of leaving it in the lazily fetched `cesium` chunk.
+
+import { CesiumBaseLayerPickerControl } from "./cesium-base-layer-picker";
 
 import { FullscreenButton, HomeButton, SceneModePicker } from "@cesium/widgets";
 
@@ -44,6 +41,10 @@ const CONTROL_CLASS = "geolibre-cesium-ctrl";
  * that owns them rather than read from a hook here.
  */
 export interface CesiumWidgetControlLabels {
+  basemap?: string;
+  imagery?: string;
+  terrain?: string;
+  projectBasemap?: string;
   /** Tooltip for the home button. */
   home: string;
   /** Tooltip for the 3D globe scene mode. */
@@ -290,7 +291,7 @@ export type CesiumWidgetControlHandle = maplibregl.IControl & {
  *
  * `fullscreen` is named separately because it is the one the app already has a
  * toggle for — Controls → Fullscreen — so `CesiumEngine` needs a handle on it
- * to answer `setBuiltInControlVisible`. The other two have no such counterpart
+ * to answer `setBuiltInControlVisible`. The remaining controls have no such counterpart
  * and are simply always present.
  */
 export interface CesiumWidgetControls {
@@ -314,12 +315,14 @@ export function createCesiumWidgetControls(
   viewer: CesiumWidget,
   fullscreenElement: HTMLElement,
   labels: CesiumWidgetControlLabels = DEFAULT_CESIUM_WIDGET_CONTROL_LABELS,
+  hasIonToken = false,
 ): CesiumWidgetControls {
   const fullscreen = new CesiumFullscreenControl(viewer, labels, fullscreenElement);
   return {
     all: [
       new CesiumHomeControl(viewer, labels),
       new CesiumSceneModeControl(viewer, labels),
+      new CesiumBaseLayerPickerControl(viewer, labels, hasIonToken),
       fullscreen,
     ],
     fullscreen,

--- a/tests/cesium-basemap-picker.test.ts
+++ b/tests/cesium-basemap-picker.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  availableCesiumBasemap,
+  basemapToCesiumImagery,
+  CESIUM_BASEMAPS,
+  normalizeCesiumBasemap,
+  sameCesiumImagery,
+} from "../packages/core/src/cesium-imagery";
+import { createEmptyProject, parseProject, serializeProject } from "../packages/core/src/project";
+
+describe("Cesium basemap choices", () => {
+  it("keeps stable unique IDs and normalizes unrecognized project values", () => {
+    assert.equal(new Set(CESIUM_BASEMAPS.map((entry) => entry.id)).size, CESIUM_BASEMAPS.length);
+    for (const value of [undefined, null, {}, "unknown", 3954]) {
+      assert.equal(normalizeCesiumBasemap(value), "project");
+    }
+    for (const entry of CESIUM_BASEMAPS) assert.equal(normalizeCesiumBasemap(entry.id), entry.id);
+  });
+
+  it("gates only ion-backed imagery on credentials", () => {
+    for (const entry of CESIUM_BASEMAPS) {
+      assert.equal(availableCesiumBasemap(entry.id, true), entry.id);
+      assert.equal(
+        availableCesiumBasemap(entry.id, false),
+        "assetId" in entry ? "project" : entry.id,
+      );
+    }
+  });
+
+  it("resolves overrides independently from the MapLibre background", () => {
+    assert.deepEqual(basemapToCesiumImagery("geolibre://blank", "natural-earth"), {
+      kind: "natural-earth",
+    });
+    assert.deepEqual(basemapToCesiumImagery(undefined, "sentinel-2"), {
+      kind: "ion",
+      assetId: 3954,
+    });
+    const osm = basemapToCesiumImagery(undefined, "osm");
+    assert.equal(osm.kind, "xyz");
+    if (osm.kind === "xyz")
+      assert.equal(osm.template, "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+    assert.deepEqual(
+      basemapToCesiumImagery(undefined, "project"),
+      basemapToCesiumImagery(undefined),
+    );
+  });
+
+  it("does not treat different ion assets as the same background", () => {
+    assert.equal(
+      sameCesiumImagery({ kind: "ion", assetId: 2 }, { kind: "ion", assetId: 3 }),
+      false,
+    );
+    assert.equal(sameCesiumImagery({ kind: "ion", assetId: 2 }, { kind: "ion", assetId: 2 }), true);
+    assert.equal(sameCesiumImagery({ kind: "natural-earth" }, { kind: "default" }), false);
+  });
+
+  it("round-trips the imagery and terrain selection through saved projects", () => {
+    const project = createEmptyProject();
+    project.preferences!.map.cesiumBasemap = "blue-marble";
+    project.preferences!.map.terrainEnabled = true;
+    const restored = parseProject(serializeProject(project));
+    assert.equal(restored.preferences?.map.cesiumBasemap, "blue-marble");
+    assert.equal(restored.preferences?.map.terrainEnabled, true);
+    const invalid = JSON.parse(serializeProject(project));
+    invalid.preferences.map.cesiumBasemap = "unrecognized-provider";
+    assert.equal(parseProject(JSON.stringify(invalid)).preferences?.map.cesiumBasemap, "project");
+    delete invalid.preferences.map.cesiumBasemap;
+    assert.equal(parseProject(JSON.stringify(invalid)).preferences?.map.cesiumBasemap, "project");
+  });
+});

--- a/tests/cesium-basemap-picker.test.ts
+++ b/tests/cesium-basemap-picker.test.ts
@@ -46,6 +46,74 @@ describe("Cesium basemap choices", () => {
     );
   });
 
+  it("includes the eight Other providers without requiring an ion token", () => {
+    const other = CESIUM_BASEMAPS.filter(
+      (entry) => "category" in entry && entry.category === "Other",
+    );
+    assert.deepEqual(
+      other.map((entry) => entry.id),
+      [
+        "esri-imagery",
+        "esri-hillshade",
+        "esri-ocean",
+        "osm",
+        "stadia-watercolor",
+        "stadia-toner",
+        "stadia-smooth",
+        "stadia-dark",
+      ],
+    );
+    for (const entry of other) {
+      assert.equal(availableCesiumBasemap(entry.id, false), entry.id);
+      const project = createEmptyProject();
+      project.preferences!.map.cesiumBasemap = entry.id;
+      assert.equal(
+        parseProject(serializeProject(project)).preferences?.map.cesiumBasemap,
+        entry.id,
+      );
+    }
+  });
+
+  it("resolves public Esri services and keeps distinct services distinct", () => {
+    const imagery = basemapToCesiumImagery(undefined, "esri-imagery");
+    const hillshade = basemapToCesiumImagery(undefined, "esri-hillshade");
+    assert.deepEqual(imagery, {
+      kind: "arcgis",
+      url: "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer",
+    });
+    assert.equal(sameCesiumImagery(imagery, hillshade), false);
+    assert.equal(
+      sameCesiumImagery(imagery, basemapToCesiumImagery(undefined, "esri-imagery")),
+      true,
+    );
+  });
+
+  it("uses the correct Stadia image formats, zoom limits and attribution", () => {
+    for (const id of [
+      "stadia-watercolor",
+      "stadia-toner",
+      "stadia-smooth",
+      "stadia-dark",
+    ] as const) {
+      const imagery = basemapToCesiumImagery(undefined, id);
+      assert.equal(imagery.kind, "xyz");
+      if (imagery.kind !== "xyz") continue;
+      assert.equal(imagery.apiKeyProvider, "stadia");
+      assert.ok(imagery.template.endsWith(id === "stadia-watercolor" ? ".jpg" : ".png"));
+      assert.equal(imagery.maximumLevel, id === "stadia-watercolor" ? 16 : 20);
+      assert.match(imagery.attribution, /Stadia Maps.*OpenMapTiles.*OpenStreetMap/);
+      assert.equal(
+        imagery.attribution.includes("Stamen Design"),
+        id === "stadia-watercolor" || id === "stadia-toner",
+      );
+      assert.ok(
+        !imagery.template.includes("api_key"),
+        "credentials are supplied only at render time",
+      );
+      assert.equal(sameCesiumImagery(imagery, { ...imagery, apiKeyProvider: undefined }), false);
+    }
+  });
+
   it("does not treat different ion assets as the same background", () => {
     assert.equal(
       sameCesiumImagery({ kind: "ion", assetId: 2 }, { kind: "ion", assetId: 3 }),

--- a/tests/cesium-basemap.test.ts
+++ b/tests/cesium-basemap.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { CesiumBasemapImagery } from "../packages/core/src/cesium-imagery";
-import { applyBasemapAppearance, applyBasemapImagery } from "../packages/map/src/cesium-basemap";
+import {
+  applyBasemapAppearance,
+  applyBasemapImagery,
+  getStadiaApiKey,
+} from "../packages/map/src/cesium-basemap";
 
 // Verifies that the project basemap lands at the bottom of the globe's imagery
 // stack (below the data layers CesiumLayerSync appends), that a basemap change
@@ -17,6 +21,7 @@ interface FakeLayer {
 function makeFakes() {
   // The imagery stack, bottom (index 0) to top, as Cesium models it.
   const stack: FakeLayer[] = [];
+  const arcgisRequests: Array<{ url: string; options: unknown }> = [];
 
   const viewer = {
     imageryLayers: {
@@ -37,6 +42,12 @@ function makeFakes() {
   };
 
   const Cesium = {
+    ArcGisMapServerImageryProvider: {
+      fromUrl(url: string, options: unknown) {
+        arcgisRequests.push({ url, options });
+        return Promise.resolve({});
+      },
+    },
     UrlTemplateImageryProvider: class {
       url: string;
       maximumLevel?: number;
@@ -62,6 +73,7 @@ function makeFakes() {
   // The two fakes only implement the surface applyBasemapImagery touches.
   return {
     stack,
+    arcgisRequests,
     viewer: viewer as unknown as Parameters<typeof applyBasemapImagery>[1],
     Cesium: Cesium as unknown as Parameters<typeof applyBasemapImagery>[0],
   };
@@ -163,6 +175,53 @@ describe("applyBasemapImagery", () => {
 
     assert.deepEqual(added, []);
     assert.deepEqual(stack, [data], "only the data layer should remain");
+  });
+
+  it("switches to Esri without removing raster overlays or using Cesium's demo token", () => {
+    const { Cesium, viewer, stack, arcgisRequests } = makeFakes();
+    const previous = applyBasemapImagery(Cesium, viewer, [], XYZ, undefined);
+    const data = pushDataLayer(stack);
+    const url = "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer";
+    const added = applyBasemapImagery(Cesium, viewer, previous, { kind: "arcgis", url }, undefined);
+    assert.deepEqual(arcgisRequests, [{ url, options: { enablePickFeatures: false } }]);
+    assert.deepEqual(stack, [added[0], data]);
+  });
+
+  it("adds the live Stadia key only to Stadia requests, encoding special characters", () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { __GEOLIBRE_RUNTIME_ENV__: { VITE_STADIA_API_KEY: " test&key=? " } },
+    });
+    try {
+      const { Cesium, viewer } = makeFakes();
+      const template = "https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg";
+      const added = applyBasemapImagery(
+        Cesium,
+        viewer,
+        [],
+        { ...XYZ, template, apiKeyProvider: "stadia" },
+        undefined,
+      );
+      assert.equal((added[0] as FakeLayer).provider?.url, template + "?api_key=test%26key%3D%3F");
+      const unrelated = applyBasemapImagery(Cesium, viewer, added, XYZ, undefined);
+      assert.equal(
+        (unrelated[0] as FakeLayer).provider?.url,
+        XYZ.kind === "xyz" ? XYZ.template : "",
+      );
+    } finally {
+      if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+      else Reflect.deleteProperty(globalThis, "window");
+    }
+  });
+
+  it("allows Stadia domain authentication and normalizes runtime API keys", () => {
+    assert.equal(getStadiaApiKey({}), undefined);
+    assert.equal(
+      getStadiaApiKey({ VITE_STADIA_API_KEY: " first ", STADIA_API_KEY: "second" }),
+      "first",
+    );
+    assert.equal(getStadiaApiKey({ STADIA_API_KEY: " second " }), "second");
   });
 
   it("falls back to Ion World Imagery when a token is configured", () => {

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -564,6 +564,45 @@ describe("CesiumEngine terrain", () => {
     engine.destroy();
   });
 
+  it("retries terrain after a failed load", async () => {
+    const fakes = makeViewer();
+    const cesium = makeCesium();
+    let attempts = 0;
+    cesium.createWorldTerrainAsync = async () => {
+      if (++attempts === 1) throw new Error("temporary network failure");
+      return { kind: "world-terrain" } as never;
+    };
+    const engine = new CesiumEngine(cesium, fakes.viewer);
+    await engine.enableWorldTerrain();
+    assert.equal(engine.isTerrainEnabled(), false);
+    assert.equal(engine.setTerrainEnabled(true), true);
+    await Promise.resolve();
+    assert.equal(attempts, 2);
+    assert.equal(engine.isTerrainEnabled(), true);
+    assert.deepEqual(fakes.viewer.terrainProvider, { kind: "world-terrain" });
+    engine.destroy();
+  });
+
+  it("ignores an old failure after a newer terrain request succeeds", async () => {
+    const fakes = makeViewer();
+    const cesium = makeCesium();
+    let rejectFirst!: (error: Error) => void;
+    cesium.createWorldTerrainAsync = () =>
+      new Promise((_, reject) => {
+        rejectFirst = reject;
+      });
+    const engine = new CesiumEngine(cesium, fakes.viewer);
+    const first = engine.enableWorldTerrain();
+    engine.setTerrainEnabled(false);
+    cesium.createWorldTerrainAsync = async () => ({ kind: "world-terrain" }) as never;
+    await engine.enableWorldTerrain();
+    rejectFirst(new Error("stale failure"));
+    await first;
+    assert.equal(engine.isTerrainEnabled(), true);
+    assert.deepEqual(fakes.viewer.terrainProvider, { kind: "world-terrain" });
+    engine.destroy();
+  });
+
   it("swaps in world terrain and reports it enabled", async () => {
     const fakes = makeViewer();
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -541,6 +541,29 @@ describe("CesiumEngine terrain correction", () => {
 });
 
 describe("CesiumEngine terrain", () => {
+  it("routes the Terrain menu and project restore through the terrain engine", async () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer);
+    assert.equal(engine.setBuiltInControlVisible("terrain", true), true);
+    await Promise.resolve();
+    assert.equal(engine.isTerrainEnabled(), true);
+    assert.deepEqual(fakes.viewer.terrainProvider, { kind: "world-terrain" });
+    assert.equal(engine.setBuiltInControlVisible("terrain", false), true);
+    assert.equal(engine.isTerrainEnabled(), false);
+    assert.notDeepEqual(fakes.viewer.terrainProvider, { kind: "world-terrain" });
+    engine.destroy();
+  });
+
+  it("does not enable world terrain without the canvas's credentials", async () => {
+    const fakes = makeViewer();
+    const engine = new CesiumEngine(makeCesium(), fakes.viewer, { worldTerrainAvailable: false });
+    assert.equal(engine.setBuiltInControlVisible("terrain", true), false);
+    await engine.enableWorldTerrain();
+    assert.equal(engine.isTerrainEnabled(), false);
+    assert.deepEqual(fakes.viewer.terrainProvider, { kind: "initial" });
+    engine.destroy();
+  });
+
   it("swaps in world terrain and reports it enabled", async () => {
     const fakes = makeViewer();
     const engine = new CesiumEngine(makeCesium(), fakes.viewer);


### PR DESCRIPTION
Add Cesium’s native basemap and terrain picker to the globe toolbar. Selections persist in projects while GeoLibre continues to manage background opacity, visibility, and data-layer order. A Project basemap option restores the shared background.

- Include Cesium ion imagery and an Other section with Esri World Imagery, Hillshade, Ocean, OpenStreetMap, and four Stadia styles. Stadia supports domain authentication or the configured runtime API key.
- Keep public basemaps available without an ion token; preserve saved ion selections while showing a project-basemap fallback when credentials are missing.
- Synchronize terrain with Controls → Terrain and project restoration. Failed terrain loads can be retried, and stale requests cannot override newer toggles.
- Support keyboard selection, responsive gallery sizing, light/dark themes, and localized labels across all 19 locales.
- Match the pale blank-globe color to MapLibre while retaining Cesium’s native sky and atmosphere.

Validation: scoped pre-commit checks, production builds, and type checking passed. The frontend suite passed 7,720 tests (one skipped); the additional basemap suite passed all 39 tests. Browser verification loaded the real 52-feature US states dataset (103 Cesium entities), exercised all seven new providers, inspected both themes and the hidden background, and confirmed public options remain available without an ion token. Earlier browser checks covered opacity, terrain synchronization, keyboard selection, project restoration, and credential fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cesium basemap picker for switching between project, imagery, terrain, and other available map sources.
  * Added support for additional basemap providers, including ArcGIS, Stadia, OpenStreetMap, Natural Earth, and Cesium ion.
  * Added project-level Cesium basemap and terrain preferences.
  * Improved terrain availability handling when credentials are unavailable.
* **Localization**
  * Added translated basemap picker labels across supported languages.
* **Style**
  * Added responsive, themed styling and accessibility support for the basemap picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->