### PR TITLE
fix(plugins): let a URL plugin blocked by its integrity pin recover through the UI

### DIFF
--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -72,6 +72,15 @@ const externallyLoadedPluginSources = new Map<string, string>();
 // bypassed (e.g. the dialog is closed and reopened mid-upgrade).
 const inFlightUrlUpgrades = new Map<string, Promise<GeoLibrePlugin>>();
 
+// Manifest URLs this session has tried to load under the SHA-256 pin (bundled
+// drop-ins are exempt from pinning and never appear here). Uninstalling a URL
+// has to drop its pin, and the loaded-source map above cannot say which URLs
+// need that: a bundle the pin held back never registers a plugin, so it is
+// absent from that map. Leaving its pin behind made the block unrecoverable
+// through the UI, because reinstalling matched the same stale pin and failed
+// again (#2318). Recording the attempt instead of the registration covers it.
+const pinnedUrlLoadAttempts = new Set<string>();
+
 export async function loadExternalPlugins(
   manager: PluginManager,
   additionalPluginDirectories: string[] = [],
@@ -229,6 +238,12 @@ async function loadPluginUrlBundles(
   bundledUrls: ReadonlySet<string>,
 ): Promise<ExternalPluginBundle[]> {
   const bundles: ExternalPluginBundle[] = [];
+  // Record the attempt before the fetch, not after a successful verification:
+  // a URL whose host is down this session still carries a pin from an earlier
+  // one, and uninstalling it must clear that pin too.
+  for (const manifestUrl of manifestUrls) {
+    if (!bundledUrls.has(manifestUrl)) pinnedUrlLoadAttempts.add(manifestUrl);
+  }
   const results = await Promise.allSettled(
     manifestUrls.map((manifestUrl) => loadPluginUrlBundle(manifestUrl)),
   );
@@ -250,9 +265,14 @@ async function loadPluginUrlBundles(
             issues.push({
               archiveName: bundle.archiveName,
               sourceUrl: bundle.sourceUrl,
+              // Point at the recovery that actually works. A held-back bundle
+              // never registers, so the marketplace's Update action (which
+              // upgrades a *loaded* plugin) is not offered for it; uninstalling
+              // the URL clears the pin, and reinstalling re-pins the published
+              // bundle after the user has had the chance to review it.
               message:
                 `Plugin at '${bundle.sourceUrl}' changed since you last trusted it and was not loaded. ` +
-                "Open Settings → Plugins and reload it to review and accept the update.",
+                "Open Settings → Plugins, uninstall it, then install it again to review and accept the update.",
             });
             continue;
           }
@@ -657,7 +677,15 @@ export function unloadRemovedUrlPlugins(
   }
   // Drop integrity pins for URLs no longer installed, so re-adding one later
   // re-pins from a fresh review rather than silently matching a stale hash.
+  // Registering a plugin is not a precondition: a bundle the pin held back
+  // (see plugin-integrity.ts) never reaches the loaded-source map, and keying
+  // this off `toRemove` alone left exactly that plugin stuck: uninstall could
+  // not clear its pin, and reinstalling hit the same stale hash (#2318).
+  for (const url of pinnedUrlLoadAttempts) {
+    if (!keep.has(url)) removedUrls.add(url);
+  }
   for (const url of removedUrls) {
+    pinnedUrlLoadAttempts.delete(url);
     removePluginBundlePin(url);
   }
   return toRemove;

--- a/tests/external-plugin-pin-recovery.test.ts
+++ b/tests/external-plugin-pin-recovery.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
+import type { PluginManager } from "../packages/plugins/src/plugin-manager";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
+
+// Recovering from a SHA-256 pin block (#2318). external-plugins pulls in
+// browser-only modules through its import chain, so the module is imported
+// lazily in `before`, after the shims below are installed.
+type ExternalPlugins = typeof import("../apps/geolibre-desktop/src/lib/external-plugins");
+type PluginIntegrity = typeof import("../apps/geolibre-desktop/src/lib/plugin-integrity");
+
+const app = {} as GeoLibreAppAPI;
+const MANIFEST_URL = "http://localhost:7777/pin-demo/plugin.json";
+const ENTRY_URL = "http://localhost:7777/pin-demo/entry.js";
+
+// Files the fetch shim serves, keyed by absolute URL.
+let served = new Map<string, string>();
+let storage = new Map<string, string>();
+
+function pluginBundle(): Map<string, string> {
+  return new Map([
+    [
+      MANIFEST_URL,
+      JSON.stringify({ id: "pin-demo", name: "Pin Demo", version: "1.0.0", entry: "entry.js" }),
+    ],
+    [
+      ENTRY_URL,
+      `export default {
+         id: "pin-demo",
+         name: "Pin Demo",
+         version: "1.0.0",
+         activate() {},
+         deactivate() {},
+       };`,
+    ],
+  ]);
+}
+
+// The loader appends a cache-busting token to asset URLs, so match on the path.
+function serve(url: string): string | undefined {
+  const withoutQuery = url.split("?")[0];
+  return served.get(withoutQuery);
+}
+
+function installBrowserShims(): void {
+  const globals = globalThis as Record<string, unknown>;
+  // shpjs (reached through the plugin-archive import chain) reads `self` at
+  // module scope.
+  globals.self = globalThis;
+  globals.localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => void storage.set(key, value),
+    removeItem: (key: string) => void storage.delete(key),
+  };
+  // Only the style teardown touches the DOM, and these bundles carry no style.
+  globals.document = { getElementById: () => null };
+  globals.fetch = (input: unknown) => {
+    const url = String(input);
+    const body = serve(url);
+    if (body === undefined) {
+      return Promise.resolve({ ok: false, status: 404 } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: () => Promise.resolve(JSON.parse(body) as unknown),
+      text: () => Promise.resolve(body),
+    } as unknown as Response);
+  };
+  // importExternalPlugin evaluates the entry through a blob URL. Node has no
+  // object URLs, so capture the source and hand back an equivalent data: URL,
+  // which `import()` does accept. That keeps the real registration path under
+  // test instead of stubbing it out.
+  class SourceBlob {
+    readonly source: string;
+    constructor(parts: string[]) {
+      this.source = parts.join("");
+    }
+  }
+  globals.Blob = SourceBlob;
+  URL.createObjectURL = (blob: unknown) =>
+    `data:text/javascript;base64,${Buffer.from((blob as SourceBlob).source).toString("base64")}`;
+  URL.revokeObjectURL = () => undefined;
+}
+
+describe("recovering a URL plugin blocked by its integrity pin", () => {
+  let externalPlugins: ExternalPlugins;
+  let integrity: PluginIntegrity;
+  let PluginManagerCtor: typeof PluginManager;
+  let manager: PluginManager;
+
+  before(async () => {
+    installBrowserShims();
+    externalPlugins = await import("../apps/geolibre-desktop/src/lib/external-plugins");
+    integrity = await import("../apps/geolibre-desktop/src/lib/plugin-integrity");
+    ({ PluginManager: PluginManagerCtor } = await import("../packages/plugins/src/plugin-manager"));
+  });
+
+  beforeEach(() => {
+    storage = new Map();
+    served = pluginBundle();
+    manager = new PluginManagerCtor();
+  });
+
+  afterEach(() => {
+    // external-plugins keeps its loaded-source map at module scope, so a plugin
+    // left registered by one test would be skipped as "already loaded" by the
+    // next. Uninstalling every URL is the same teardown the app performs.
+    externalPlugins.unloadRemovedUrlPlugins(manager, [], app);
+  });
+
+  it("clears the pin on uninstall even though the blocked plugin never registered", async () => {
+    // A bundle whose hash no longer matches the pin recorded on an earlier
+    // visit: held back, so nothing registers and no loaded source is recorded.
+    integrity.pinPluginBundle(MANIFEST_URL, "0".repeat(64));
+
+    const blocked = await externalPlugins.loadExternalPlugins(manager, [], [MANIFEST_URL]);
+    assert.deepEqual(blocked.loadedPluginIds, []);
+    assert.equal(manager.list().length, 0);
+    assert.match(blocked.issues[0].message, /changed since you last trusted it/);
+    assert.equal(integrity.getPluginBundlePin(MANIFEST_URL), "0".repeat(64));
+
+    // Uninstalling drops the URL from settings. Before #2318 this left the
+    // stale pin behind, because only plugins that had registered were known.
+    externalPlugins.unloadRemovedUrlPlugins(manager, [], app);
+    assert.equal(integrity.getPluginBundlePin(MANIFEST_URL), null);
+
+    // So reinstalling now re-pins the published bundle and loads it.
+    const reinstalled = await externalPlugins.loadExternalPlugins(manager, [], [MANIFEST_URL]);
+    assert.deepEqual(reinstalled.loadedPluginIds, ["pin-demo"]);
+    assert.deepEqual(reinstalled.issues, []);
+    assert.equal(
+      integrity.getPluginBundlePin(MANIFEST_URL),
+      await integrity.computePluginBundleHash({
+        entrySource: served.get(ENTRY_URL) ?? "",
+        styleSource: null,
+      }),
+    );
+  });
+
+  it("still clears the pin and unregisters when the plugin did load", async () => {
+    const loaded = await externalPlugins.loadExternalPlugins(manager, [], [MANIFEST_URL]);
+    assert.deepEqual(loaded.loadedPluginIds, ["pin-demo"]);
+    assert.notEqual(integrity.getPluginBundlePin(MANIFEST_URL), null);
+
+    assert.deepEqual(externalPlugins.unloadRemovedUrlPlugins(manager, [], app), ["pin-demo"]);
+    assert.equal(manager.list().length, 0);
+    assert.equal(integrity.getPluginBundlePin(MANIFEST_URL), null);
+  });
+
+  it("keeps the pin for a URL that is still installed", async () => {
+    await externalPlugins.loadExternalPlugins(manager, [], [MANIFEST_URL]);
+    const pinned = integrity.getPluginBundlePin(MANIFEST_URL);
+    assert.notEqual(pinned, null);
+
+    externalPlugins.unloadRemovedUrlPlugins(manager, [MANIFEST_URL], app);
+    assert.equal(integrity.getPluginBundlePin(MANIFEST_URL), pinned);
+    assert.equal(manager.list().length, 1);
+  });
+});


### PR DESCRIPTION
Fixes #2318

## The problem

`loadPluginUrlBundles` holds back a remotely-installed plugin whose bundle hash no longer matches its SHA-256 pin, which is the point of the pin. But the plugin then never registers, and every recovery path in the UI is keyed off having registered:

- `unloadRemovedUrlPlugins` dropped a pin only for URLs it found in `externallyLoadedPluginSources`, a map populated on registration. Uninstalling a blocked plugin therefore left the stale pin behind, and reinstalling the same URL matched it again and failed identically.
- `isUpgradeable` requires `loadedVersions.get(entry.id) !== undefined`, so the Update button never appeared, and `reloadExternalUrlPlugin` throws without a loaded version. Reloading the app does not help, because the pin lives in `localStorage`.

The only way out was editing `localStorage["geolibre.pluginBundlePins"]` in DevTools. Worth noting how reachable this is: a held-back bundle is *never* loaded in the session that reports it, so the Update action the error message pointed at is by construction never offered for a plugin in this state.

## The fix

Track the manifest URLs each session attempts to load under the pin (bundled drop-ins are exempt from pinning and are not tracked), and prune the pins of every tracked URL that is no longer installed. This takes the issue's first branch: uninstalling always clears the pin, whether or not the plugin ever registered, so reinstalling re-pins the published bundle from a fresh trust-on-first-use and loads it.

Two details:

- The attempt is recorded before the fetch, not after a successful verification. A URL whose host is down this session still carries a pin from an earlier one, and uninstalling it has to clear that pin too.
- Pruning is scoped to URLs this session actually tried, rather than to the whole pin store. A shared-settings session (`applyTemporaryDesktopSettings`) replaces `pluginManifestUrls` before the first scan, and a blanket prune there would silently discard the user's persistent pins for their own installed plugins.

Pins for URLs that are still installed are untouched, and uninstalling a plugin that *did* load behaves as before.

The held-back message also changes, since it pointed at a recovery that cannot be reached; it now names the uninstall/reinstall that works.

## Verification

Reproduced first, in the web build with a plugin served over `http://localhost`: install the manifest URL, let it load and pin, change the served `entry.js`, reload. Confirmed the reported symptoms on `main` — uninstall left the pin intact, reinstall failed with the same message, `Upgradeable (0)`.

With the fix, the full flow was driven in the real app through both UI routes and both themes:

- Settings tab (raw manifest URL), light and dark: block, Remove clears the pin, re-Add loads the changed bundle and pins its new hash.
- Marketplace card, light and dark: installed the registry's Sample Plugin, poisoned its pin to simulate a changed published bundle, reloaded to get the "Failed" card, then trash → confirm → Install. The plugin recovers and the pin comes back as the genuine bundle hash.

Also added `tests/external-plugin-pin-recovery.test.ts` (3 tests, covering the blocked-then-recovered path, the already-loaded path, and that a still-installed URL keeps its pin). The first test fails on `main` and passes here. Full frontend suite green (7843 pass), coverage gate green, `npm run typecheck`, and pre-commit on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recovery for URL-based plugins that fail integrity verification, allowing them to be uninstalled and reinstalled successfully.
  * Improved integrity error guidance to recommend uninstalling and reinstalling the affected plugin.
  * Ensured removed plugins no longer retain stale integrity pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->