### PR TITLE
fix(map): wait for swipe comparison imagery before thumbnail capture

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
+++ b/apps/geolibre-desktop/src/hooks/useScreenshotReadiness.ts
@@ -1,7 +1,11 @@
 import { useEffect, type RefObject } from "react";
 import { useAppStore } from "@geolibre/core";
 import type { MapEngine } from "@geolibre/map";
-import { getRasterLoadState, getSharedDeckLoadState } from "@geolibre/plugins";
+import {
+  getRasterLoadState,
+  getSharedDeckLoadState,
+  getSwipeRasterLoadState,
+} from "@geolibre/plugins";
 import { inspectScreenshotLayers, screenshotReadinessEnabled } from "../lib/screenshot-readiness";
 
 /** Opt-in DOM contract for browser automation; adds no pixels to the screenshot. */
@@ -75,6 +79,7 @@ export function useScreenshotReadiness(
         map && pluginsReady && !projectBusy && !cesium
           ? inspectScreenshotLayers(map, store.layers, store.layerGroups, {
               raster: getRasterLoadState,
+              swipe: getSwipeRasterLoadState,
               deck: getSharedDeckLoadState,
             })
           : { pending: ["Project and map initialization"], errors: [] };

--- a/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
+++ b/apps/geolibre-desktop/src/lib/screenshot-readiness.ts
@@ -15,6 +15,7 @@ export function screenshotReadinessEnabled(search: string): boolean {
 }
 
 export interface LayerLoadProbe {
+  swipe?: (id: string) => { loading: boolean; error: string | null; mainVisible: boolean } | null;
   raster: (id: string) => {
     loading: boolean;
     error: string | null;
@@ -72,6 +73,19 @@ export function inspectScreenshotLayers(
     if (typeof layer.metadata.error === "string") {
       errors.push(`${layer.name}: ${layer.metadata.error}`);
       continue;
+    }
+    const swipe = probe.swipe?.(layer.id);
+    if (swipe) {
+      if (swipe.error) {
+        errors.push(`${layer.name}: ${swipe.error}`);
+        continue;
+      }
+      if (swipe.loading) {
+        pending.push(layer.name);
+        continue;
+      }
+      // Right-only rasters are intentionally absent from the main renderer.
+      if (!swipe.mainVisible) continue;
     }
     const isRaster = layer.metadata.sourceKind === "maplibre-gl-raster";
     let requiresDeck = false;

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -637,7 +637,11 @@ export {
   maplibreElevationProfilePlugin,
   ELEVATION_PROFILE_PLUGIN_ID,
 } from "./plugins/elevation-profile";
-export { maplibreSwipePlugin, SWIPE_PLUGIN_ID } from "./plugins/maplibre-swipe";
+export {
+  maplibreSwipePlugin,
+  SWIPE_PLUGIN_ID,
+  getSwipeRasterLoadState,
+} from "./plugins/maplibre-swipe";
 export {
   maplibreGraticulePlugin,
   GRATICULE_PLUGIN_ID,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -119,7 +119,7 @@ const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
 // so a rename in a future release degrades to a no-op rather than a crash --
 // re-verify these names AND the .mlr-control-close selector in
 // wireRasterCloseButton when bumping the dependency.
-type RasterControlInternals = {
+export type RasterControlInternals = {
   _layerManager?: RasterLayerManagerInternals;
   _panel?: HTMLElement;
 };
@@ -137,6 +137,12 @@ type MapControlHost = {
 };
 type MapboxOverlayConstructor = new (props: Record<string, unknown>) => OverlayLike;
 type RasterLayerManagerInternals = {
+  // Comparison-mirror readiness reads the real MapboxOverlay. The main-map
+  // shared-overlay proxy need not expose these fields. Verified with 0.14.11.
+  _overlay?: {
+    _deck?: { isInitialized: boolean };
+    _props?: { layers?: { isLoaded: boolean }[] };
+  };
   /** The currently selected raster id (read to restore it after inspect). */
   selectedId?: string | null;
   _device?: unknown;

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -69,6 +69,11 @@ let unsubscribeCogRasterChanges: (() => void) | null = null;
 /** Read comparison rasters under the mirror's generated ids. */
 export function getSwipeRasterLoadState(layerId: string) {
   const forced = cogMainForced.get(layerId);
+  // This probe covers maplibre-gl-raster, including the Nepal flood project.
+  // Legacy CogLayerControl (kind "cog", sourceKind "cog-url") uses a separate
+  // private overlay in SwipeCogMirror with no tile-readiness probe. Leave it
+  // on the inspector's existing fail-closed path; opacity-based main-map
+  // visibility is not evidence that the comparison tiles have finished.
   if (!forced || forced.kind !== "raster") return null;
   const state = swipeControl?.getState();
   // Left-only rasters are not mirrored. Unassigned and both-side rasters are.

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -66,6 +66,20 @@ let cogPendingComparisonMap: MapLibreMap | undefined;
 let cogReconcileScheduled = false;
 let unsubscribeCogRasterChanges: (() => void) | null = null;
 
+/** Read comparison rasters under the mirror's generated ids. */
+export function getSwipeRasterLoadState(layerId: string) {
+  const forced = cogMainForced.get(layerId);
+  if (!forced || forced.kind !== "raster") return null;
+  const state = swipeControl?.getState();
+  // Left-only rasters are not mirrored. Unassigned and both-side rasters are.
+  if (state?.leftLayers.includes(layerId) && !state.rightLayers.includes(layerId)) return null;
+  const result = rasterMirror?.getLoadState(layerId) ?? {
+    loading: true,
+    error: null,
+  };
+  return { ...result, mainVisible: forced.visible };
+}
+
 const cogSwipeProvider: SwipeLayerProvider = {
   getLayers: () =>
     [...getSwipeCogRasters(), ...getSwipeMaplibreRasters()].map((raster) => ({

--- a/packages/plugins/src/plugins/swipe-raster-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-raster-mirror.ts
@@ -76,6 +76,38 @@ export class SwipeRasterMirror {
     return this.map;
   }
 
+  /** Probe the private comparison overlay, never the main-map shared Deck. */
+  getLoadState(layerId: string): { loading: boolean; error: string | null } {
+    const entry = this.applied.get(layerId);
+    const raster = entry && this.control?.getRaster(entry.mirrorId);
+    // RasterControl has no public tile-readiness API. This is the same manager
+    // seam used by patchWebRasterOverlayFactory, verified against 0.14.11.
+    // Missing internals fail closed after a dependency upgrade.
+    const overlay = (
+      this.control as unknown as {
+        _layerManager?: {
+          _overlay?: {
+            _deck?: { isInitialized: boolean };
+            _props?: { layers?: { isLoaded: boolean }[] };
+          };
+        };
+      } | null
+    )?._layerManager?._overlay;
+    const layers = overlay?._props?.layers;
+    return {
+      loading:
+        !raster ||
+        raster.loading ||
+        !overlay?._deck?.isInitialized ||
+        !layers?.length ||
+        layers.some((layer) => !layer.isLoaded) ||
+        !this.map.loaded() ||
+        !this.map.areTilesLoaded() ||
+        this.map.isMoving(),
+      error: raster?.error?.message ?? null,
+    };
+  }
+
   sync(desired: SwipeRasterSnapshot[]): Promise<void> {
     this.syncChain = this.syncChain.catch(() => {}).then(() => this.reconcile(desired));
     return this.syncChain;

--- a/packages/plugins/src/plugins/swipe-raster-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-raster-mirror.ts
@@ -1,5 +1,6 @@
 import type { Map as MapLibreMap } from "maplibre-gl";
 import type { RasterControl, RasterLayerState } from "maplibre-gl-raster";
+import type { RasterControlInternals } from "./maplibre-raster";
 
 export interface SwipeRasterSnapshot {
   id: string;
@@ -83,16 +84,8 @@ export class SwipeRasterMirror {
     // RasterControl has no public tile-readiness API. This is the same manager
     // seam used by patchWebRasterOverlayFactory, verified against 0.14.11.
     // Missing internals fail closed after a dependency upgrade.
-    const overlay = (
-      this.control as unknown as {
-        _layerManager?: {
-          _overlay?: {
-            _deck?: { isInitialized: boolean };
-            _props?: { layers?: { isLoaded: boolean }[] };
-          };
-        };
-      } | null
-    )?._layerManager?._overlay;
+    const overlay = (this.control as unknown as RasterControlInternals | null)?._layerManager
+      ?._overlay;
     const layers = overlay?._props?.layers;
     return {
       loading:

--- a/tests/screenshot-readiness.test.ts
+++ b/tests/screenshot-readiness.test.ts
@@ -220,3 +220,21 @@ test("swipe checks comparison tiles instead of requiring right-only rasters on t
     { pending: [], errors: ["NLCD: Tile failed"] },
   );
 });
+
+test("legacy CogLayerControl output without a swipe probe still fails closed", () => {
+  const cog = { ...layer, metadata: { sourceKind: "cog-url", nativeLayerIds: [layer.id] } };
+  const custom = {
+    ...map,
+    getLayer: () => ({ id: layer.id, type: "custom" }),
+  } as unknown as MapLibreMap;
+  const legacyProbe: LayerLoadProbe = { ...probe, swipe: () => null };
+  assert.deepEqual(inspectScreenshotLayers(custom, [cog], [], legacyProbe), {
+    pending: [],
+    errors: ["NLCD: screenshot readiness is not supported for this custom renderer"],
+  });
+  const absent = { ...map, getLayersOrder: () => [] } as unknown as MapLibreMap;
+  assert.deepEqual(inspectScreenshotLayers(absent, [cog], [], legacyProbe), {
+    pending: ["NLCD"],
+    errors: [],
+  });
+});

--- a/tests/screenshot-readiness.test.ts
+++ b/tests/screenshot-readiness.test.ts
@@ -185,3 +185,38 @@ test("a derived native layer belongs to the longest matching layer id", () => {
     errors: [],
   });
 });
+
+test("swipe checks comparison tiles instead of requiring right-only rasters on the main map", () => {
+  const swipeProbe = (loading: boolean, mainVisible = false): LayerLoadProbe => ({
+    ...probe,
+    swipe: () => ({ loading, mainVisible, error: null }),
+  });
+  const missing = {
+    ...map,
+    getLayersOrder: () => [],
+  } as unknown as MapLibreMap;
+  assert.deepEqual(inspectScreenshotLayers(missing, [layer], [], swipeProbe(false)), {
+    pending: [],
+    errors: [],
+  });
+  assert.deepEqual(inspectScreenshotLayers(missing, [layer], [], swipeProbe(true)), {
+    pending: ["NLCD"],
+    errors: [],
+  });
+  // Both-side rasters still need their main-map rendering.
+  assert.deepEqual(inspectScreenshotLayers(missing, [layer], [], swipeProbe(false, true)), {
+    pending: ["NLCD"],
+    errors: [],
+  });
+  assert.deepEqual(
+    inspectScreenshotLayers(missing, [layer], [], {
+      ...probe,
+      swipe: () => ({
+        loading: false,
+        mainVisible: false,
+        error: "Tile failed",
+      }),
+    }),
+    { pending: [], errors: ["NLCD: Tile failed"] },
+  );
+});

--- a/tests/swipe-raster-mirror.test.ts
+++ b/tests/swipe-raster-mirror.test.ts
@@ -187,3 +187,51 @@ describe("SwipeRasterMirror", () => {
     assert.deepEqual(rec.calls, ["add:a=>m1"]);
   });
 });
+
+describe("comparison screenshot readiness", () => {
+  it("waits for the mirrored raster, its deck tiles, and its map; exposes errors", async () => {
+    let headerLoading = false;
+    let tileLoaded = false;
+    let mapLoaded = true;
+    let error: Error | undefined;
+    const deckLayer = {
+      get isLoaded() {
+        return tileLoaded;
+      },
+    };
+    const control = {
+      getRaster: () => ({ loading: headerLoading, error }),
+      _layerManager: {
+        _overlay: {
+          _deck: { isInitialized: true },
+          _props: { layers: [deckLayer] },
+        },
+      },
+    } as unknown as RasterControl;
+    const map = {
+      loaded: () => mapLoaded,
+      areTilesLoaded: () => mapLoaded,
+      isMoving: () => false,
+    } as unknown as MapLibreMap;
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(map, {
+      ...rec.deps,
+      createControl: async () => control,
+    });
+    assert.equal(mirror.getLoadState("a").loading, true);
+    await mirror.sync([raster("a")]);
+    assert.equal(mirror.getLoadState("a").loading, true);
+    tileLoaded = true;
+    assert.deepEqual(mirror.getLoadState("a"), { loading: false, error: null });
+    headerLoading = true;
+    assert.equal(mirror.getLoadState("a").loading, true);
+    headerLoading = false;
+    mapLoaded = false;
+    assert.equal(mirror.getLoadState("a").loading, true);
+    mapLoaded = true;
+    error = new Error("Tile failed");
+    assert.equal(mirror.getLoadState("a").error, "Tile failed");
+    mirror.destroy();
+    assert.equal(mirror.getLoadState("a").loading, true);
+  });
+});


### PR DESCRIPTION
Layer Swipe projects such as [Nepal Flash Floods](https://share.geolibre.app/giswqs/nepal-flash-floods) render correctly but never become ready for thumbnail capture. Right-only rasters are hidden on the main map and rendered by the comparison mirror; checking only the main renderer leaves them pending, so Share.GeoLibre substitutes a generic world-map tile.

Probe the comparison mirror's raster headers, deck tiles, and map readiness before allowing capture. Right-only rasters no longer require main-map output, while both-side rasters still require both renderers. Loading errors continue to prevent capture. The mirror probe uses the existing RasterControl internal-manager seam, verified against 0.14.11, and remains pending if those internals are unavailable.

Validation:
- Reproduced the stuck loading state against the public Nepal project and verified the local fix reaches `ready` with no pending layers or errors and captures the flood comparison.
- 24 screenshot-readiness and raster-mirror tests pass, including a regression that failed before the fix.
- TypeScript checks, full production build, repository ESLint, and all scoped pre-commit hooks pass.
- Full `npm run ci` passed lint, translation checks, build, frontend coverage, and worker checks; stopped at backend coverage because the active Python environment has no `pytest`. Rust checks were not reached.

Scope: this fix covers `maplibre-gl-raster` imagery, including the Nepal project. Legacy `CogLayerControl` / `cog-url` imagery still uses the existing fail-closed readiness path because its separate private overlay has no tile-readiness probe. A regression test ensures unsupported legacy output is not reported ready.

After the viewer is deployed, regenerate the affected project's thumbnail to replace the stored fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot readiness checks for swipe comparison layers.
  * Screenshots now wait for comparison tiles and overlays to finish loading and report related errors.
  * Layers shown only on the comparison side are handled correctly, while layers visible on both maps still require main-map rendering.

* **Tests**
  * Added coverage for loading, error, movement, and post-destruction states during screenshot capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
