### PR TITLE
fix(e2e): expect four Cesium toolbar controls, not three

### DIFF
--- a/e2e/cesium-primary-renderer.spec.ts
+++ b/e2e/cesium-primary-renderer.spec.ts
@@ -231,9 +231,10 @@ test.describe("Cesium toolbar controls on the globe", () => {
     await expect(globe).toBeVisible({ timeout: 60_000 });
     await expect(globe.locator("canvas")).toBeVisible({ timeout: 60_000 });
 
-    // All three controls mount into the globe's control host.
+    // All four controls mount into the globe's control host.
     await expect(page.locator(".cesium-home-button")).toBeVisible({ timeout: 60_000 });
     await expect(page.locator(".cesium-sceneModePicker-wrapper")).toBeVisible();
+    await expect(page.locator(".geolibre-cesium-basemap-picker")).toBeVisible();
     await expect(page.locator(".cesium-fullscreenButton")).toBeVisible();
     // Tooltips come from the app's catalogs, not the widgets' English defaults.
     // The fullscreen one is the interesting case: Cesium derives it from the
@@ -248,11 +249,13 @@ test.describe("Cesium toolbar controls on the globe", () => {
     // They line up. Cesium gives the scene-mode picker's wrapper a 3px side
     // margin and leaves the fullscreen button to inherit a size from a `Viewer`
     // layout that does not exist here, so both drifted out of the column before
-    // `index.css` pinned them.
+    // `index.css` pinned them. Every control container carries
+    // `.geolibre-cesium-ctrl`, so this counts one visible button per control:
+    // home, scene mode, the basemap/terrain picker, and fullscreen.
     const edges = await page
       .locator(".geolibre-cesium-ctrl button:visible")
       .evaluateAll((buttons) => buttons.map((button) => button.getBoundingClientRect().right));
-    expect(edges).toHaveLength(3);
+    expect(edges).toHaveLength(4);
     for (const edge of edges) expect(edge).toBeCloseTo(edges[0], 0);
 
     // The globe seeded from the 2D camera, so this is the scale to preserve.


### PR DESCRIPTION
The `E2E smoke (Playwright)` job has been red on `main` since #2292, and every open PR inherits the failure (it is the only failing check on #2273, for example).

## Cause

`cesium-primary-renderer.spec.ts` asserts that the globe's toolbar controls line up in one column, and counts them with `.geolibre-cesium-ctrl button:visible`. Each control gets its own container carrying that class, so the count tracks the number of controls. #2292 added the basemap/terrain picker as a fourth control (`createCesiumWidgetControls` now returns home, scene mode, base layer picker, fullscreen), and `cesium-base-layer-picker.ts` gives its container the same `geolibre-cesium-ctrl` class. The locator therefore matches four buttons and `expect(edges).toHaveLength(3)` fails:

```
Expected length: 3
Received length: 4
Received array:  [1226, 1226, 1226, 1226]
```

The identical right edges show the four already line up — the alignment this test exists to protect is intact, only the hardcoded count was stale.

## Change

Assert four instead of three, and add a visibility check for `.geolibre-cesium-basemap-picker` next to the existing three, so the new control is covered by the same "mounts into the control host and lines up" guarantee rather than just inflating a number.

## Testing

Reproduced locally against a keyless production build (`CESIUM_TOKEN=""`), served with `vite preview`: the spec fails with the same `[1226, 1226, 1226, 1226]` on `main` and passes with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for the Cesium toolbar to include the basemap and terrain picker.
  * Added verification that four controls are visible, aligned, and mounted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->