### PR TITLE
fix: restore scrolling in mobile map panels

### DIFF
--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2471,21 +2471,27 @@ body,
 }
 
 @media (max-width: 767px) {
-  /* Planetary Computer sizes its panel from the live map rectangle. Keep it
-     out of this viewport-based cap, which ignores the mobile sidebar strips
-     and status bar and leaves the bottom of its scroll area clipped. */
+  /* Only the legacy Components grid needs a viewport-based fallback. The
+     standalone panels below calculate their own map-relative height limits. */
+  .geolibre-components-control .maplibre-gl-control-grid-floating-panel,
+  .geolibre-components-control .maplibre-gl-control-grid-relocated {
+    max-height: calc(100vh - 96px) !important;
+    max-height: calc(100dvh - 96px) !important;
+    overflow-y: auto;
+  }
+
+  /* Preserve mobile width bounds without overriding map-relative heights.
+     A viewport-based height cap ignores sidebar strips and the status bar,
+     leaving the bottom of these panels' scroll areas clipped. */
   .geolibre-components-control .maplibre-gl-control-grid-floating-panel,
   .geolibre-components-control .maplibre-gl-control-grid-relocated,
   .geolibre-pmtiles-control .maplibre-gl-pmtiles-layer-panel,
   .geolibre-zarr-control .maplibre-gl-zarr-layer-panel,
+  .maplibregl-map .pc-control-panel,
   .maplibregl-map .layer-control-panel,
   .duckdb-control-panel {
     box-sizing: border-box;
-    /* 96px clears the mobile top toolbar plus the panel's own top offset */
-    max-height: calc(100vh - 96px) !important;
-    max-height: calc(100dvh - 96px) !important;
     max-width: calc(100vw - 20px) !important;
-    overflow-y: auto;
   }
 
   .duckdb-control-panel {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2471,11 +2471,13 @@ body,
 }
 
 @media (max-width: 767px) {
+  /* Planetary Computer sizes its panel from the live map rectangle. Keep it
+     out of this viewport-based cap, which ignores the mobile sidebar strips
+     and status bar and leaves the bottom of its scroll area clipped. */
   .geolibre-components-control .maplibre-gl-control-grid-floating-panel,
   .geolibre-components-control .maplibre-gl-control-grid-relocated,
   .geolibre-pmtiles-control .maplibre-gl-pmtiles-layer-panel,
   .geolibre-zarr-control .maplibre-gl-zarr-layer-panel,
-  .maplibregl-map .pc-control-panel,
   .maplibregl-map .layer-control-panel,
   .duckdb-control-panel {
     box-sizing: border-box;


### PR DESCRIPTION
Mobile panels could extend below the visible map, leaving their bottom controls inaccessible even after scrolling. GeoLibre's shared viewport-based height override replaced the map-relative limits calculated by Planetary Computer, PMTiles, Zarr, DuckDB, and Layer Control. For example, at 393 × 750, the Copernicus DEM form received a 654px limit instead of its calculated 555px limit.

Keep the shared mobile width constraints, but let these five standalone panels use their own height limits and scrolling. Retain the separate fallback for the Components grid, which uses different positioning and is hidden from the current Plugins menu. No upstream package release is needed.

Validation:
- Reproduced clipping in all five panels before removing their height override.
- Verified PMTiles, Zarr, DuckDB, and Layer Control in light and dark themes at 360 × 640, 393 × 750, 360 × 500, and 1280 × 800. Their panels stay inside the map; the forms' bottom buttons are visible after scrolling.
- Verified Planetary Computer with the live Copernicus DEM GLO-30 collection in both themes, including portrait, landscape, desktop, and narrow 320px/360px width checks. Chromium touch swiping reached the bottom, and Search Items returned 50 real results.
- Scoped pre-commit checks passed, including the production build.
- Native Android system bars were not tested on a physical device.

Fixes #2323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile panel layouts by limiting height and vertical scrolling only where needed.
  * Standalone PMTiles, Zarr, Planetary Computer, Layer, and DuckDB panels can now manage their own map-relative heights while retaining responsive width constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->