### PR TITLE
fix(plugins): allow clearing pins on uninstall and re-trusting blocked plugins (#2318)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -215,18 +215,21 @@ export function ManagePluginsDialog({
   // An update is available only when the registry version is strictly newer
   // than the loaded one (directional, not any mismatch). isNewerVersion orders
   // a pre-release below its release, so an rc user is offered the GA build.
+  // A plugin blocked by a load failure (such as an integrity pin mismatch, #2318)
+  // also offers the Update action so users can re-fetch and re-trust it.
   const isUpgradeable = useCallback(
     (entry: PluginRegistryEntry) => {
+      if (!isInstalled(entry)) return false;
+      if (externalLoadIssues.has(entry.manifestUrl)) return true;
       const loaded = loadedVersions.get(entry.id);
       const ownsLoadedPlugin = pluginManifestUrlsForIds([entry.id]).includes(entry.manifestUrl);
       return (
-        isInstalled(entry) &&
         ownsLoadedPlugin &&
         loaded !== undefined &&
         isNewerVersion(entry.version, loaded)
       );
     },
-    [isInstalled, loadedVersions],
+    [isInstalled, loadedVersions, externalLoadIssues],
   );
 
   // True when the entry is in settings (so the badge reads "Installed") but the
@@ -637,7 +640,7 @@ export function ManagePluginsDialog({
                                 {category}
                               </span>
                             ))}
-                            {updateAvailable ? (
+                            {updateAvailable && !loadIssue ? (
                               <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-amber-600 dark:text-amber-400">
                                 {t("managePlugins.updateAvailable")}
                               </span>

--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -223,11 +223,7 @@ export function ManagePluginsDialog({
       if (externalLoadIssues.has(entry.manifestUrl)) return true;
       const loaded = loadedVersions.get(entry.id);
       const ownsLoadedPlugin = pluginManifestUrlsForIds([entry.id]).includes(entry.manifestUrl);
-      return (
-        ownsLoadedPlugin &&
-        loaded !== undefined &&
-        isNewerVersion(entry.version, loaded)
-      );
+      return ownsLoadedPlugin && loaded !== undefined && isNewerVersion(entry.version, loaded);
     },
     [isInstalled, loadedVersions, externalLoadIssues],
   );

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -343,6 +343,10 @@ export async function upgradeExternalPlugin(
   mapControllerRef: RefObject<MapEngine | null>,
 ): Promise<void> {
   await reloadExternalUrlPlugin(manager, manifestUrl, createAppAPI(mapControllerRef));
+  if (externalPluginLoadIssues.has(manifestUrl)) {
+    externalPluginLoadIssues.delete(manifestUrl);
+    notifyExternalPluginsListeners();
+  }
 }
 
 // Install a plugin from a local `.zip` archive (desktop only). The Rust backend

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -66,6 +66,11 @@ export interface ExternalPluginLoadResult {
 // plugins until the app restarts.
 const externallyLoadedPluginSources = new Map<string, string>();
 
+// The most recent set of installed manifest URLs known to the loader.
+// Tracked so reloads can confirm that a manifest URL was not uninstalled
+// while an asynchronous bundle fetch was in flight (#2318).
+let lastKnownInstalledManifestUrls: Set<string> | null = null;
+
 // In-flight upgrade promises keyed by manifest URL. reloadExternalUrlPlugin is
 // otherwise not re-entrant-safe: concurrent calls for the same URL capture the
 // same existingId/wasActive snapshot and would double-register. Coalescing them
@@ -98,6 +103,7 @@ export async function loadExternalPlugins(
 ): Promise<ExternalPluginLoadResult> {
   const issues: ExternalPluginLoadIssue[] = [];
   const bundledUrls = new Set(options.bundledManifestUrls ?? []);
+  lastKnownInstalledManifestUrls = new Set(pluginManifestUrls.map((url) => url.trim()));
   // The filesystem scan (Tauri IPC + disk), the manifest URL fetches (network),
   // and the IndexedDB read (web-installed archives) are independent, so overlap
   // them. Web-installed archives are the browser counterpart of the desktop
@@ -639,7 +645,8 @@ export function unloadRemovedUrlPlugins(
   currentManifestUrls: string[],
   app: GeoLibreAppAPI,
 ): string[] {
-  const keep = new Set(currentManifestUrls);
+  const keep = new Set(currentManifestUrls.map((url) => url.trim()));
+  lastKnownInstalledManifestUrls = keep;
   // Collect first, then mutate: manager.unregister notifies subscribers
   // synchronously, so removing entries in a separate pass avoids mutating the
   // map while iterating it.
@@ -748,6 +755,16 @@ async function reloadExternalUrlPluginUncoalesced(
     plugin = await importExternalPlugin(bundle);
   } finally {
     clearTimeout(timeout);
+  }
+
+  // If the plugin was uninstalled while we were fetching (its URL was removed
+  // from installed settings by unloadRemovedUrlPlugins or its source dropped
+  // from the loaded map), don't resurrect it.
+  if (
+    lastKnownInstalledManifestUrls !== null &&
+    !lastKnownInstalledManifestUrls.has(manifestUrl.trim())
+  ) {
+    return plugin;
   }
 
   if (existingId !== null) {

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -27,6 +27,7 @@ import {
 } from "./plugin-asset-url";
 import {
   computePluginBundleHash,
+  listPinnedPluginUrls,
   pinPluginBundle,
   removePluginBundlePin,
   verifyPluginBundleIntegrity,
@@ -657,8 +658,13 @@ export function unloadRemovedUrlPlugins(
   }
   // Drop integrity pins for URLs no longer installed, so re-adding one later
   // re-pins from a fresh review rather than silently matching a stale hash.
-  for (const url of removedUrls) {
-    removePluginBundlePin(url);
+  // Check all stored pins against keep so plugins that failed initial verification
+  // on startup (and never entered externallyLoadedPluginSources) also clear their
+  // stale pin when uninstalled (#2318).
+  for (const url of listPinnedPluginUrls()) {
+    if (!keep.has(url)) {
+      removePluginBundlePin(url);
+    }
   }
   return toRemove;
 }
@@ -744,32 +750,24 @@ async function reloadExternalUrlPluginUncoalesced(
     clearTimeout(timeout);
   }
 
-  // Nothing was loaded for this URL (existingId null — e.g. the manifest is in
-  // settings but its initial load failed). Throw rather than registering the
-  // fetched plugin as a side effect, so the caller surfaces the inconsistency
-  // instead of the UI reporting a silent, invisible "success".
-  if (existingId === null) {
-    throw new Error(
-      `Cannot update plugin: no loaded version was found for '${manifestUrl}'. Try reloading the app.`,
-    );
+  if (existingId !== null) {
+    // If the plugin was uninstalled while we were fetching (its source was
+    // removed from the loaded map by unloadRemovedUrlPlugins), don't resurrect it.
+    if (!externallyLoadedPluginSources.has(existingId)) return plugin;
+
+    // A version that changes its plugin id (e.g. the author renamed it) would
+    // leave the marketplace's installed/version state pointing at the old id.
+    // Refuse rather than silently register a mismatched plugin.
+    if (existingId !== plugin.id) {
+      throw new Error(
+        `Cannot update plugin: the published version exports id '${plugin.id}' but the installed version has id '${existingId}'. Reinstall it manually.`,
+      );
+    }
+
+    manager.unregister(existingId, app);
+    removeExternalPluginStyle(existingId);
+    externallyLoadedPluginSources.delete(existingId);
   }
-
-  // If the plugin was uninstalled while we were fetching (its source was
-  // removed from the loaded map by unloadRemovedUrlPlugins), don't resurrect it.
-  if (!externallyLoadedPluginSources.has(existingId)) return plugin;
-
-  // A version that changes its plugin id (e.g. the author renamed it) would
-  // leave the marketplace's installed/version state pointing at the old id.
-  // Refuse rather than silently register a mismatched plugin.
-  if (existingId !== plugin.id) {
-    throw new Error(
-      `Cannot update plugin: the published version exports id '${plugin.id}' but the installed version has id '${existingId}'. Reinstall it manually.`,
-    );
-  }
-
-  manager.unregister(existingId, app);
-  removeExternalPluginStyle(existingId);
-  externallyLoadedPluginSources.delete(existingId);
   manager.register(plugin);
   externallyLoadedPluginSources.set(plugin.id, manifestUrl);
   // Explicit user reload: accept this version as the new trusted baseline so the

--- a/apps/geolibre-desktop/src/lib/plugin-integrity.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-integrity.ts
@@ -99,6 +99,13 @@ export function removePluginBundlePin(url: string): void {
   }
 }
 
+/**
+ * Return all plugin manifest URLs currently pinned in storage.
+ */
+export function listPinnedPluginUrls(): string[] {
+  return Object.keys(readPins());
+}
+
 export type PluginBundleIntegrity =
   /** No prior pin; pinned now and allowed (trust on first use). */
   | { status: "pinned-first-use" }

--- a/tests/plugin-integrity.test.ts
+++ b/tests/plugin-integrity.test.ts
@@ -4,9 +4,12 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import {
   computePluginBundleHash,
   getPluginBundlePin,
+  listPinnedPluginUrls,
   removePluginBundlePin,
   verifyPluginBundleIntegrity,
 } from "../apps/geolibre-desktop/src/lib/plugin-integrity";
+import { unloadRemovedUrlPlugins } from "../apps/geolibre-desktop/src/lib/external-plugins";
+import { PluginManager } from "../packages/plugins/src/plugin-manager";
 
 // plugin-integrity reads/writes the bare `localStorage` global (=== window's in
 // the browser). Emulate just enough for Node's test runner.
@@ -73,5 +76,35 @@ describe("plugin bundle integrity pinning", () => {
     assert.equal(getPluginBundlePin(url), null);
     const afterRemoval = await verifyPluginBundleIntegrity(url, tampered);
     assert.equal(afterRemoval.status, "pinned-first-use");
+  });
+
+  it("lists all pinned plugin manifest URLs", async () => {
+    const urlA = "https://plugins.example.com/a/plugin.json";
+    const urlB = "https://plugins.example.com/b/plugin.json";
+    assert.deepEqual(listPinnedPluginUrls(), []);
+
+    await verifyPluginBundleIntegrity(urlA, { entrySource: "a", styleSource: null });
+    assert.deepEqual(listPinnedPluginUrls(), [urlA]);
+
+    await verifyPluginBundleIntegrity(urlB, { entrySource: "b", styleSource: null });
+    assert.deepEqual(listPinnedPluginUrls().sort(), [urlA, urlB].sort());
+
+    removePluginBundlePin(urlA);
+    assert.deepEqual(listPinnedPluginUrls(), [urlB]);
+  });
+
+  it("unloadRemovedUrlPlugins drops pins for URLs that failed initial load and never registered (#2318)", async () => {
+    const failedUrl = "https://plugins.example.com/failed/plugin.json";
+    const keptUrl = "https://plugins.example.com/kept/plugin.json";
+    await verifyPluginBundleIntegrity(failedUrl, { entrySource: "v1", styleSource: null });
+    await verifyPluginBundleIntegrity(keptUrl, { entrySource: "v1", styleSource: null });
+
+    const manager = new PluginManager();
+    // When the user uninstalls failedUrl (leaving only keptUrl in settings)
+    unloadRemovedUrlPlugins(manager, [keptUrl]);
+
+    // The stale pin for failedUrl must be cleared even though it never successfully registered
+    assert.equal(getPluginBundlePin(failedUrl), null);
+    assert.notEqual(getPluginBundlePin(keptUrl), null);
   });
 });

--- a/tests/plugin-integrity.test.ts
+++ b/tests/plugin-integrity.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../apps/geolibre-desktop/src/lib/plugin-integrity";
 import { unloadRemovedUrlPlugins } from "../apps/geolibre-desktop/src/lib/external-plugins";
 import { PluginManager } from "../packages/plugins/src/plugin-manager";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 
 // plugin-integrity reads/writes the bare `localStorage` global (=== window's in
 // the browser). Emulate just enough for Node's test runner.
@@ -100,8 +101,9 @@ describe("plugin bundle integrity pinning", () => {
     await verifyPluginBundleIntegrity(keptUrl, { entrySource: "v1", styleSource: null });
 
     const manager = new PluginManager();
+    const app = {} as GeoLibreAppAPI;
     // When the user uninstalls failedUrl (leaving only keptUrl in settings)
-    unloadRemovedUrlPlugins(manager, [keptUrl]);
+    unloadRemovedUrlPlugins(manager, [keptUrl], app);
 
     // The stale pin for failedUrl must be cleared even though it never successfully registered
     assert.equal(getPluginBundlePin(failedUrl), null);


### PR DESCRIPTION
Closes #2318

### Summary of Changes

When a URL-installed plugin bundle changes after its initial trust, it is blocked from loading by its SHA-256 integrity pin (`plugin-integrity.ts`). However, when this occurred on the first load of a session (before the plugin ever registered in the plugin manager):
1. **Uninstalling left stale pins in `localStorage`**: `unloadRemovedUrlPlugins` only dropped pins for URLs matching registered entries in `externallyLoadedPluginSources`. Because the blocked plugin never registered, its pin remained persisted, preventing reinstallation even after removal.
2. **"Update" action was unavailable**: `isUpgradeable` required `loadedVersions.get(entry.id) !== undefined`, which was false for blocked plugins.
3. **`reloadExternalUrlPlugin` threw an error**: Even if invoked directly, it rejected with `Cannot update plugin: no loaded version was found...` when `existingId === null`.

This PR fixes the recovery path across all three layers:
- **Pin cleanup on removal**: `unloadRemovedUrlPlugins` now checks all pinned manifest URLs via `listPinnedPluginUrls()` and removes pins for any URL not present in the active `keep` set, guaranteeing stale pins are cleared on uninstall even if the plugin never registered.
- **Support reloading un-registered plugins**: `reloadExternalUrlPlugin` now handles `existingId === null` gracefully, fetching and registering the updated bundle and recording the new trusted pin.
- **UI recovery in `ManagePluginsDialog`**: `isUpgradeable` now returns true for installed plugins with active load issues (such as integrity pin blocks), allowing users to review and update/re-trust the plugin.
- **State notification**: `upgradeExternalPlugin` clears `externalPluginLoadIssues` on success and notifies listeners so error badges disappear immediately.
- **Unit tests**: Added regression tests in `tests/plugin-integrity.test.ts` verifying `listPinnedPluginUrls()` and pin removal on uninstallation.

### Testing Done

- Added unit tests in `tests/plugin-integrity.test.ts`:
  - Verified `listPinnedPluginUrls` tracks and returns all stored pins.
  - Verified `unloadRemovedUrlPlugins` drops pins for uninstalled URLs that failed initial load and never registered.
  - Verified all tests pass via `node --import tsx --test tests/plugin-integrity.test.ts`.
- Validated TypeScript and Vite production bundle (`npm run build -w geolibre-desktop`).
- Validated ESLint (`npx eslint apps/geolibre-desktop/src/... tests/plugin-integrity.test.ts`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin load failures now take priority over “Update available” messaging, making the plugin’s actual status clearer.
  * Updating an affected external plugin now clears its previous failure state after a successful reload.
  * Fixed stale integrity verification data that could prevent removed or previously failed plugins from loading correctly.
  * External plugins that were not loaded successfully can now be registered during a reload.
  * Improved plugin handling when plugins are removed while loading.

* **Tests**
  * Added coverage for plugin integrity cleanup and verification-pin management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->