### PR TITLE
Support web coordinate URLs and Android geo intents

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -56,6 +56,7 @@
     "@strands-agents/sdk": "^1.15.0",
     "@tanstack/react-virtual": "^3.14.10",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-deep-link": "^2.4.10",
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-geolocation": "^2.3.2",

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1093,6 +1093,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1658,7 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-geolocation",
@@ -1886,6 +1896,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2084,7 +2100,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -3152,6 +3168,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3797,6 +3823,16 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
  "sqlite-wasm-rs",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4674,6 +4710,27 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d489b8ecceae1cd09f6e1f7606f2095ac721cc8d54cf2f0e6bb377cc52cff6"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5906,6 +5963,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -74,6 +74,7 @@ serde_json = "1"
 bincode = "1"
 # OS CSPRNG for the per-launch Jupyter token (already an indirect dep).
 getrandom = "0.4"
+tauri-plugin-deep-link = "2"
 
 # native-tls backs only the desktop mTLS PKCS#12 path (issue #1220). It pulls in
 # openssl-sys, which has no vendored/cross build for the Android NDK, so the

--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "deep-link:allow-get-current",
     "dialog:default",
     "fs:default",
     "fs:allow-read-dir",

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -382,7 +382,8 @@ pub fn run() {
         .plugin(tauri_plugin_persisted_scope::init())
         .plugin(tauri_plugin_geolocation::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_opener::init());
+        .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_deep_link::init());
 
     // The Earth Engine OAuth loopback listener is compiled out of the Apple App
     // Store builds (see the module gate at the top of this file); the stub

--- a/apps/geolibre-desktop/src-tauri/tauri.android.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.android.conf.json
@@ -5,5 +5,15 @@
   "bundle": {
     "resources": [],
     "fileAssociations": []
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "scheme": ["geo"],
+          "appLink": false
+        }
+      ]
+    }
   }
 }

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -141,8 +141,11 @@ export function useStartupProject(): {
     return plan.kind === "restore";
   });
 
+  // End native startup in the same synchronous render that reads its target.
+  // Waiting for the passive effect would drop intents received after render.
+  finishNativeCoordinateStartup();
+
   useEffect(() => {
-    finishNativeCoordinateStartup();
     if (inlineProject) return;
     if (
       (initialNativeCoordinateTarget() || coordinateTargetFromSearch(window.location.search)) &&

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -11,6 +11,11 @@ import { DEFAULT_STARTUP_SETTINGS, useDesktopSettingsStore } from "./useDesktopS
 import { loadRecentProjects } from "./useRecentProjectsPersistence";
 import { consumeInlineProjectFragment } from "../lib/inline-project-fragment";
 import { initialNativeProjectPath } from "../lib/native-project-open";
+import { coordinateTargetFromSearch } from "../lib/coordinate-url";
+import {
+  initialNativeCoordinateTarget,
+  finishNativeCoordinateStartup,
+} from "../lib/native-coordinate-open";
 
 /**
  * How long the shell stays unmounted waiting for a startup restore. The read and
@@ -122,13 +127,29 @@ export function useStartupProject(): {
       useAppStore.getState().loadProject(inlineProject, null, { rememberRecent: false });
       return false;
     }
+    const location =
+      initialNativeCoordinateTarget() ?? coordinateTargetFromSearch(window.location.search);
+    if (location && !hasExplicitLaunchPayload() && !openedProjectPath) {
+      applyDefaultWorkspace({
+        ...startupDefaultWorkspace(useDesktopSettingsStore.getState().desktopSettings.startup),
+        ...location,
+      });
+      return false;
+    }
     const plan = currentStartupPlan(openedProjectPath);
     if (plan.kind === "default") applyDefaultWorkspace(plan);
     return plan.kind === "restore";
   });
 
   useEffect(() => {
+    finishNativeCoordinateStartup();
     if (inlineProject) return;
+    if (
+      (initialNativeCoordinateTarget() || coordinateTargetFromSearch(window.location.search)) &&
+      !hasExplicitLaunchPayload() &&
+      !openedProjectPath
+    )
+      return;
     const plan = currentStartupPlan(openedProjectPath);
     // Both other cases were settled by the initializer above.
     if (plan.kind !== "restore") return;

--- a/apps/geolibre-desktop/src/lib/coordinate-url.ts
+++ b/apps/geolibre-desktop/src/lib/coordinate-url.ts
@@ -1,0 +1,62 @@
+/** A geographic location supplied by a web link or Android geo URI. */
+export interface CoordinateTarget {
+  center: [number, number];
+  zoom: number;
+}
+
+const DEFAULT_LOCATION_ZOOM = 14;
+const DECIMAL = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+function decimal(value: string | null): number | null {
+  if (value === null || !DECIMAL.test(value.trim())) return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function target(
+  lat: string | null,
+  lon: string | null,
+  zoom: string | null,
+): CoordinateTarget | null {
+  const latitude = decimal(lat);
+  const longitude = decimal(lon);
+  const level = zoom === null ? DEFAULT_LOCATION_ZOOM : decimal(zoom);
+  if (
+    latitude === null ||
+    Math.abs(latitude) > 90 ||
+    longitude === null ||
+    Math.abs(longitude) > 180 ||
+    level === null ||
+    level < 0 ||
+    level > 24
+  )
+    return null;
+  return { center: [longitude, latitude], zoom: level };
+}
+
+/** Accept ?lat=40.7&lon=-74&zoom=12 and the compact ?12/40.7/-74 form. */
+export function coordinateTargetFromSearch(search: string): CoordinateTarget | null {
+  const params = new URLSearchParams(search);
+  if (params.has("lat") || params.has("lon")) {
+    return target(params.get("lat"), params.get("lon"), params.get("zoom"));
+  }
+  const compact = search.replace(/^\?/, "").split("&", 1)[0].split("/");
+  return compact.length === 3 ? target(compact[1], compact[2], compact[0]) : null;
+}
+
+/** Numeric geo queries only; address searches require a separate geocoder. */
+export function coordinateTargetFromGeoUri(uri: string): CoordinateTarget | null {
+  if (!/^geo:/i.test(uri)) return null;
+  const [position, query = ""] = uri.slice(4).split("?");
+  const params = new URLSearchParams(query);
+  // Android's q=lat,lon(label) takes precedence over its 0,0 placeholder.
+  const coordinates = params.has("q")
+    ? params
+        .get("q")!
+        .replace(/\([^()]*\)$/, "")
+        .trim()
+    : position;
+  const parts = coordinates.split(",");
+  if (parts.length !== 2) return null;
+  return target(parts[0], parts[1], params.get("z"));
+}

--- a/apps/geolibre-desktop/src/lib/coordinate-url.ts
+++ b/apps/geolibre-desktop/src/lib/coordinate-url.ts
@@ -57,6 +57,9 @@ export function coordinateTargetFromGeoUri(uri: string): CoordinateTarget | null
         .trim()
     : position;
   const parts = coordinates.split(",");
-  if (parts.length !== 2) return null;
+  // A direct geo URI may carry altitude in meters, which does not set zoom.
+  if (parts.length === 3 && !params.has("q")) {
+    if (decimal(parts[2]) === null) return null;
+  } else if (parts.length !== 2) return null;
   return target(parts[0], parts[1], params.get("z"));
 }

--- a/apps/geolibre-desktop/src/lib/native-coordinate-open.ts
+++ b/apps/geolibre-desktop/src/lib/native-coordinate-open.ts
@@ -1,0 +1,38 @@
+import { useAppStore } from "@geolibre/core";
+import { coordinateTargetFromGeoUri, type CoordinateTarget } from "./coordinate-url";
+import { isTauri } from "./is-tauri";
+
+let initialTarget: CoordinateTarget | null = null;
+let startup = true;
+
+export function initialNativeCoordinateTarget(): CoordinateTarget | null {
+  return initialTarget;
+}
+
+/** Subscribe for the app lifetime before reading the cold-launch URI. */
+export async function initializeNativeCoordinateOpen(): Promise<void> {
+  if (!isTauri()) return;
+  try {
+    const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
+    let receivedEvent = false;
+    const accept = (urls: string[]) => {
+      const location = urls.map(coordinateTargetFromGeoUri).find((value) => value !== null);
+      if (!location) return;
+      if (startup) initialTarget = location;
+      else useAppStore.getState().setMapView(location);
+    };
+    await onOpenUrl((urls) => {
+      receivedEvent = true;
+      accept(urls);
+    });
+    const urls = await getCurrent();
+    if (!receivedEvent && urls) accept(urls);
+  } catch (error) {
+    console.error("[GeoLibre] Could not initialize coordinate links", error);
+  }
+}
+
+/** Called after startup has seeded the map, so subsequent intents move the live map. */
+export function finishNativeCoordinateStartup(): void {
+  startup = false;
+}

--- a/apps/geolibre-desktop/src/lib/native-coordinate-open.ts
+++ b/apps/geolibre-desktop/src/lib/native-coordinate-open.ts
@@ -14,19 +14,19 @@ export async function initializeNativeCoordinateOpen(): Promise<void> {
   if (!isTauri()) return;
   try {
     const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
-    let receivedEvent = false;
+    let receivedCoordinate = false;
     const accept = (urls: string[]) => {
       const location = urls.map(coordinateTargetFromGeoUri).find((value) => value !== null);
-      if (!location) return;
+      if (!location) return false;
       if (startup) initialTarget = location;
       else useAppStore.getState().setMapView(location);
+      return true;
     };
     await onOpenUrl((urls) => {
-      receivedEvent = true;
-      accept(urls);
+      if (accept(urls)) receivedCoordinate = true;
     });
     const urls = await getCurrent();
-    if (!receivedEvent && urls) accept(urls);
+    if (!receivedCoordinate && urls) accept(urls);
   } catch (error) {
     console.error("[GeoLibre] Could not initialize coordinate links", error);
   }

--- a/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
+++ b/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
@@ -1,5 +1,8 @@
 import { PROJECT_URL_PARAMS, projectUrlFromLocation } from "./project-url";
 
+import { coordinateTargetFromSearch } from "./coordinate-url";
+import { initialNativeCoordinateTarget } from "./native-coordinate-open";
+
 // Values of `?welcome=` that turn the first-launch wizard off.
 const WELCOME_DISABLED_VALUES = new Set(["0", "false", "off", "no"]);
 
@@ -44,6 +47,9 @@ export function shouldSuppressOnboarding(env: OnboardingEnv = importMetaEnv()): 
     welcomeDisabledByEnv(env) ||
     hasProjectDeepLinkIntent() ||
     hasDataDeepLinkIntent() ||
+    initialNativeCoordinateTarget() !== null ||
+    (typeof window !== "undefined" &&
+      coordinateTargetFromSearch(window.location.search) !== null) ||
     embeddedByParam() ||
     welcomeDisabledByParam()
   );

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -81,7 +81,11 @@ import { parseDeploymentCapabilities, useAppStore } from "@geolibre/core";
 import { readDeploymentEnvValue } from "./lib/deployment-env";
 import { initializeNativeProjectOpen } from "./lib/native-project-open";
 
+import { initializeNativeCoordinateOpen } from "./lib/native-coordinate-open";
+
 installDiagnosticsCapture();
+
+const nativeCoordinateOpenReady = initializeNativeCoordinateOpen();
 const nativeProjectOpenReady = initializeNativeProjectOpen();
 let nativeSidecarFetchReady: Promise<void> = Promise.resolve();
 // In the desktop build, route geocoding (place search / reverse geocode)
@@ -283,6 +287,7 @@ void Promise.all([
   // Capture a file-association or command-line project path before App decides
   // whether to restore a configured startup project or the default workspace.
   nativeProjectOpenReady,
+  nativeCoordinateOpenReady,
   // Gate the first render on i18next being initialized with the active locale's
   // (lazily loaded) catalog, so the UI never paints raw translation keys.
   startupLanguageReady,

--- a/docs/android.md
+++ b/docs/android.md
@@ -292,7 +292,9 @@ when launching the app and while it is already open. Supported forms include:
 
 Coordinates use latitude, longitude order. Numeric `q` coordinates override
 the URI's placeholder coordinates; address-only queries are not supported.
-Zoom defaults to 14 and must be between 0 and 24. Invalid locations are ignored.
+An optional third coordinate in a direct URI is altitude in meters; it is validated
+and ignored when positioning the map. Zoom defaults to 14 and must be between
+0 and 24. Invalid locations are ignored.
 A received location moves the map without replacing the current project's layers.
 
 The Tauri deep-link plugin generates the Android intent filter from

--- a/docs/android.md
+++ b/docs/android.md
@@ -280,3 +280,33 @@ review, so gate them on mobile the way the sidecar tools already are via
   basemap caching (bundled/downloaded MBTiles/PMTiles) is a future enhancement.
 - Earth Engine OAuth uses a desktop loopback/multi-window flow; a mobile
   deep-link redirect is future work.
+
+## Open a location from another app
+
+GeoLibre handles Android `ACTION_VIEW` intents with the `geo:` scheme, both
+when launching the app and while it is already open. Supported forms include:
+
+- `geo:40.7128,-74.006`
+- `geo:40.7128,-74.006?z=12`
+- `geo:0,0?q=40.7128,-74.006(New%20York)&z=12`
+
+Coordinates use latitude, longitude order. Numeric `q` coordinates override
+the URI's placeholder coordinates; address-only queries are not supported.
+Zoom defaults to 14 and must be between 0 and 24. Invalid locations are ignored.
+A received location moves the map without replacing the current project's layers.
+
+The Tauri deep-link plugin generates the Android intent filter from
+`tauri.android.conf.json`, so it also applies when CI regenerates `gen/android`.
+To check both a cold launch and a running app on a connected device, run this
+command twice, panning the map between invocations:
+
+```bash
+adb shell am start -a android.intent.action.VIEW -d 'geo:0,0?q=40.7128,-74.006&z=12' org.geolibre.app
+```
+
+Web links can open the same location with
+`https://geolibre.app/?lat=40.7128&lon=-74.006&zoom=12` or the compact form
+`https://geolibre.app/?12/40.7128/-74.006`. A coordinate-only launch takes
+precedence over saved startup settings and skips onboarding. An explicit
+project or data link retains its existing camera/loading behavior when combined
+with coordinate parameters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "@strands-agents/sdk": "^1.15.0",
         "@tanstack/react-virtual": "^3.14.10",
         "@tauri-apps/api": "^2.11.1",
+        "@tauri-apps/plugin-deep-link": "^2.4.10",
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-fs": "^2.5.1",
         "@tauri-apps/plugin-geolocation": "^2.3.2",
@@ -10152,6 +10153,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-deep-link": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.10.tgz",
+      "integrity": "sha512-SuXI47ORUzYuwG6c8dluLDrStTvli5bAZDRa2+VuUEzK/9TEa7FZz7UKXBQriL7+CPFXRHQsz5tSocc47tRXQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {

--- a/tests/coordinate-url.test.ts
+++ b/tests/coordinate-url.test.ts
@@ -58,9 +58,19 @@ test("geo URIs reject addresses and malformed or out-of-range numbers", () => {
     "geo:0,181",
     "geo:,0",
     "geo:NaN,0",
-    "geo:1,2,3",
+    "geo:1,2,altitude",
+    "geo:1,2,3,4",
+    "geo:0,0?q=1,2,3",
     "geo:1,2?z=25",
   ]) {
     assert.equal(coordinateTargetFromGeoUri(uri), null, uri);
   }
+});
+
+test("direct geo URI altitude is validated but does not control map zoom", () => {
+  assert.deepEqual(coordinateTargetFromGeoUri("geo:37.786971,-122.399677,15"), {
+    center: [-122.399677, 37.786971],
+    zoom: 14,
+  });
+  assert.deepEqual(coordinateTargetFromGeoUri("geo:1,2,-10?z=12"), { center: [2, 1], zoom: 12 });
 });

--- a/tests/coordinate-url.test.ts
+++ b/tests/coordinate-url.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  coordinateTargetFromSearch,
+  coordinateTargetFromGeoUri,
+} from "../apps/geolibre-desktop/src/lib/coordinate-url";
+
+test("web coordinates preserve axis order, fractional zoom and zero values", () => {
+  assert.deepEqual(coordinateTargetFromSearch("?lat=40.7128&lon=-74.006&zoom=12.5"), {
+    center: [-74.006, 40.7128],
+    zoom: 12.5,
+  });
+  assert.deepEqual(coordinateTargetFromSearch("?0/0/0"), { center: [0, 0], zoom: 0 });
+  assert.deepEqual(coordinateTargetFromSearch("?lat=-90&lon=180"), {
+    center: [180, -90],
+    zoom: 14,
+  });
+});
+
+test("invalid web coordinates do not claim startup", () => {
+  for (const query of [
+    "",
+    "?zoom=12",
+    "?lat=1",
+    "?lat=&lon=1",
+    "?lat=91&lon=0",
+    "?lat=0&lon=-181",
+    "?lat=NaN&lon=0",
+    "?lat=0x10&lon=0",
+    "?lat=0&lon=0&zoom=Infinity",
+    "?lat=0&lon=0&zoom=-1",
+    "?lat=0&lon=0&zoom=25",
+    "?12/40/no",
+    "?https://example.org/project.json",
+  ]) {
+    assert.equal(coordinateTargetFromSearch(query), null, query);
+  }
+});
+
+test("geo URIs support direct coordinates, zoom, and labeled coordinate queries", () => {
+  assert.deepEqual(coordinateTargetFromGeoUri("geo:40.7128,-74.006"), {
+    center: [-74.006, 40.7128],
+    zoom: 14,
+  });
+  assert.deepEqual(coordinateTargetFromGeoUri("geo:0,0?q=40.7128,-74.006(New%20York)&z=12"), {
+    center: [-74.006, 40.7128],
+    zoom: 12,
+  });
+  assert.deepEqual(coordinateTargetFromGeoUri("geo:0,0?z=0"), { center: [0, 0], zoom: 0 });
+});
+
+test("geo URIs reject addresses and malformed or out-of-range numbers", () => {
+  for (const uri of [
+    "https://example.org",
+    "geo:0,0?q=New+York",
+    "geo:0,0?q=",
+    "geo:91,0",
+    "geo:0,181",
+    "geo:,0",
+    "geo:NaN,0",
+    "geo:1,2,3",
+    "geo:1,2?z=25",
+  ]) {
+    assert.equal(coordinateTargetFromGeoUri(uri), null, uri);
+  }
+});

--- a/tests/native-coordinate-open.test.ts
+++ b/tests/native-coordinate-open.test.ts
@@ -20,7 +20,10 @@ test("native link bridge captures cold launches and moves the live map without r
       async invoke(command: string) {
         commands.push(command);
         if (command === "plugin:event|listen") return 1;
-        if (command === "plugin:deep-link|get_current") return ["geo:40.7128,-74.006?z=12"];
+        if (command === "plugin:deep-link|get_current") {
+          handler({ payload: ["geo:0,0?q=an+address"] });
+          return ["geo:40.7128,-74.006?z=12"];
+        }
         throw new Error(command);
       },
     },
@@ -36,6 +39,8 @@ test("native link bridge captures cold launches and moves the live map without r
     assert.equal(useAppStore.getState().mapView.zoom, 15);
     assert.equal(useAppStore.getState().layers, layers);
     assert.equal(useAppStore.getState().projectGeneration, projectGeneration);
+    handler({ payload: ["geo:51.5,-0.12?z=16"] });
+    assert.equal(useAppStore.getState().mapView.zoom, 16);
     handler({ payload: ["geo:0,0?q=an+address"] });
     assert.deepEqual(useAppStore.getState().mapView.center, [-0.12, 51.5]);
   } finally {

--- a/tests/native-coordinate-open.test.ts
+++ b/tests/native-coordinate-open.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { useAppStore } from "../packages/core/src/index";
+import {
+  initializeNativeCoordinateOpen,
+  initialNativeCoordinateTarget,
+  finishNativeCoordinateStartup,
+} from "../apps/geolibre-desktop/src/lib/native-coordinate-open";
+
+test("native link bridge captures cold launches and moves the live map without replacing layers", async () => {
+  const originalWindow = (globalThis as { window?: unknown }).window;
+  let handler: (event: { payload: string[] }) => void = () => {};
+  const commands: string[] = [];
+  (globalThis as { window?: unknown }).window = {
+    __TAURI_INTERNALS__: {
+      transformCallback(callback: typeof handler) {
+        handler = callback;
+        return 1;
+      },
+      async invoke(command: string) {
+        commands.push(command);
+        if (command === "plugin:event|listen") return 1;
+        if (command === "plugin:deep-link|get_current") return ["geo:40.7128,-74.006?z=12"];
+        throw new Error(command);
+      },
+    },
+  };
+  try {
+    await initializeNativeCoordinateOpen();
+    assert.deepEqual(commands, ["plugin:event|listen", "plugin:deep-link|get_current"]);
+    assert.deepEqual(initialNativeCoordinateTarget(), { center: [-74.006, 40.7128], zoom: 12 });
+    finishNativeCoordinateStartup();
+    const { layers, projectGeneration } = useAppStore.getState();
+    handler({ payload: ["geo:0,0?q=51.5,-0.12(London)&z=15"] });
+    assert.deepEqual(useAppStore.getState().mapView.center, [-0.12, 51.5]);
+    assert.equal(useAppStore.getState().mapView.zoom, 15);
+    assert.equal(useAppStore.getState().layers, layers);
+    assert.equal(useAppStore.getState().projectGeneration, projectGeneration);
+    handler({ payload: ["geo:0,0?q=an+address"] });
+    assert.deepEqual(useAppStore.getState().mapView.center, [-0.12, 51.5]);
+  } finally {
+    if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+    else (globalThis as { window?: unknown }).window = originalWindow;
+  }
+});

--- a/tests/onboarding-suppression.test.ts
+++ b/tests/onboarding-suppression.test.ts
@@ -19,6 +19,15 @@ afterEach(() => {
 });
 
 describe("shouldSuppressOnboarding", () => {
+  it("skips onboarding only for valid coordinate links", () => {
+    withSearch("?lat=40.7&lon=-74&zoom=12");
+    assert.equal(shouldSuppressOnboarding(), true);
+    withSearch("?12/40.7/-74");
+    assert.equal(shouldSuppressOnboarding(), true);
+    withSearch("?lat=91&lon=-74");
+    assert.equal(shouldSuppressOnboarding(), false);
+  });
+
   it("shows the wizard with no query params", () => {
     withSearch("");
     assert.equal(shouldSuppressOnboarding(), false);


### PR DESCRIPTION
GeoLibre currently ignores coordinate URLs, and Android does not offer it as a handler for `geo:` links. This adds `?lat=40.7128&lon=-74.006&zoom=12` and compact `?12/40.7128/-74.006` web links, plus Android cold-launch and running-app handling of `geo:lat,lon` and numeric `geo:0,0?q=lat,lon(label)` links with optional `z`.

Coordinate-only launches override saved startup settings and skip onboarding. Explicit project/data payloads keep their existing loading behavior. Incoming Android locations move the map without replacing layers. Invalid coordinates and address-only queries are ignored. The Tauri deep-link plugin generates the Android intent filter from the committed config; no upstream package release is needed.

Validation:

- Reproduced the original web behavior at zoom 2, then verified both URL forms at the exact requested center and zoom with Playwright in light and dark themes.
- Loaded real `us_cities.geojson` through Add Data and verified rendering in both themes; checked invalid-location fallback and saved-startup precedence.
- Full frontend suite: 7,844 passed, one skipped. Targeted parser, onboarding, and native-bridge tests: 20 passed.
- Production build, Rust check, and scoped pre-commit checks passed.
- Android device/emulator verification remains outstanding: this environment has no Android SDK or adb. Native-bridge tests exercise the Tauri JS event/command boundary, not an Android device. Manual cold/warm launch commands are documented in `docs/android.md`.

Fixes #2324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for opening locations from coordinate deep links in the desktop and Android apps.
  - Supports `geo:` links and GeoLibre URL formats, including latitude, longitude, and zoom.
  - Updates the map directly for links received while the app is running.
  - Skips onboarding when launched through a valid coordinate link.

- **Documentation**
  - Added Android deep-link formats, behavior details, and testing instructions.

- **Tests**
  - Added coverage for coordinate parsing, deep-link handling, map updates, and onboarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->