### PR TITLE
feat(map): add Cesium feature picking, popups and highlighting

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrimaryCesiumCanvas.tsx
@@ -68,6 +68,7 @@ export function PrimaryCesiumCanvas({ engineRef, onEngineReady }: PrimaryCesiumC
         engineRef={engineRef}
         onEngineReady={onEngineReady}
         controlLabels={controlLabels}
+        popupCloseLabel={t("common.close")}
       />
       {/* The globe works without an Ion token — it draws the project basemap —
           so say what a token would add rather than hiding the view. Bottom-end

--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -208,23 +208,19 @@ test.describe("Cesium toolbar controls on the globe", () => {
 
     await waitForMap(page);
 
-    // Zoom the 2D map in first, so the globe seeds from a close camera rather
-    // than the default whole-Earth view. That is not incidental tidying: wheel
-    // zoom on a globe framed at the full Earth trips a `DeveloperError:
-    // normalized result is not a number` inside Cesium's own
-    // ScreenSpaceCameraController and stops the render loop. It reproduces on an
-    // unmodified build, so it predates these controls and is not what this test
-    // is here to catch — the test above avoids it the same way, by arriving on
-    // the globe already zoomed in.
-    const mapBox = await page.getByTestId("map-canvas").boundingBox();
-    expect(mapBox).not.toBeNull();
-    await page.mouse.move(mapBox!.x + mapBox!.width / 2, mapBox!.y + mapBox!.height / 2);
-    for (let tick = 0; tick < 5; tick++) {
-      await page.mouse.wheel(0, -200);
-      await page.waitForTimeout(80);
-    }
+    // Seed a known close camera through the UI. A burst of wheel events can
+    // still be queued while two identical status-bar samples appear stable on
+    // a busy CI runner. Wait for the requested endpoint before swapping engines.
+    await page.getByRole("button", { name: "View", exact: true }).click();
+    await page.getByRole("menuitem", { name: /Set View/ }).click();
+    const dialog = page.getByRole("dialog", { name: "Set View" });
+    await dialog.locator("#set-view-longitude").fill("-97.5");
+    await dialog.locator("#set-view-latitude").fill("35.4");
+    await dialog.locator("#set-view-zoom").fill("6");
+    await dialog.getByRole("button", { name: "Go", exact: true }).click();
+    await expect(dialog).toBeHidden();
+    await expect.poll(() => readZoom(page), { timeout: 30_000 }).toBe(6);
     const zoomOn2dMap = await waitForStableZoom(page);
-    expect(zoomOn2dMap).toBeGreaterThan(2);
 
     await chooseRenderer(page, "Cesium");
     const globe = page.getByTestId("primary-cesium");

--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -172,7 +172,7 @@ test.describe("Cesium as the primary rendering engine", () => {
 
 /**
  * Cesium's own toolbar buttons on the globe (issue #2270): the home button, the
- * scene-mode picker, and the fullscreen button.
+ * scene-mode picker, basemap picker, and the fullscreen button.
  *
  * The unit tests cover the camera maths and the morph guards against a fake
  * Cesium, which by construction cannot catch what matters here — that the
@@ -231,10 +231,11 @@ test.describe("Cesium toolbar controls on the globe", () => {
     await expect(globe).toBeVisible({ timeout: 60_000 });
     await expect(globe.locator("canvas")).toBeVisible({ timeout: 60_000 });
 
-    // All three controls mount into the globe's control host.
+    // All four controls mount into the globe's control host.
     await expect(page.locator(".cesium-home-button")).toBeVisible({ timeout: 60_000 });
     await expect(page.locator(".cesium-sceneModePicker-wrapper")).toBeVisible();
     await expect(page.locator(".cesium-fullscreenButton")).toBeVisible();
+    await expect(page.locator(".geolibre-cesium-basemap-picker button")).toBeVisible();
     // Tooltips come from the app's catalogs, not the widgets' English defaults.
     // The fullscreen one is the interesting case: Cesium derives it from the
     // fullscreen state as a read-only computed, so it is written onto the button
@@ -252,7 +253,7 @@ test.describe("Cesium toolbar controls on the globe", () => {
     const edges = await page
       .locator(".geolibre-cesium-ctrl button:visible")
       .evaluateAll((buttons) => buttons.map((button) => button.getBoundingClientRect().right));
-    expect(edges).toHaveLength(3);
+    expect(edges).toHaveLength(4);
     for (const edge of edges) expect(edge).toBeCloseTo(edges[0], 0);
 
     // The globe seeded from the 2D camera, so this is the scale to preserve.
@@ -322,7 +323,7 @@ test.describe("Cesium toolbar controls on the globe", () => {
 
     await toggleFullscreen();
     await expect(page.locator(".cesium-fullscreenButton")).toHaveCount(0);
-    // The other two have no menu counterpart and are unaffected.
+    // The other controls have no menu counterpart and are unaffected.
     await expect(page.locator(".cesium-home-button")).toBeVisible();
 
     await toggleFullscreen();

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -12,6 +12,7 @@ import type { CesiumWidget, ImageryLayer } from "@cesium/engine";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { applyBasemapAppearance, applyBasemapImagery, getStadiaApiKey } from "./cesium-basemap";
 import { isSameView } from "./cesium-camera";
+import { installCesiumInteractions } from "./cesium-interactions";
 import { CesiumEngine } from "./cesium-engine";
 import type { MapEngine } from "./map-engine";
 import { CesiumControlHost, setPrimaryCesiumControlHost } from "./cesium-control-host";
@@ -155,6 +156,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   const viewerRef = useRef<CesiumWidget | null>(null);
   const cesiumRef = useRef<typeof import("@cesium/engine") | null>(null);
   const engineInstanceRef = useRef<CesiumEngine | null>(null);
+  const interactionCleanup = useRef<(() => void) | null>(null);
   const controlHostRef = useRef<CesiumControlHost | null>(null);
   // The Cesium toolbar widgets mounted on the primary globe, kept so the label
   // effect can retranslate them and the unmount can remove them.
@@ -439,6 +441,8 @@ export const CesiumCanvas = memo(function CesiumCanvas({
         // imagery stack rather than having to be lowered past the data layers.
         applyBasemap();
         engine.syncLayers(paneLayersRef.current);
+        if (isPrimaryRef.current)
+          interactionCleanup.current = installCesiumInteractions(Cesium, viewer, engine);
 
         // Publish the engine only for the primary globe — see `engineRef`.
         if (isPrimaryRef.current && engineRefProp.current) {
@@ -457,6 +461,8 @@ export const CesiumCanvas = memo(function CesiumCanvas({
       cancelled = true;
       // Drops the engine's listeners and its layer sync; the viewer itself is
       // destroyed below.
+      interactionCleanup.current?.();
+      interactionCleanup.current = null;
       engineInstanceRef.current?.destroy();
       // Clear the published ref before the engine is torn down, so nothing can
       // reach a destroyed engine through it. Only ours is cleared: a pane never

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -106,6 +106,8 @@ export interface CesiumCanvasProps {
    * Only the primary globe hosts controls, so this is ignored on a grid pane.
    */
   controlLabels?: CesiumWidgetControlLabels;
+  /** Translated accessible label for the Identify popup close button. */
+  popupCloseLabel?: string;
 }
 
 /**
@@ -151,6 +153,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   engineRef,
   onEngineReady,
   controlLabels,
+  popupCloseLabel,
 }: CesiumCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<CesiumWidget | null>(null);
@@ -180,6 +183,8 @@ export const CesiumCanvas = memo(function CesiumCanvas({
   engineRefProp.current = engineRef;
   const onEngineReadyRef = useRef(onEngineReady);
   onEngineReadyRef.current = onEngineReady;
+  const popupCloseLabelRef = useRef(popupCloseLabel);
+  popupCloseLabelRef.current = popupCloseLabel;
   const controlLabelsRef = useRef(controlLabels);
   controlLabelsRef.current = controlLabels;
 
@@ -422,6 +427,9 @@ export const CesiumCanvas = memo(function CesiumCanvas({
           }
         }
 
+        // Widget imports can finish after unmount has already destroyed this viewer.
+        if (cancelled || viewer.isDestroyed()) return;
+
         // Seed the camera from the shared store camera before the first frame.
         // The primary globe always seeds from `mapView`, which is what carries
         // the camera across a renderer switch: MapLibre wrote the view the user
@@ -442,7 +450,12 @@ export const CesiumCanvas = memo(function CesiumCanvas({
         applyBasemap();
         engine.syncLayers(paneLayersRef.current);
         if (isPrimaryRef.current)
-          interactionCleanup.current = installCesiumInteractions(Cesium, viewer, engine);
+          interactionCleanup.current = installCesiumInteractions(
+            Cesium,
+            viewer,
+            engine,
+            () => popupCloseLabelRef.current ?? "Close",
+          );
 
         // Publish the engine only for the primary globe — see `engineRef`.
         if (isPrimaryRef.current && engineRefProp.current) {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1,4 +1,9 @@
 import {
+  createHoverTooltipElement,
+  createIdentifyPopupElement,
+  createIdentifyPopupRows,
+} from "./feature-popup";
+import {
   applyGroupEffects,
   applyMatchedSelection,
   createPointerElevationResolver,
@@ -10,22 +15,15 @@ import {
   isInlineImageValue,
   isPopupClickEnabled,
   isPopupHoverEnabled,
-  isSafePopupUrl,
   NETCDF_IMAGE_SOURCE_KIND,
   PHOTO_FULL_PROPERTY,
   PHOTO_PROPERTY,
   resolveConfiguredPopupTitle,
   resolveLayerCapabilities,
-  resolvePopupBody,
-  resolvePopupRows,
-  resolvePopupTitle,
   stringifyPopupValue,
   useAppStore,
-  type FieldVisibility,
   type GeoLibreLayer,
-  type LayerPopupConfig,
   type PointerElevationResolver,
-  type PopupRow,
 } from "@geolibre/core";
 import * as maplibregl from "maplibre-gl";
 import type { Feature, Polygon } from "geojson";
@@ -206,198 +204,6 @@ interface GeoLibreTimeSliderBridge {
   ) => Promise<TimeSliderPixelIdentifyBridgeResult | null>;
 }
 
-/**
- * The author's popup design for a layer, plus what the renderer needs to apply
- * it. Every field is optional: the WMS, pixel and status popups pass none of
- * it and get exactly the rendering they always had.
- */
-interface IdentifyPopupOptions {
-  popup?: LayerPopupConfig;
-  fieldVisibility?: Record<string, FieldVisibility>;
-  /** The real feature, when the caller has one — feeds geometry-aware expressions. */
-  feature?: Feature | null;
-  /** Map zoom for `["zoom"]` in the title/body expressions. */
-  zoom?: number;
-}
-
-/** The document language, so formatted numbers and dates follow the UI locale. */
-function documentLocale(): string | undefined {
-  const lang = typeof document !== "undefined" ? document.documentElement.lang.trim() : "";
-  return lang || undefined;
-}
-
-/**
- * Draw one resolved value into its cell. `"auto"` keeps the historical
- * behavior (sanitized KML description markup, inline base64 images as
- * thumbnails, everything else as text); the explicit kinds render what the
- * author asked for, and fall back to text when the value cannot support it
- * (a `link` whose value is not an http(s) URL, an `image` that is not one).
- */
-function renderPopupValue(cell: HTMLElement, row: PopupRow): void {
-  if (row.kind === "image") {
-    if (isSafePopupUrl(row.value, true)) {
-      const image = document.createElement("img");
-      // Trimmed, because that is the copy isSafePopupUrl actually validated —
-      // as in the link branch below.
-      image.src = row.value.trim();
-      image.alt = row.label;
-      image.loading = "lazy";
-      image.className = "max-h-40 max-w-full rounded";
-      cell.appendChild(image);
-      return;
-    }
-    cell.textContent = row.text;
-    return;
-  }
-
-  if (row.kind === "link") {
-    if (isSafePopupUrl(row.value)) {
-      const link = document.createElement("a");
-      link.href = row.value.trim();
-      link.target = "_blank";
-      link.rel = "noopener noreferrer";
-      link.className = "break-all underline";
-      link.textContent = row.linkLabel ?? row.text;
-      cell.appendChild(link);
-      return;
-    }
-    cell.textContent = row.text;
-    return;
-  }
-
-  if (row.kind === "auto") {
-    // Render known KML description structures as sanitized markup. Requiring a
-    // supported tag keeps ordinary text such as "Elevation <500m>" intact.
-    if (
-      row.field === "description" &&
-      typeof row.value === "string" &&
-      /<(?:a|b|br|div|em|i|p|span|strong|table|tbody|td|th|thead|tr)\b/i.test(row.value)
-    ) {
-      appendSanitizedKmlDescription(cell, row.value);
-      return;
-    }
-    // Render inline image data URLs (e.g. a geotagged-photo or field-collection
-    // thumbnail) as an actual thumbnail rather than a multi-kilobyte string.
-    // Match base64 raster images only, excluding SVG (which can carry scripts)
-    // so an untrusted GeoJSON value can't smuggle one in.
-    if (isInlineImageValue(row.value)) {
-      const image = document.createElement("img");
-      image.src = row.value;
-      image.alt = row.field;
-      image.loading = "lazy";
-      image.className = "max-h-40 max-w-full rounded";
-      cell.appendChild(image);
-      return;
-    }
-  }
-
-  cell.textContent = row.text;
-}
-
-function createIdentifyPopupElement(
-  layerName: string,
-  properties: Record<string, unknown>,
-  featureId?: string | number,
-  options: IdentifyPopupOptions = {},
-): HTMLElement {
-  const { popup, fieldVisibility, feature, zoom } = options;
-
-  const root = document.createElement("div");
-  root.className =
-    "geolibre-identify-popup-root flex min-w-[min(18rem,calc(100vw-48px))] max-w-[min(520px,calc(100vw-48px))] flex-col text-xs";
-
-  const title = document.createElement("div");
-  // Leave room for MapLibre's close button, which sits in the same corner the
-  // heading would otherwise run into.
-  title.className = "mb-2 pe-6 font-semibold text-foreground";
-  title.textContent = resolvePopupTitle(layerName, properties, popup, {
-    feature,
-    zoom,
-    fieldVisibility,
-  });
-  root.appendChild(title);
-
-  root.appendChild(createIdentifyPopupRows(properties, featureId, options));
-
-  return root;
-}
-
-/** Build the attribute rows shared by per-layer and all-layer Identify popups. */
-function createIdentifyPopupRows(
-  properties: Record<string, unknown>,
-  featureId?: string | number,
-  options: IdentifyPopupOptions = {},
-  scrollable = true,
-): HTMLElement {
-  const { popup, fieldVisibility, feature, zoom } = options;
-  const locale = documentLocale();
-
-  const rows = document.createElement("div");
-  rows.className = scrollable ? "geolibre-identify-popup-rows pe-2" : "pe-2";
-
-  // An author-supplied body expression replaces the whole body outright — the
-  // field table AND the synthetic id row. The point of it is a sentence
-  // instead of rows, and a raw feature id dangling under that sentence would
-  // undo it. The designer disables the "Show the feature id row" checkbox
-  // while a body expression is set, so the UI does not offer a control that
-  // cannot take effect.
-  const body = resolvePopupBody(properties, popup, { feature, zoom, fieldVisibility });
-  if (body !== null) {
-    const paragraph = document.createElement("div");
-    paragraph.className = "whitespace-pre-wrap break-words text-foreground";
-    paragraph.textContent = body;
-    rows.appendChild(paragraph);
-    return rows;
-  }
-
-  const appendRow = (row: PopupRow) => {
-    const rowElement = document.createElement("div");
-    rowElement.className = "grid grid-cols-[minmax(5rem,0.45fr)_1fr] gap-2 border-t py-1";
-
-    const keyCell = document.createElement("div");
-    keyCell.className = "break-words font-medium text-muted-foreground";
-    keyCell.textContent = row.label;
-
-    const valueCell = document.createElement("div");
-    valueCell.className = "break-words text-foreground";
-    renderPopupValue(valueCell, row);
-
-    rowElement.append(keyCell, valueCell);
-    rows.appendChild(rowElement);
-  };
-
-  const showFeatureId = featureId != null && popup?.showFeatureId !== false;
-  if (showFeatureId) {
-    appendRow({
-      field: "id",
-      label: "id",
-      value: featureId,
-      text: stringifyPopupValue(featureId),
-      kind: "auto",
-    });
-  }
-
-  // resolvePopupRows drops GeoLibre's internal columns and the heavy
-  // full-resolution photo twin, and applies the author's field list, order,
-  // labels and formatting. Its result is empty for a feature with nothing to
-  // show, which is what the "No attributes" state reports.
-  const resolved = resolvePopupRows(properties, {
-    popup,
-    fieldVisibility,
-    locale,
-  });
-  if (resolved.length === 0 && !showFeatureId) {
-    const empty = document.createElement("div");
-    empty.className = "text-muted-foreground";
-    empty.textContent = "No attributes";
-    rows.appendChild(empty);
-  } else {
-    for (const row of resolved) appendRow(row);
-  }
-
-  return rows;
-}
-
 interface GlobalIdentifyHit {
   layer: GeoLibreLayer;
   properties: Record<string, unknown>;
@@ -528,115 +334,6 @@ function createGlobalIdentifyPopupElement(
   }
 
   return root;
-}
-
-/**
- * The hover tooltip's content: the layer's popup title over the fields the
- * author flagged for hover. Kept deliberately small — this follows the pointer,
- * so it shows the one or two fields that name the feature, never the table.
- */
-function createHoverTooltipElement(
-  layerName: string,
-  properties: Record<string, unknown>,
-  options: IdentifyPopupOptions = {},
-): HTMLElement | null {
-  const { popup, fieldVisibility, feature, zoom } = options;
-  const rows = resolvePopupRows(properties, {
-    popup,
-    fieldVisibility,
-    hover: true,
-    locale: documentLocale(),
-  });
-  const configuredTitle = resolveConfiguredPopupTitle(properties, popup, {
-    feature,
-    zoom,
-    fieldVisibility,
-  });
-  // Nothing to say: no flagged field, and no title the author configured, so
-  // the tip would be a box repeating the layer name the user can already read
-  // in the Layers panel. Keyed on whether a title was configured rather than on
-  // whether it happens to equal the layer name — a feature legitimately called
-  // the same thing as its layer still deserves its tooltip.
-  if (rows.length === 0 && configuredTitle === null) return null;
-  const title = configuredTitle ?? layerName;
-
-  const root = document.createElement("div");
-  root.className = "geolibre-hover-tooltip-root flex max-w-[16rem] flex-col gap-0.5 text-xs";
-
-  const heading = document.createElement("div");
-  heading.className = "font-semibold text-foreground";
-  heading.textContent = title;
-  root.appendChild(heading);
-
-  for (const row of rows) {
-    const line = document.createElement("div");
-    line.className = "flex gap-1.5 text-foreground";
-    const label = document.createElement("span");
-    label.className = "shrink-0 text-muted-foreground";
-    label.textContent = row.label;
-    const value = document.createElement("span");
-    value.className = "min-w-0 break-words";
-    // A tooltip is a one-line read, so a link shows as its text rather than as
-    // a clickable anchor — the tip has `pointer-events: none` and could not be
-    // clicked anyway. Image rows never reach here: resolvePopupRows drops them
-    // from the hover subset rather than printing a data URL.
-    value.textContent = row.text;
-    line.append(label, value);
-    root.appendChild(line);
-  }
-
-  return root;
-}
-
-const KML_DESCRIPTION_TAGS = new Set([
-  "a",
-  "b",
-  "br",
-  "div",
-  "em",
-  "i",
-  "p",
-  "span",
-  "strong",
-  "table",
-  "tbody",
-  "td",
-  "th",
-  "thead",
-  "tr",
-]);
-
-/** Render useful KML description markup while dropping scripts and attributes. */
-function appendSanitizedKmlDescription(target: HTMLElement, html: string): void {
-  const parsed = new DOMParser().parseFromString(html, "text/html");
-  const copy = (node: Node, parent: Node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      parent.appendChild(document.createTextNode(node.textContent ?? ""));
-      return;
-    }
-    if (!(node instanceof Element)) return;
-    const tag = node.localName.toLowerCase();
-    if (tag === "script" || tag === "style" || tag === "head" || tag === "meta") return;
-    if (!KML_DESCRIPTION_TAGS.has(tag)) {
-      for (const child of node.childNodes) copy(child, parent);
-      return;
-    }
-    const element = document.createElement(tag);
-    if (tag === "a") {
-      const href = node.getAttribute("href")?.trim();
-      if (href && /^(https?:|mailto:)/i.test(href)) {
-        element.setAttribute("href", href);
-        element.setAttribute("target", "_blank");
-        element.setAttribute("rel", "noopener noreferrer");
-      }
-    }
-    for (const child of node.childNodes) copy(child, element);
-    parent.appendChild(element);
-  };
-  const content = document.createElement("div");
-  content.className = "geolibre-kml-description";
-  for (const child of parsed.body.childNodes) copy(child, content);
-  target.appendChild(content);
 }
 
 function createIdentifyMessagePopupElement(layerName: string, message: string): HTMLElement {

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -7,7 +7,7 @@ import {
   type StoryChapterAnimation,
   type StoryChapterLocation,
 } from "@geolibre/core";
-import type { CesiumWidget } from "@cesium/engine";
+import type { Cartesian2, CesiumWidget } from "@cesium/engine";
 import type { FeatureCollection } from "geojson";
 import type * as maplibregl from "maplibre-gl";
 import {
@@ -39,7 +39,7 @@ type CesiumNs = typeof import("@cesium/engine");
 /**
  * What the globe can do (issue #2260).
  *
- * The four `false` flags are not "not yet wired" — they are the operations
+ * The `false` flags are not "not yet wired" — they are the operations
  * Cesium has no equivalent for, or that this engine deliberately does not claim:
  *
  * - `styleSpec` / `nativeMapInstance`: Cesium draws imagery layers and
@@ -48,12 +48,7 @@ type CesiumNs = typeof import("@cesium/engine");
  *   canvas stays 2D-only.
  * - `customLayers`: a MapLibre `CustomLayerInterface` is a callback into
  *   MapLibre's own WebGL pass; deck.gl's MapLibre interop is the same shape.
- * - `picking`: `identifyFeatures` needs `scene.drillPick` plus a mapping from a
- *   picked primitive back to a `GeoLibreLayer` id and feature id, which
- *   `CesiumLayerSync` does not record today. Claiming it before that exists
- *   would make Identify report "no features here" instead of "not available".
- * - `onMapDrawing` / `domControls`: no manual-placement pin and nowhere to host
- *   an `IControl`. The control host is issue #2263.
+ * - `onMapDrawing`: no manual-placement pin.
  *
  * `terrain: true` is the flag worth noting in the other direction — terrain is
  * native on the globe, and the old `primaryRenderer === "cesium"` gates disabled
@@ -64,7 +59,7 @@ export const CESIUM_CAPABILITIES: MapEngineCapabilities = Object.freeze({
   nativeMapInstance: false,
   customLayers: false,
   terrain: true,
-  picking: false,
+  picking: true,
   onMapDrawing: false,
   domControls: true,
 });
@@ -522,18 +517,69 @@ export class CesiumEngine implements MapEngine {
 
   // ------------------------------------------------------------------ picking
 
-  /** Empty until the globe can map a picked primitive back to a feature id. */
-  identifyFeatures(_lngLat: [number, number], _layerId?: string): IdentifiedFeature[] {
-    return [];
+  identifyFeatures(lngLat: [number, number], layerId?: string): IdentifiedFeature[] {
+    const viewer = this.live();
+    if (!viewer || this.isMorphing() || !lngLat.every(Number.isFinite)) return [];
+    const world = this.Cesium.Cartesian3.fromDegrees(
+      lngLat[0],
+      lngLat[1],
+      groundHeightAt(this.Cesium, viewer, lngLat[0], lngLat[1]),
+    );
+    const point = this.Cesium.SceneTransforms.worldToWindowCoordinates(viewer.scene, world);
+    return point ? this.identifyAtScreen(point, layerId) : [];
+  }
+
+  /** Use the actual pointer position for hover/click, including elevated geometry. */
+  identifyAtScreen(point: Cartesian2, layerId?: string): IdentifiedFeature[] {
+    const viewer = this.live();
+    if (
+      !viewer ||
+      this.isMorphing() ||
+      !Number.isFinite(point.x) ||
+      !Number.isFinite(point.y) ||
+      point.x < 0 ||
+      point.y < 0 ||
+      point.x > viewer.canvas.clientWidth ||
+      point.y > viewer.canvas.clientHeight
+    )
+      return [];
+    const results: IdentifiedFeature[] = [];
+    const seen = new Set<string>();
+    for (const picked of viewer.scene.drillPick(point)) {
+      const entity = picked?.id ?? picked?.primitive?.id;
+      if (!entity || typeof entity !== "object") continue;
+      const feature = this.layerSync.resolveFeature(entity);
+      if (!feature || (layerId !== undefined && feature.layerId !== layerId)) continue;
+      const key = JSON.stringify([feature.layerId, feature.featureId]);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      results.push(feature);
+    }
+    return results;
   }
 
   highlightFeature(
-    _layer: GeoLibreLayer | undefined,
-    _featureId: string | string[] | null,
-    _options: { fit?: boolean } = {},
-  ): void {}
+    layer: GeoLibreLayer | undefined,
+    featureId: string | string[] | null,
+    options: { fit?: boolean } = {},
+  ): void {
+    if (!this.live()) return;
+    const ids = featureId === null ? [] : Array.isArray(featureId) ? featureId : [featureId];
+    this.layerSync.highlight(layer?.id, ids);
+    if (!options.fit || !layer?.geojson || !ids.length) return;
+    const selected = new Set(ids);
+    const features = layer.geojson.features.filter((feature, index) =>
+      selected.has(String(feature.id ?? index)),
+    );
+    const bounds = getLayerBounds({ ...layer, geojson: { type: "FeatureCollection", features } });
+    if (features.length && bounds) this.fitBounds(bounds);
+  }
 
-  clearFeatureHighlight(): void {}
+  clearFeatureHighlight(): void {
+    if (!this.live()) return;
+    this.layerSync.highlight(undefined, []);
+    this.live()?.scene.requestRender();
+  }
 
   /** Places nothing and returns a no-op teardown; see `onMapDrawing`. */
   startManualPlacement(_lngLat: [number, number], _options: ManualPlacementOptions): () => void {

--- a/packages/map/src/cesium-engine.ts
+++ b/packages/map/src/cesium-engine.ts
@@ -520,11 +520,29 @@ export class CesiumEngine implements MapEngine {
   identifyFeatures(lngLat: [number, number], layerId?: string): IdentifiedFeature[] {
     const viewer = this.live();
     if (!viewer || this.isMorphing() || !lngLat.every(Number.isFinite)) return [];
-    const world = this.Cesium.Cartesian3.fromDegrees(
-      lngLat[0],
-      lngLat[1],
-      groundHeightAt(this.Cesium, viewer, lngLat[0], lngLat[1]),
-    );
+    const height = groundHeightAt(this.Cesium, viewer, lngLat[0], lngLat[1]);
+    const world = this.Cesium.Cartesian3.fromDegrees(lngLat[0], lngLat[1], height);
+    if (viewer.scene.mode === this.Cesium.SceneMode.SCENE3D) {
+      // Projection alone also maps the far hemisphere onto the visible globe.
+      // Use the public ray/ellipsoid API (EllipsoidalOccluder is private).
+      const origin = viewer.camera.positionWC;
+      // Below-sea-level terrain must not be rejected merely for lying inside the ellipsoid.
+      const target =
+        height < 0 ? this.Cesium.Cartesian3.fromDegrees(lngLat[0], lngLat[1], 0) : world;
+      const direction = this.Cesium.Cartesian3.subtract(
+        target,
+        origin,
+        new this.Cesium.Cartesian3(),
+      );
+      const distance = this.Cesium.Cartesian3.magnitude(direction);
+      if (distance === 0) return [];
+      const intersection = this.Cesium.IntersectionTests.rayEllipsoid(
+        new this.Cesium.Ray(origin, direction),
+        viewer.scene.globe.ellipsoid,
+      );
+      // Allow rounding at the surface; only intersections before the target occlude it.
+      if (intersection && intersection.start > 0 && intersection.start < distance - 1) return [];
+    }
     const point = this.Cesium.SceneTransforms.worldToWindowCoordinates(viewer.scene, world);
     return point ? this.identifyAtScreen(point, layerId) : [];
   }

--- a/packages/map/src/cesium-interactions.ts
+++ b/packages/map/src/cesium-interactions.ts
@@ -13,6 +13,7 @@ export function installCesiumInteractions(
   C: typeof import("@cesium/engine"),
   viewer: CesiumWidget,
   engine: CesiumEngine,
+  closeLabel: () => string = () => "Close",
 ): () => void {
   const handler = new C.ScreenSpaceEventHandler(viewer.canvas);
   const host = viewer.canvas.parentElement!;
@@ -48,6 +49,16 @@ export function installCesiumInteractions(
       boxShadow: "0 2px 12px #0005",
       pointerEvents: isHover ? "none" : "auto",
     });
+    if (!isHover) {
+      const close = document.createElement("button");
+      close.type = "button";
+      close.textContent = "×";
+      close.setAttribute("aria-label", closeLabel());
+      close.className =
+        "absolute end-1 top-1 rounded px-1 text-lg hover:bg-muted focus-visible:outline";
+      close.addEventListener("click", clearPopup);
+      box.append(close);
+    }
     box.append(content);
     host.append(box);
     box.style.left = `${Math.max(0, Math.min(point.x + 12, host.clientWidth - box.offsetWidth))}px`;
@@ -85,11 +96,13 @@ export function installCesiumInteractions(
     clearPopup();
     const state = useAppStore.getState();
     const target = state.identifyLayerId;
+    if (!target) return;
     const hits = engine.identifyAtScreen(
       event.position,
       target && target !== IDENTIFY_ALL_LAYERS_ID ? target : undefined,
     );
     const content = document.createElement("div");
+    let selected = false;
     for (const hit of hits) {
       const layer = state.layers.find((item) => item.id === hit.layerId);
       if (!layer || !isPopupClickEnabled(layer.popup)) continue;
@@ -103,7 +116,8 @@ export function installCesiumInteractions(
           zoom: engine.readView().zoom,
         }),
       );
-      if (hit === hits[0]) {
+      if (!selected) {
+        selected = true;
         state.selectLayer(layer.id);
         state.selectFeature(hit.featureId);
       }

--- a/packages/map/src/cesium-interactions.ts
+++ b/packages/map/src/cesium-interactions.ts
@@ -1,0 +1,167 @@
+import {
+  IDENTIFY_ALL_LAYERS_ID,
+  isPopupClickEnabled,
+  isPopupHoverEnabled,
+  useAppStore,
+} from "@geolibre/core";
+import type { Cartesian2, CesiumWidget } from "@cesium/engine";
+import type { CesiumEngine } from "./cesium-engine";
+import { createHoverTooltipElement, createIdentifyPopupElement } from "./feature-popup";
+
+/** Globe input uses the same popup field, expression and sanitization path as 2D. */
+export function installCesiumInteractions(
+  C: typeof import("@cesium/engine"),
+  viewer: CesiumWidget,
+  engine: CesiumEngine,
+): () => void {
+  const handler = new C.ScreenSpaceEventHandler(viewer.canvas);
+  const host = viewer.canvas.parentElement!;
+  let popup: HTMLElement | null = null;
+  let hover: HTMLElement | null = null;
+  let pending: Cartesian2 | null = null;
+  let frame = 0;
+  let moving = false;
+  const clearHover = () => {
+    if (frame) cancelAnimationFrame(frame);
+    frame = 0;
+    pending = null;
+    hover?.remove();
+    hover = null;
+  };
+  const clearPopup = () => {
+    popup?.remove();
+    popup = null;
+  };
+  const place = (content: HTMLElement, point: Cartesian2, isHover: boolean) => {
+    const box = document.createElement("div");
+    box.className = isHover ? "geolibre-hover-tooltip" : "geolibre-identify-popup";
+    Object.assign(box.style, {
+      position: "absolute",
+      zIndex: "10",
+      maxWidth: "min(520px, 90%)",
+      maxHeight: "60%",
+      overflow: "auto",
+      padding: "10px",
+      borderRadius: "6px",
+      background: "hsl(var(--background))",
+      color: "hsl(var(--foreground))",
+      boxShadow: "0 2px 12px #0005",
+      pointerEvents: isHover ? "none" : "auto",
+    });
+    box.append(content);
+    host.append(box);
+    box.style.left = `${Math.max(0, Math.min(point.x + 12, host.clientWidth - box.offsetWidth))}px`;
+    box.style.top = `${Math.max(0, Math.min(point.y + 12, host.clientHeight - box.offsetHeight))}px`;
+    return box;
+  };
+  handler.setInputAction((event: { endPosition: Cartesian2 }) => {
+    pending = C.Cartesian2.clone(event.endPosition);
+    if (frame) return;
+    frame = requestAnimationFrame(() => {
+      frame = 0;
+      const point = pending;
+      const state = useAppStore.getState();
+      hover?.remove();
+      hover = null;
+      if (!point || moving || state.identifyLayerId) return;
+      for (const hit of engine.identifyAtScreen(point)) {
+        const layer = state.layers.find((item) => item.id === hit.layerId);
+        if (!layer || !isPopupHoverEnabled(layer.popup)) continue;
+        const content = createHoverTooltipElement(layer.name, hit.properties, {
+          popup: layer.popup,
+          fieldVisibility: layer.fieldVisibility,
+          feature: hit.geometry
+            ? { type: "Feature", properties: hit.properties, geometry: hit.geometry }
+            : null,
+          zoom: engine.readView().zoom,
+        });
+        if (content) hover = place(content, point, true);
+        break;
+      }
+    });
+  }, C.ScreenSpaceEventType.MOUSE_MOVE);
+  handler.setInputAction((event: { position: Cartesian2 }) => {
+    clearHover();
+    clearPopup();
+    const state = useAppStore.getState();
+    const target = state.identifyLayerId;
+    const hits = engine.identifyAtScreen(
+      event.position,
+      target && target !== IDENTIFY_ALL_LAYERS_ID ? target : undefined,
+    );
+    const content = document.createElement("div");
+    for (const hit of hits) {
+      const layer = state.layers.find((item) => item.id === hit.layerId);
+      if (!layer || !isPopupClickEnabled(layer.popup)) continue;
+      content.append(
+        createIdentifyPopupElement(layer.name, hit.properties, hit.featureId ?? undefined, {
+          popup: layer.popup,
+          fieldVisibility: layer.fieldVisibility,
+          feature: hit.geometry
+            ? { type: "Feature", properties: hit.properties, geometry: hit.geometry }
+            : null,
+          zoom: engine.readView().zoom,
+        }),
+      );
+      if (hit === hits[0]) {
+        state.selectLayer(layer.id);
+        state.selectFeature(hit.featureId);
+      }
+      if (target !== IDENTIFY_ALL_LAYERS_ID) break;
+    }
+    if (content.childElementCount) popup = place(content, event.position, false);
+  }, C.ScreenSpaceEventType.LEFT_CLICK);
+  const selection = () => {
+    const state = useAppStore.getState();
+    engine.highlightFeature(
+      state.layers.find((layer) => layer.id === state.selectedLayerId),
+      state.selectedFeatureIds.length ? state.selectedFeatureIds : state.selectedFeatureId,
+    );
+  };
+  const unsubscribe = useAppStore.subscribe((state, prev) => {
+    if (
+      state.selectedLayerId !== prev.selectedLayerId ||
+      state.selectedFeatureIds !== prev.selectedFeatureIds ||
+      state.selectedFeatureId !== prev.selectedFeatureId
+    )
+      selection();
+    if (
+      state.identifyLayerId !== prev.identifyLayerId ||
+      state.layers !== prev.layers ||
+      state.layerGroups !== prev.layerGroups
+    ) {
+      clearHover();
+      clearPopup();
+    }
+  });
+  const escape = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      clearHover();
+      clearPopup();
+    }
+  };
+  viewer.canvas.addEventListener("mouseleave", clearHover);
+  window.addEventListener("keydown", escape);
+  const moveStart = () => {
+    moving = true;
+    clearHover();
+    clearPopup();
+  };
+  const moveEnd = () => {
+    moving = false;
+  };
+  viewer.camera.moveStart.addEventListener(moveStart);
+  viewer.camera.moveEnd.addEventListener(moveEnd);
+
+  selection();
+  return () => {
+    unsubscribe();
+    handler.destroy();
+    clearHover();
+    clearPopup();
+    viewer.canvas.removeEventListener("mouseleave", clearHover);
+    window.removeEventListener("keydown", escape);
+    viewer.camera.moveStart.removeEventListener(moveStart);
+    viewer.camera.moveEnd.removeEventListener(moveEnd);
+  };
+}

--- a/packages/map/src/cesium-layer-sync.ts
+++ b/packages/map/src/cesium-layer-sync.ts
@@ -3,6 +3,7 @@ import type {
   Cesium3DTileset,
   CesiumWidget,
   DataSource,
+  Entity,
   ImageryLayer,
   ImageryProvider,
   Resource,
@@ -356,6 +357,81 @@ function needsRebuild(prev: GeoLibreLayer, next: GeoLibreLayer): boolean {
 }
 
 export class CesiumLayerSync {
+  private readonly featureRefs = new WeakMap<object, { layerId: string; index: number }>();
+  private readonly imageryRefs = new WeakMap<object, string>();
+  private selection: { layerId: string; ids: Set<string> } | null = null;
+  private highlightRestorers: Array<() => void> = [];
+
+  /** Only live, visible entities owned by this synchronizer can identify a feature. */
+  resolveFeature(entity: object) {
+    const ref = this.featureRefs.get(entity);
+    if (!ref) return null;
+    const entry = this.entries.get(ref.layerId);
+    if (
+      !entry ||
+      entry.cancelled ||
+      !entry.layer.visible ||
+      entry.layer.opacity <= 0 ||
+      entry.kind !== "geojson" ||
+      !(entry.handle as DataSource | null)?.entities.contains(entity as Entity)
+    )
+      return null;
+    const feature = entry.layer.geojson?.features[ref.index];
+    return feature
+      ? {
+          layerId: ref.layerId,
+          featureId: String(feature.id ?? ref.index),
+          properties: feature.properties ?? {},
+          geometry: feature.geometry,
+        }
+      : null;
+  }
+
+  /** Imagery has a layer identity, but no synchronous GeoJSON feature identity. */
+  imageryLayerId(imagery: object): string | undefined {
+    return this.imageryRefs.get(imagery);
+  }
+
+  highlight(layerId: string | undefined, ids: string[]): void {
+    this.restoreHighlight();
+    this.selection = layerId && ids.length ? { layerId, ids: new Set(ids) } : null;
+    this.applyHighlight();
+    this.viewer.scene.requestRender();
+  }
+
+  private restoreHighlight(): void {
+    for (const restore of this.highlightRestorers.splice(0)) restore();
+  }
+
+  private applyHighlight(): void {
+    const selected = this.selection;
+    const entry = selected && this.entries.get(selected.layerId);
+    if (!selected || !entry || entry.kind !== "geojson" || !entry.handle) return;
+    const C = this.Cesium;
+    const color = C.Color.fromCssColorString("#facc15");
+    for (const entity of (entry.handle as DataSource).entities.values) {
+      const ref = this.featureRefs.get(entity);
+      const feature = ref && entry.layer.geojson?.features[ref.index];
+      if (!feature || !selected.ids.has(String(feature.id ?? ref?.index))) continue;
+      for (const key of ["polygon", "polyline", "billboard", "point"] as const) {
+        const original = entity[key];
+        if (!original) continue;
+        const highlighted = original.clone();
+        if (key === "polygon" || key === "polyline") {
+          (highlighted as NonNullable<Entity["polygon"]>).material = new C.ColorMaterialProperty(
+            color,
+          );
+        } else {
+          (highlighted as NonNullable<Entity["point"]>).color = new C.ConstantProperty(color);
+        }
+        // Keep the actual Property objects, including time-varying styles, intact.
+        Object.assign(entity, { [key]: highlighted });
+        this.highlightRestorers.push(() => Object.assign(entity, { [key]: original }));
+      }
+    }
+    this.viewer.scene.requestRender();
+  }
+
   private readonly entries = new Map<string, LayerEntry>();
   /** Imagery id order last asserted on the globe, to skip redundant reorders. */
   private lastImageryOrder = "";
@@ -369,6 +445,7 @@ export class CesiumLayerSync {
 
   /** Reconcile the globe to `layers` (order preserved for imagery stacking). */
   sync(layers: GeoLibreLayer[]): void {
+    this.restoreHighlight();
     this.currentLayers = layers;
     const nextIds = new Set(layers.map((l) => l.id));
     for (const [id, entry] of this.entries) {
@@ -425,9 +502,12 @@ export class CesiumLayerSync {
       this.reorderImagery();
       this.lastImageryOrder = imageryOrder;
     }
+    this.applyHighlight();
   }
 
   destroy(): void {
+    this.restoreHighlight();
+    this.selection = null;
     for (const entry of this.entries.values()) this.destroyEntry(entry);
     this.entries.clear();
   }
@@ -600,6 +680,7 @@ export class CesiumLayerSync {
         viewer.imageryLayers.remove(imageryLayer, true);
         return;
       }
+      this.imageryRefs.set(imageryLayer, layer.id);
       entry.handle = imageryLayer;
       this.applyAppearance(entry);
       if (isAsync) {
@@ -641,7 +722,18 @@ export class CesiumLayerSync {
     // (applyGeoJsonStyle) rather than reloading the whole data source.
     const fillAlpha = (style.fillOpacity ?? 0.6) * layer.opacity;
     try {
-      const dataSource = await Cesium.GeoJsonDataSource.load(layer.geojson, {
+      // Cesium splits multipart geometries into several entities. A private
+      // property survives that split; feature ids alone do not (Cesium suffixes them).
+      const indexKey = "__geolibre_cesium_feature_index";
+      const data = {
+        ...layer.geojson,
+        features: layer.geojson.features.map((feature, index) => ({
+          ...feature,
+          id: JSON.stringify([layer.id, index]),
+          properties: { ...feature.properties, [indexKey]: index },
+        })),
+      };
+      const dataSource = await Cesium.GeoJsonDataSource.load(data, {
         stroke,
         strokeWidth: style.strokeWidth ?? 2,
         fill: fill.withAlpha(fillAlpha),
@@ -654,11 +746,17 @@ export class CesiumLayerSync {
         viewer.dataSources.remove(dataSource, true);
         return;
       }
+      for (const entity of dataSource.entities.values) {
+        const index = entity.properties?.[indexKey]?.getValue(viewer.clock.currentTime);
+        if (Number.isInteger(index)) this.featureRefs.set(entity, { layerId: layer.id, index });
+      }
       entry.handle = dataSource;
       // applyAppearance → applyGeoJsonStyle fades every entity kind (fill,
       // stroke, marker) by the layer opacity right after load, so points/lines
       // match the 2D map instead of rendering fully opaque.
       this.applyAppearance(entry);
+      this.restoreHighlight();
+      this.applyHighlight();
     } catch {
       // A malformed FeatureCollection should not break the whole sync.
     }

--- a/packages/map/src/cesium-layer-sync.ts
+++ b/packages/map/src/cesium-layer-sync.ts
@@ -387,7 +387,10 @@ export class CesiumLayerSync {
       : null;
   }
 
-  /** Imagery has a layer identity, but no synchronous GeoJSON feature identity. */
+  /**
+   * Retained for future asynchronous imagery feature queries, as requested in #2274.
+   * Imagery has a layer identity, but no synchronous GeoJSON feature identity.
+   */
   imageryLayerId(imagery: object): string | undefined {
     return this.imageryRefs.get(imagery);
   }

--- a/packages/map/src/feature-popup.ts
+++ b/packages/map/src/feature-popup.ts
@@ -1,0 +1,314 @@
+import {
+  stringifyPopupValue,
+  isInlineImageValue,
+  isSafePopupUrl,
+  resolvePopupTitle,
+  resolvePopupBody,
+  resolvePopupRows,
+  resolveConfiguredPopupTitle,
+  type FieldVisibility,
+  type LayerPopupConfig,
+  type PopupRow,
+} from "@geolibre/core";
+import type { Feature } from "geojson";
+
+/**
+ * The author's popup design for a layer, plus what the renderer needs to apply
+ * it. Every field is optional: the WMS, pixel and status popups pass none of
+ * it and get exactly the rendering they always had.
+ */
+export interface IdentifyPopupOptions {
+  popup?: LayerPopupConfig;
+  fieldVisibility?: Record<string, FieldVisibility>;
+  /** The real feature, when the caller has one — feeds geometry-aware expressions. */
+  feature?: Feature | null;
+  /** Map zoom for `["zoom"]` in the title/body expressions. */
+  zoom?: number;
+}
+
+/** The document language, so formatted numbers and dates follow the UI locale. */
+function documentLocale(): string | undefined {
+  const lang = typeof document !== "undefined" ? document.documentElement.lang.trim() : "";
+  return lang || undefined;
+}
+
+/**
+ * Draw one resolved value into its cell. `"auto"` keeps the historical
+ * behavior (sanitized KML description markup, inline base64 images as
+ * thumbnails, everything else as text); the explicit kinds render what the
+ * author asked for, and fall back to text when the value cannot support it
+ * (a `link` whose value is not an http(s) URL, an `image` that is not one).
+ */
+function renderPopupValue(cell: HTMLElement, row: PopupRow): void {
+  if (row.kind === "image") {
+    if (isSafePopupUrl(row.value, true)) {
+      const image = document.createElement("img");
+      // Trimmed, because that is the copy isSafePopupUrl actually validated —
+      // as in the link branch below.
+      image.src = row.value.trim();
+      image.alt = row.label;
+      image.loading = "lazy";
+      image.className = "max-h-40 max-w-full rounded";
+      cell.appendChild(image);
+      return;
+    }
+    cell.textContent = row.text;
+    return;
+  }
+
+  if (row.kind === "link") {
+    if (isSafePopupUrl(row.value)) {
+      const link = document.createElement("a");
+      link.href = row.value.trim();
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.className = "break-all underline";
+      link.textContent = row.linkLabel ?? row.text;
+      cell.appendChild(link);
+      return;
+    }
+    cell.textContent = row.text;
+    return;
+  }
+
+  if (row.kind === "auto") {
+    // Render known KML description structures as sanitized markup. Requiring a
+    // supported tag keeps ordinary text such as "Elevation <500m>" intact.
+    if (
+      row.field === "description" &&
+      typeof row.value === "string" &&
+      /<(?:a|b|br|div|em|i|p|span|strong|table|tbody|td|th|thead|tr)\b/i.test(row.value)
+    ) {
+      appendSanitizedKmlDescription(cell, row.value);
+      return;
+    }
+    // Render inline image data URLs (e.g. a geotagged-photo or field-collection
+    // thumbnail) as an actual thumbnail rather than a multi-kilobyte string.
+    // Match base64 raster images only, excluding SVG (which can carry scripts)
+    // so an untrusted GeoJSON value can't smuggle one in.
+    if (isInlineImageValue(row.value)) {
+      const image = document.createElement("img");
+      image.src = row.value;
+      image.alt = row.field;
+      image.loading = "lazy";
+      image.className = "max-h-40 max-w-full rounded";
+      cell.appendChild(image);
+      return;
+    }
+  }
+
+  cell.textContent = row.text;
+}
+
+export function createIdentifyPopupElement(
+  layerName: string,
+  properties: Record<string, unknown>,
+  featureId?: string | number,
+  options: IdentifyPopupOptions = {},
+): HTMLElement {
+  const { popup, fieldVisibility, feature, zoom } = options;
+
+  const root = document.createElement("div");
+  root.className =
+    "geolibre-identify-popup-root flex min-w-[min(18rem,calc(100vw-48px))] max-w-[min(520px,calc(100vw-48px))] flex-col text-xs";
+
+  const title = document.createElement("div");
+  // Leave room for MapLibre's close button, which sits in the same corner the
+  // heading would otherwise run into.
+  title.className = "mb-2 pe-6 font-semibold text-foreground";
+  title.textContent = resolvePopupTitle(layerName, properties, popup, {
+    feature,
+    zoom,
+    fieldVisibility,
+  });
+  root.appendChild(title);
+
+  root.appendChild(createIdentifyPopupRows(properties, featureId, options));
+
+  return root;
+}
+
+/** Build the attribute rows shared by per-layer and all-layer Identify popups. */
+export function createIdentifyPopupRows(
+  properties: Record<string, unknown>,
+  featureId?: string | number,
+  options: IdentifyPopupOptions = {},
+  scrollable = true,
+): HTMLElement {
+  const { popup, fieldVisibility, feature, zoom } = options;
+  const locale = documentLocale();
+
+  const rows = document.createElement("div");
+  rows.className = scrollable ? "geolibre-identify-popup-rows pe-2" : "pe-2";
+
+  // An author-supplied body expression replaces the whole body outright — the
+  // field table AND the synthetic id row. The point of it is a sentence
+  // instead of rows, and a raw feature id dangling under that sentence would
+  // undo it. The designer disables the "Show the feature id row" checkbox
+  // while a body expression is set, so the UI does not offer a control that
+  // cannot take effect.
+  const body = resolvePopupBody(properties, popup, { feature, zoom, fieldVisibility });
+  if (body !== null) {
+    const paragraph = document.createElement("div");
+    paragraph.className = "whitespace-pre-wrap break-words text-foreground";
+    paragraph.textContent = body;
+    rows.appendChild(paragraph);
+    return rows;
+  }
+
+  const appendRow = (row: PopupRow) => {
+    const rowElement = document.createElement("div");
+    rowElement.className = "grid grid-cols-[minmax(5rem,0.45fr)_1fr] gap-2 border-t py-1";
+
+    const keyCell = document.createElement("div");
+    keyCell.className = "break-words font-medium text-muted-foreground";
+    keyCell.textContent = row.label;
+
+    const valueCell = document.createElement("div");
+    valueCell.className = "break-words text-foreground";
+    renderPopupValue(valueCell, row);
+
+    rowElement.append(keyCell, valueCell);
+    rows.appendChild(rowElement);
+  };
+
+  const showFeatureId = featureId != null && popup?.showFeatureId !== false;
+  if (showFeatureId) {
+    appendRow({
+      field: "id",
+      label: "id",
+      value: featureId,
+      text: stringifyPopupValue(featureId),
+      kind: "auto",
+    });
+  }
+
+  // resolvePopupRows drops GeoLibre's internal columns and the heavy
+  // full-resolution photo twin, and applies the author's field list, order,
+  // labels and formatting. Its result is empty for a feature with nothing to
+  // show, which is what the "No attributes" state reports.
+  const resolved = resolvePopupRows(properties, {
+    popup,
+    fieldVisibility,
+    locale,
+  });
+  if (resolved.length === 0 && !showFeatureId) {
+    const empty = document.createElement("div");
+    empty.className = "text-muted-foreground";
+    empty.textContent = "No attributes";
+    rows.appendChild(empty);
+  } else {
+    for (const row of resolved) appendRow(row);
+  }
+
+  return rows;
+}
+
+/**
+ * The hover tooltip's content: the layer's popup title over the fields the
+ * author flagged for hover. Kept deliberately small — this follows the pointer,
+ * so it shows the one or two fields that name the feature, never the table.
+ */
+export function createHoverTooltipElement(
+  layerName: string,
+  properties: Record<string, unknown>,
+  options: IdentifyPopupOptions = {},
+): HTMLElement | null {
+  const { popup, fieldVisibility, feature, zoom } = options;
+  const rows = resolvePopupRows(properties, {
+    popup,
+    fieldVisibility,
+    hover: true,
+    locale: documentLocale(),
+  });
+  const configuredTitle = resolveConfiguredPopupTitle(properties, popup, {
+    feature,
+    zoom,
+    fieldVisibility,
+  });
+  // Nothing to say: no flagged field, and no title the author configured, so
+  // the tip would be a box repeating the layer name the user can already read
+  // in the Layers panel. Keyed on whether a title was configured rather than on
+  // whether it happens to equal the layer name — a feature legitimately called
+  // the same thing as its layer still deserves its tooltip.
+  if (rows.length === 0 && configuredTitle === null) return null;
+  const title = configuredTitle ?? layerName;
+
+  const root = document.createElement("div");
+  root.className = "geolibre-hover-tooltip-root flex max-w-[16rem] flex-col gap-0.5 text-xs";
+
+  const heading = document.createElement("div");
+  heading.className = "font-semibold text-foreground";
+  heading.textContent = title;
+  root.appendChild(heading);
+
+  for (const row of rows) {
+    const line = document.createElement("div");
+    line.className = "flex gap-1.5 text-foreground";
+    const label = document.createElement("span");
+    label.className = "shrink-0 text-muted-foreground";
+    label.textContent = row.label;
+    const value = document.createElement("span");
+    value.className = "min-w-0 break-words";
+    // A tooltip is a one-line read, so a link shows as its text rather than as
+    // a clickable anchor — the tip has `pointer-events: none` and could not be
+    // clicked anyway. Image rows never reach here: resolvePopupRows drops them
+    // from the hover subset rather than printing a data URL.
+    value.textContent = row.text;
+    line.append(label, value);
+    root.appendChild(line);
+  }
+
+  return root;
+}
+
+const KML_DESCRIPTION_TAGS = new Set([
+  "a",
+  "b",
+  "br",
+  "div",
+  "em",
+  "i",
+  "p",
+  "span",
+  "strong",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
+]);
+
+/** Render useful KML description markup while dropping scripts and attributes. */
+function appendSanitizedKmlDescription(target: HTMLElement, html: string): void {
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+  const copy = (node: Node, parent: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      parent.appendChild(document.createTextNode(node.textContent ?? ""));
+      return;
+    }
+    if (!(node instanceof Element)) return;
+    const tag = node.localName.toLowerCase();
+    if (tag === "script" || tag === "style" || tag === "head" || tag === "meta") return;
+    if (!KML_DESCRIPTION_TAGS.has(tag)) {
+      for (const child of node.childNodes) copy(child, parent);
+      return;
+    }
+    const element = document.createElement(tag);
+    if (tag === "a") {
+      const href = node.getAttribute("href")?.trim();
+      if (href && /^(https?:|mailto:)/i.test(href)) {
+        element.setAttribute("href", href);
+        element.setAttribute("target", "_blank");
+        element.setAttribute("rel", "noopener noreferrer");
+      }
+    }
+    for (const child of node.childNodes) copy(child, element);
+    parent.appendChild(element);
+  };
+  const content = document.createElement("div");
+  content.className = "geolibre-kml-description";
+  for (const child of parsed.body.childNodes) copy(child, content);
+  target.appendChild(content);
+}

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -1032,3 +1032,159 @@ describe("CesiumEngine camera reads during a morph", () => {
     engine.destroy();
   });
 });
+
+describe("Cesium feature picking", () => {
+  async function setup() {
+    // Real Cesium entities/properties exercise cloning and material restoration.
+    // Only loading and the GPU pick pass are replaced.
+    const C = await import("@cesium/engine");
+    const f = makeViewer();
+    const sources: import("@cesium/engine").CustomDataSource[] = [];
+    let picks: unknown[] = [];
+    let projected: { x: number; y: number } | undefined = { x: 400, y: 300 };
+    Object.assign(f.viewer, {
+      clock: { currentTime: C.JulianDate.now() },
+      dataSources: {
+        add: async (ds: import("@cesium/engine").CustomDataSource) => {
+          sources.push(ds);
+          return ds;
+        },
+        remove: (ds: import("@cesium/engine").CustomDataSource) => {
+          sources.splice(sources.indexOf(ds), 1);
+        },
+      },
+    });
+    Object.assign((f.viewer as import("@cesium/engine").CesiumWidget).scene, {
+      drillPick: () => picks,
+      requestRender: () => {},
+    });
+    const ns = {
+      ...makeCesium(),
+      Color: C.Color,
+      ColorMaterialProperty: C.ColorMaterialProperty,
+      ConstantProperty: C.ConstantProperty,
+      SceneTransforms: { worldToWindowCoordinates: () => projected },
+      GeoJsonDataSource: {
+        load: async (data: import("geojson").FeatureCollection) => {
+          const ds = new C.CustomDataSource();
+          for (const feature of data.features) {
+            // Two render entities per feature models a multipart geometry.
+            for (let part = 0; part < 2; part++)
+              ds.entities.add(
+                new C.Entity({
+                  id: `${feature.id}-${part}`,
+                  properties: feature.properties ?? {},
+                  polygon: { material: C.Color.BLUE },
+                }),
+              );
+          }
+          return ds;
+        },
+      },
+    };
+    const engine = new CesiumEngine(ns as never, f.viewer);
+    const layer: import("../packages/core/src/types").GeoLibreLayer = {
+      id: "cities",
+      name: "Cities",
+      type: "geojson",
+      source: {},
+      metadata: {},
+      visible: true,
+      opacity: 1,
+      style: {},
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: 0,
+            properties: { name: "Zero", __geolibre_cesium_feature_index: "user value" },
+            geometry: {
+              type: "MultiPoint",
+              coordinates: [
+                [0, 0],
+                [1, 1],
+              ],
+            },
+          },
+          {
+            type: "Feature",
+            properties: { name: "No id" },
+            geometry: { type: "Point", coordinates: [2, 2] },
+          },
+        ],
+      },
+    };
+    engine.syncLayers([layer]);
+    await new Promise((resolve) => setImmediate(resolve));
+    return {
+      engine,
+      layer,
+      sources,
+      C,
+      f,
+      pick: (value: unknown[]) => {
+        picks = value;
+      },
+      project: (value: typeof projected) => {
+        projected = value;
+      },
+    };
+  }
+
+  it("returns original geometry and properties, deduplicates multipart picks and preserves zero/index ids", async () => {
+    const { engine, sources, layer, pick, project } = await setup();
+    const entities = sources[0].entities.values;
+    pick([
+      { id: entities[0] },
+      { id: entities[1] },
+      { primitive: { id: entities[2] } },
+      { id: {} },
+    ]);
+    const hits = engine.identifyFeatures([0, 0]);
+    assert.deepEqual(
+      hits.map((hit) => hit.featureId),
+      ["0", "1"],
+    );
+    assert.equal(hits[0].geometry, layer.geojson!.features[0].geometry);
+    assert.equal(hits[0].properties.__geolibre_cesium_feature_index, "user value");
+    assert.deepEqual(engine.identifyFeatures([0, 0], "other"), []);
+    project(undefined);
+    assert.deepEqual(engine.identifyFeatures([0, 0]), []);
+    assert.deepEqual(engine.identifyAtScreen({ x: -1, y: 1 } as never), []);
+    engine.destroy();
+    assert.deepEqual(engine.identifyFeatures([0, 0]), []);
+  });
+
+  it("rejects hidden, removed and replaced entities", async () => {
+    const { engine, layer, sources, pick } = await setup();
+    pick([{ id: sources[0].entities.values[0] }]);
+    engine.syncLayers([{ ...layer, visible: false }]);
+    assert.deepEqual(engine.identifyFeatures([0, 0]), []);
+    engine.syncLayers([
+      { ...layer, geojson: { ...layer.geojson!, features: [...layer.geojson!.features] } },
+    ]);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(engine.identifyFeatures([0, 0]), []);
+    engine.syncLayers([]);
+    assert.deepEqual(engine.identifyFeatures([0, 0]), []);
+    engine.destroy();
+  });
+
+  it("restores exact styles, keeps selection through opacity changes and fits selected features", async () => {
+    const { engine, layer, sources, C, f } = await setup();
+    const entity = sources[0].entities.values[0];
+    const original = entity.polygon;
+    engine.highlightFeature(layer, ["0"], { fit: true });
+    assert.notEqual(entity.polygon, original);
+    assert.equal(f.flights.length, 1);
+    engine.clearFeatureHighlight();
+    assert.equal(entity.polygon, original);
+    engine.highlightFeature(layer, "0");
+    engine.syncLayers([{ ...layer, opacity: 0.25 }]);
+    engine.clearFeatureHighlight();
+    const material = entity.polygon!.material as import("@cesium/engine").ColorMaterialProperty;
+    assert.equal(material.color!.getValue(C.JulianDate.now()).alpha, 0.6 * 0.25);
+    engine.destroy();
+  });
+});

--- a/tests/cesium-engine.test.ts
+++ b/tests/cesium-engine.test.ts
@@ -1060,6 +1060,12 @@ describe("Cesium feature picking", () => {
     });
     const ns = {
       ...makeCesium(),
+      Cartesian3: Object.assign(makeCesium().Cartesian3, {
+        subtract: C.Cartesian3.subtract,
+        magnitude: C.Cartesian3.magnitude,
+      }),
+      Ray: C.Ray,
+      IntersectionTests: { rayEllipsoid: () => undefined },
       Color: C.Color,
       ColorMaterialProperty: C.ColorMaterialProperty,
       ConstantProperty: C.ConstantProperty,
@@ -1187,4 +1193,43 @@ describe("Cesium feature picking", () => {
     assert.equal(material.color!.getValue(C.JulianDate.now()).alpha, 0.6 * 0.25);
     engine.destroy();
   });
+});
+
+it("rejects far-side coordinates before GPU picking, including below-sea-level terrain", async () => {
+  const C = await import("@cesium/engine");
+  const f = makeViewer();
+  const viewer = f.viewer as import("@cesium/engine").CesiumWidget;
+  let picks = 0;
+  Object.defineProperty(viewer.camera, "positionWC", {
+    get: () => C.Cartesian3.fromDegrees(0, 0, 1000000),
+  });
+  viewer.scene.globe.ellipsoid = C.Ellipsoid.WGS84;
+  Object.assign(viewer.scene, {
+    drillPick: () => {
+      picks++;
+      return [];
+    },
+  });
+  const engine = new CesiumEngine(
+    {
+      ...makeCesium(),
+      Cartesian3: C.Cartesian3,
+      Ray: C.Ray,
+      IntersectionTests: C.IntersectionTests,
+      SceneTransforms: { worldToWindowCoordinates: () => new C.Cartesian2(400, 300) },
+    } as never,
+    f.viewer,
+  );
+  for (const height of [0, -400]) {
+    f.setGroundHeight(height);
+    const before = picks;
+    engine.identifyFeatures([180, 0]);
+    assert.equal(picks, before, "far side must never query the visible features");
+    engine.identifyFeatures([0, 0]);
+    assert.equal(picks, before + 1, "near side remains pickable");
+  }
+  f.setSceneMode(C.SceneMode.SCENE2D);
+  engine.identifyFeatures([180, 0]);
+  assert.equal(picks, 3, "flat views must not use 3D occlusion");
+  engine.destroy();
 });

--- a/tests/cesium-interactions.test.ts
+++ b/tests/cesium-interactions.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { afterEach, it } from "node:test";
+import { parseHTML } from "linkedom";
+import { Cartesian2, Event as CesiumEvent, ScreenSpaceEventType } from "@cesium/engine";
+import { useAppStore } from "../packages/core/src/store";
+import { IDENTIFY_ALL_LAYERS_ID } from "../packages/core/src/store";
+import type { GeoLibreLayer } from "../packages/core/src/types";
+import { installCesiumInteractions } from "../packages/map/src/cesium-interactions";
+
+const original = {
+  window: globalThis.window,
+  document: globalThis.document,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  cancelAnimationFrame: globalThis.cancelAnimationFrame,
+};
+let cleanup: (() => void) | undefined;
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+  Object.assign(globalThis, original);
+});
+
+function setup() {
+  const { window, document } = parseHTML("<html><body><div><canvas></canvas></div></body></html>");
+  const frames = new Map<number, FrameRequestCallback>();
+  Object.assign(globalThis, {
+    window,
+    document,
+    requestAnimationFrame: (fn: FrameRequestCallback) => {
+      frames.set(1, fn);
+      return 1;
+    },
+    cancelAnimationFrame: (id: number) => frames.delete(id),
+  });
+  const actions = new Map<number, (event: unknown) => void>();
+  let destroyed = false;
+  let queries = 0;
+  let highlights = 0;
+  const layers = [false, true, true].map(
+    (click, index): GeoLibreLayer => ({
+      id: String(index),
+      name: `Layer ${index}`,
+      type: "geojson",
+      source: {},
+      metadata: {},
+      visible: true,
+      opacity: 1,
+      style: {},
+      popup: { click, hover: true, titleField: "name" },
+    }),
+  );
+  useAppStore.setState({
+    layers,
+    selectedLayerId: null,
+    selectedFeatureId: null,
+    selectedFeatureIds: [],
+    identifyLayerId: IDENTIFY_ALL_LAYERS_ID,
+  });
+  const camera = { moveStart: new CesiumEvent(), moveEnd: new CesiumEvent() };
+  cleanup = installCesiumInteractions(
+    {
+      Cartesian2,
+      ScreenSpaceEventType,
+      ScreenSpaceEventHandler: class {
+        setInputAction(fn: (event: unknown) => void, type: number) {
+          actions.set(type, fn);
+        }
+        destroy() {
+          destroyed = true;
+          actions.clear();
+        }
+      },
+    } as never,
+    { canvas: document.querySelector("canvas"), camera } as never,
+    {
+      identifyAtScreen: () => {
+        queries++;
+        return layers.map((layer) => ({
+          layerId: layer.id,
+          featureId: "0",
+          properties: { name: layer.name },
+          geometry: null,
+        }));
+      },
+      highlightFeature: () => {
+        highlights++;
+      },
+      readView: () => ({ zoom: 3 }),
+    } as never,
+    () => "Fermer",
+  );
+  return {
+    document,
+    camera,
+    frames,
+    click: () =>
+      actions.get(ScreenSpaceEventType.LEFT_CLICK)?.({ position: new Cartesian2(10, 10) }),
+    hover: () =>
+      actions.get(ScreenSpaceEventType.MOUSE_MOVE)?.({ endPosition: new Cartesian2(10, 10) }),
+    get queries() {
+      return queries;
+    },
+    get highlights() {
+      return highlights;
+    },
+    get destroyed() {
+      return destroyed;
+    },
+  };
+}
+
+it("selects the first eligible hit, even when a disabled popup is topmost", () => {
+  const f = setup();
+  f.click();
+  assert.equal(useAppStore.getState().selectedLayerId, "1");
+  assert.equal(useAppStore.getState().selectedFeatureId, "0");
+  assert.equal(f.document.querySelectorAll(".geolibre-identify-popup-root").length, 2);
+  const button = f.document.querySelector("button")!;
+  assert.equal(button.getAttribute("aria-label"), "Fermer");
+  assert.equal(button.getAttribute("type"), "button");
+  button.click();
+  assert.equal(f.document.querySelector(".geolibre-identify-popup"), null);
+});
+
+it("does not query or select on a click when Identify is off", () => {
+  const f = setup();
+  useAppStore.setState({ identifyLayerId: null });
+  f.click();
+  assert.equal(f.queries, 0);
+  assert.equal(useAppStore.getState().selectedFeatureId, null);
+  assert.equal(f.document.querySelector(".geolibre-identify-popup"), null);
+});
+
+it("cancels queued hover and detaches handlers and subscriptions on teardown", () => {
+  const f = setup();
+  useAppStore.setState({ identifyLayerId: null });
+  f.hover();
+  assert.equal(f.frames.size, 1);
+  cleanup!();
+  cleanup = undefined;
+  assert.equal(f.frames.size, 0);
+  assert.equal(f.destroyed, true);
+  assert.equal(f.camera.moveStart.numberOfListeners, 0);
+  assert.equal(f.camera.moveEnd.numberOfListeners, 0);
+  const before = f.highlights;
+  useAppStore.getState().selectFeature("after-destroy");
+  assert.equal(f.highlights, before);
+});

--- a/tests/cesium-layer-sync.test.ts
+++ b/tests/cesium-layer-sync.test.ts
@@ -206,7 +206,8 @@ describe("CesiumLayerSync", () => {
     sync.sync([mkLayer({ type: "geojson", geojson: fc as never, visible: true })]);
     await f.flush();
     assert.equal(f.calls.geojsonLoads.length, 1);
-    assert.equal(f.calls.geojsonLoads[0].data, fc);
+    assert.notEqual(f.calls.geojsonLoads[0].data, fc);
+    assert.deepEqual(fc, { type: "FeatureCollection", features: [{}] });
     assert.equal(f.calls.geojsonLoads[0].options.clampToGround, true);
     assert.equal(f.calls.dataSourcesAdded.length, 1);
   });


### PR DESCRIPTION
Clicking GeoJSON features on the primary Cesium globe now opens their configured attribute popups, selects and highlights them, and shows configured hover tooltips. Identify and attribute-table highlight/zoom calls now work through the Cesium engine's picking capability.

Cesium entities retain their store layer and feature identities across multipart expansion. Picks return original geometry and properties, deduplicate render primitives, and exclude hidden or stale entities. Highlighting preserves the original graphics and survives opacity updates and asynchronous reloads. The globe and MapLibre share the popup formatting and sanitization code. Imagery entries retain layer identity; raster service feature queries remain outside the synchronous GeoJSON picking API.

Validation: 141 focused Cesium and popup tests passed; production build and scoped pre-commit hooks passed. Playwright CLI verified click, hover, selection, Escape cleanup, and popup backgrounds using real `us_cities.geojson` data in light and dark themes. No upstream package release was needed.

Fixes #2274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added feature identification on Cesium maps through hover and click interactions.
  - Added identify popups and hover tooltips with configurable fields, links, images, and sanitized content.
  - Added feature highlighting, selection tracking, and camera fitting for selected features.
  - Added support for filtering identification by map layer.
  - Added translated labels for popup close buttons.

- **Bug Fixes**
  - Improved feature identity handling for multipart and zero-valued features.
  - Preserved original map data while preparing Cesium-rendered features.
  - Improved interaction cleanup when switching views or closing the map.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->