### PR TITLE
docs: add three more video tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Switch bodies from the planet switcher in the Layers panel. See [Demos](https://
 - [Regularize Building Footprints in the Browser with GeoLibre](https://youtu.be/xjfPYxgEEEc)
 - [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o)
 - [Create Reusable GIS Workflows with GeoLibre Model Builder and AI Assistant](https://youtu.be/dzjNKM6slgs)
+- [Mapping the 2026 Nepal Floods with Free High-Resolution Satellite Imagery](https://youtu.be/UDO1BCwOAAc)
+- [Building Cloud-Native GIS Workflows with GeoLibre](https://youtu.be/RgNoKsvZ5Hk)
+- [Image Georeferencing Using GeoLibre in the Browser](https://youtu.be/lbioujkDSG0)
 
 All of them, with chapters and summaries, are on the [Video Tutorials](https://geolibre.app/tutorials/videos/) page.
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -107,6 +107,9 @@ See [Embedding & Sharing](user-guide/embedding.md) for every URL parameter.
 - [Regularize Building Footprints in the Browser with GeoLibre](https://youtu.be/xjfPYxgEEEc) — squaring up AI-derived building polygons with the Rust engine.
 - [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o) — pairing GeoLibre with GeoLens for a self-hosted geospatial data stack.
 - [Create Reusable GIS Workflows with GeoLibre Model Builder and AI Assistant](https://youtu.be/dzjNKM6slgs) — graphical models, including ones the AI Assistant builds from a prompt.
+- [Mapping the 2026 Nepal Floods with Free High-Resolution Satellite Imagery](https://youtu.be/UDO1BCwOAAc) — disaster imagery from Vantor, Planet, and OpenAerialMap in one before-and-after map.
+- [Building Cloud-Native GIS Workflows with GeoLibre](https://youtu.be/RgNoKsvZ5Hk) — an hour-long webinar on the cloud-native stack behind GeoLibre.
+- [Image Georeferencing Using GeoLibre in the Browser](https://youtu.be/lbioujkDSG0) — pinning a scanned campus map to the basemap with ground control points.
 
 All of them, with chapters and summaries, are on
 [Video Tutorials](tutorials/videos.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,9 @@ See [iOS](ios.md) for what runs on mobile and for build details.
 - [Regularize Building Footprints in the Browser with GeoLibre](https://youtu.be/xjfPYxgEEEc)
 - [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o)
 - [Create Reusable GIS Workflows with GeoLibre Model Builder and AI Assistant](https://youtu.be/dzjNKM6slgs)
+- [Mapping the 2026 Nepal Floods with Free High-Resolution Satellite Imagery](https://youtu.be/UDO1BCwOAAc)
+- [Building Cloud-Native GIS Workflows with GeoLibre](https://youtu.be/RgNoKsvZ5Hk)
+- [Image Georeferencing Using GeoLibre in the Browser](https://youtu.be/lbioujkDSG0)
 
 All of them, with chapters and summaries, are on [Video Tutorials](tutorials/videos.md).
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -29,5 +29,8 @@ Work through them in order for a guided tour, or jump to the one that matches yo
 - [Regularize Building Footprints in the Browser with GeoLibre](https://youtu.be/xjfPYxgEEEc)
 - [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o)
 - [Create Reusable GIS Workflows with GeoLibre Model Builder and AI Assistant](https://youtu.be/dzjNKM6slgs)
+- [Mapping the 2026 Nepal Floods with Free High-Resolution Satellite Imagery](https://youtu.be/UDO1BCwOAAc)
+- [Building Cloud-Native GIS Workflows with GeoLibre](https://youtu.be/RgNoKsvZ5Hk)
+- [Image Georeferencing Using GeoLibre in the Browser](https://youtu.be/lbioujkDSG0)
 
 All of them, with chapters and summaries, are on [Video Tutorials](videos.md).

--- a/docs/tutorials/videos.md
+++ b/docs/tutorials/videos.md
@@ -235,6 +235,106 @@ Related: [Processing Tools](../user-guide/processing.md) ·
     - 17:32 Customizing AI-generated models
     - 18:25 Conclusion
 
+## Mapping the 2026 Nepal Floods with Free High-Resolution Satellite Imagery
+
+<div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/UDO1BCwOAAc" title="Mapping the 2026 Nepal Floods with Free High-Resolution Satellite Imagery" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+</div>
+
+**23:14 · August 2026 · [Watch on YouTube](https://youtu.be/UDO1BCwOAAc)**
+
+A full disaster-response workflow on the Nepal–China border flood: find, view,
+compare, and download open imagery from Vantor Open Data, Planet Crisis
+Response, and OpenAerialMap. Builds a before-and-after swipe map, explores the
+valley in 3D terrain, pulls building footprints from Overture Maps, and exports
+the result for damage assessment.
+
+Try it yourself with the
+[live sample project](https://share.geolibre.app/giswqs/nepal-flash-floods).
+
+Related: [Plugins & Marketplace](../user-guide/plugins.md) ·
+[Data Integrations](../user-guide/data-integrations.md) ·
+[Map Controls](../user-guide/map-controls.md)
+
+??? note "Chapters"
+
+    As with the 1.0 tour, the last few chapter timestamps in the video
+    description run past the recording's 23:14 length.
+
+    - 00:00 Nepal–China border flood seen from space
+    - 02:02 Building the before-and-after map
+    - 03:05 Finding the affected location
+    - 06:09 Searching Vantor Open Data
+    - 08:40 Exploring the terrain in 3D
+    - 12:08 Adding post-event satellite imagery
+    - 14:53 Comparing damage with Layer Swipe
+    - 18:39 Sharing the interactive GeoLibre map
+    - 20:06 Exploring Planet Crisis Response imagery
+    - 22:52 Finding imagery with OpenAerialMap
+    - 25:14 Extracting buildings from Overture Maps
+    - 27:20 Exporting data for damage assessment
+    - 28:30 Conclusion
+
+## Building Cloud-Native GIS Workflows with GeoLibre
+
+<div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/RgNoKsvZ5Hk" title="Building Cloud-Native GIS Workflows with GeoLibre" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+</div>
+
+**1:07:28 · September 2026 · [Watch on YouTube](https://youtu.be/RgNoKsvZ5Hk)**
+
+A recorded webinar, and the longest single overview of the project. Covers how
+GeoLibre uses COG, GeoParquet, PMTiles, DuckDB, and WebAssembly to work with
+large vector, raster, and LiDAR datasets directly in the browser, then walks the
+plugin ecosystem, the cross-platform builds (browser, desktop, mobile, Jupyter,
+R), and the emerging GeoAI integration.
+
+Slides: [geolibre-slides-en.html](https://assets.geolibre.app/slides/geolibre-slides-en.html)
+
+Related: [Cloud-Native Data](cloud-native-data.md) ·
+[Architecture](../architecture.md) ·
+[Python API](../python.md) · [R Package](../r.md)
+
+## Image Georeferencing Using GeoLibre in the Browser
+
+<div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/lbioujkDSG0" title="Image Georeferencing Using GeoLibre in the Browser" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe>
+</div>
+
+**15:35 · September 2026 · [Watch on YouTube](https://youtu.be/lbioujkDSG0)**
+
+Georeferences a scanned University of Tennessee campus map with no desktop GIS:
+place ground control points, pick a transformation, read the per-GCP and RMS
+residuals, and align the image to a basemap. Then exports a GeoTIFF, reloads it,
+handles NoData transparency, compares it against the basemap with the swipe
+tool, and shares the finished map.
+
+Sample data:
+[UTK campus map](https://assets.geolibre.app/data/utk-parking-map.jpg) ·
+[control points](https://assets.geolibre.app/data/utk-parking-map-gcps.csv)
+
+Related: [Processing Tools](../user-guide/processing.md) ·
+[Adding Data](../user-guide/adding-data.md) ·
+[Sharing & Embedding](sharing-embedding.md)
+
+??? note "Chapters"
+
+    - 00:00 Introduction to image georeferencing
+    - 01:44 Launching GeoLibre and choosing a basemap
+    - 02:44 Opening the Georeferencing tool
+    - 03:20 Loading an image
+    - 03:50 Choosing a transformation method
+    - 04:55 Selecting ground control points
+    - 08:34 Checking coordinates and residuals
+    - 11:17 Evaluating georeferencing accuracy
+    - 11:30 Exporting control points and a GeoTIFF
+    - 12:26 Adding the georeferenced image to the map
+    - 12:59 Comparing layers with the swipe tool
+    - 13:35 Loading the exported GeoTIFF
+    - 14:07 Handling NoData and transparency
+    - 14:42 Sharing the georeferenced map
+    - 15:29 Conclusion
+
 ## More videos
 
 The channel also covers GeoAI, DuckDB, and geospatial Python more broadly:


### PR DESCRIPTION
Adds three recent Open Geospatial Solutions videos to the documentation, following the existing per-video format on the Video Tutorials page (embed, duration/date line, summary, related links, chapter list) and appending them to the four short link lists that mirror it (README, Getting Started, Tutorials index, Demos).

New videos:

- **Mapping the 2026 Nepal Floods with Free High-Resolution Satellite Imagery** (23:14, August 2026) — https://youtu.be/UDO1BCwOAAc. Disaster imagery from Vantor Open Data, Planet Crisis Response, and OpenAerialMap in one before-and-after swipe map, plus 3D terrain, Overture building footprints, and export for damage assessment. Links the live sample project at https://share.geolibre.app/giswqs/nepal-flash-floods.
- **Building Cloud-Native GIS Workflows with GeoLibre** (1:07:28, September 2026) — https://youtu.be/RgNoKsvZ5Hk. The recorded webinar covering COG, GeoParquet, PMTiles, DuckDB, and WebAssembly, the plugin ecosystem, the cross-platform builds, and the GeoAI integration. It has no chapter markers, so it gets a summary and a slides link instead of a chapter block.
- **Image Georeferencing Using GeoLibre in the Browser** (15:35, September 2026) — https://youtu.be/lbioujkDSG0. Georeferencing a scanned UTK campus map with ground control points, residuals, GeoTIFF export, NoData transparency, and sharing. Links the sample image and control-point CSV.

Titles, durations, publish dates, chapters, and sample-data links all come from the videos' own metadata and descriptions rather than being written from memory. The four external links added (sample project, sample image, GCP CSV, slides deck) were each checked and return 200.

One thing worth flagging: the Nepal video's last three chapter timestamps (25:14, 27:20, 28:30) run past the recording's actual 23:14 length. That is the same artifact the 1.0 tour entry already documents, so the chapter block carries a short note saying so rather than silently listing timestamps that do not exist.

`pre-commit run --files` on the five changed files passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added three video tutorials covering:
    - Mapping the 2026 Nepal floods with free satellite imagery
    - Building cloud-native GIS workflows with GeoLibre
    - Georeferencing images directly in the browser
  - Included video embeds, durations, publication dates, descriptions, related resources, and chapter lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->