### PR TITLE
feat(map): project, unproject, and getBounds on the globe's control facade

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -1125,3 +1125,36 @@ are the reference implementations of this pattern. A plugin bound to the globe
 must restore any scene state it changes on `deactivate`, because both engines
 are rebuilt on a renderer swap and the host re-activates compatible plugins
 against the new one.
+
+### What a MapLibre control gets on the globe
+
+`app.addMapControl` works under Cesium too. The globe mounts the control's DOM
+in the same four `.maplibregl-ctrl-{top,bottom}-{left,right}` corner containers
+over its canvas — so the scoped CSS in `index.css` keeps applying — and hands
+`onAdd` a MapLibre-shaped facade over the Cesium scene rather than a real
+`Map`. The facade answers:
+
+- `getContainer`, `getCanvas`, `isStyleLoaded`, and the `Evented` methods
+  (`on` / `off` / `once` / `fire`).
+- `getCenter`, `getZoom`, `getBearing`, `getPitch` from the store's map view,
+  and `jumpTo` / `flyTo` / `easeTo` by writing it back.
+- `project`, `unproject`, and `getBounds` from the live scene: a coordinate is
+  projected on the terrain surface, a screen point is picked against terrain
+  then the ellipsoid, and the bounds come from the camera's view rectangle. A
+  coordinate the scene cannot place reads as off-screen window coordinates, a
+  screen point that misses the globe unprojects to the view centre, and a
+  camera with no bounded view rectangle reports the whole world — the same
+  shapes MapLibre's globe projection answers with, so a control keeps running
+  instead of throwing mid-render.
+- `setStyle(url)`, routed to the project basemap.
+- `addSource` / `getSource` / `removeSource`, kept in a map on the facade.
+
+Everything that paints through the Mapbox Style Spec — `addLayer`,
+`setPaintProperty`, `setLayoutProperty`, `getStyle` — **throws**. That is the
+honest boundary: a control that draws its own map layers has no globe
+representation, and a silent no-op would leave it reporting success while
+nothing appears. `addMapControl` catches the throw and returns `false`, so a
+control that trips it fails to mount rather than taking plugin activation down
+with it. A plugin whose control needs those methods should keep the default
+`engines: ["maplibre"]` and, if the globe matters, add a Cesium branch through
+`app.getCesiumScene()`.

--- a/packages/map/src/CesiumCanvas.tsx
+++ b/packages/map/src/CesiumCanvas.tsx
@@ -403,7 +403,7 @@ export const CesiumCanvas = memo(function CesiumCanvas({
         if (cancelled || viewer.isDestroyed()) return;
 
         if (viewId === undefined) {
-          const host = new CesiumControlHost(viewer, container);
+          const host = new CesiumControlHost(viewer, container, Cesium);
           controlHostRef.current = host;
           setPrimaryCesiumControlHost(host);
           // Cesium's native toolbar widgets. Imported

--- a/packages/map/src/cesium-control-host.ts
+++ b/packages/map/src/cesium-control-host.ts
@@ -1,6 +1,20 @@
 import * as maplibregl from "maplibre-gl";
 import type { CesiumWidget } from "@cesium/engine";
 import { useAppStore } from "@geolibre/core";
+import { groundHeightAt, pickGlobeHit } from "./cesium-camera";
+
+/** The Cesium module namespace, injected so this file never imports the engine. */
+type CesiumNs = typeof import("@cesium/engine");
+
+/**
+ * Where {@link CesiumMapFacade.project} puts a coordinate the scene cannot
+ * place: behind the camera, or on the far side of the globe. MapLibre's own
+ * globe projection answers such a point with window coordinates far outside
+ * the canvas rather than with an error, and the controls that call `project`
+ * read the result as "off screen" — so answer the same way instead of
+ * throwing at them mid-render.
+ */
+const OFF_SCREEN_PX = -1e6;
 
 class CesiumMapFacade extends maplibregl.Evented {
   private sources = new Map<string, any>();
@@ -9,6 +23,7 @@ class CesiumMapFacade extends maplibregl.Evented {
   constructor(
     private host: CesiumControlHost,
     private viewer: CesiumWidget,
+    private Cesium: CesiumNs | null,
   ) {
     super();
   }
@@ -92,12 +107,55 @@ class CesiumMapFacade extends maplibregl.Evented {
     return this;
   }
 
-  // Not implemented but required by IControl type definition/plugins in fallback
+  /**
+   * Window coordinates for a geographic position, the globe's answer to
+   * MapLibre's `project` (issue #2262).
+   *
+   * The position is placed on the terrain surface first — `SceneTransforms`
+   * projects a point in the scene, and a coordinate held at ellipsoid zero
+   * would land visibly uphill or downhill of its own ground once terrain is
+   * on. A point the scene cannot place answers {@link OFF_SCREEN_PX} rather
+   * than throwing; see that constant.
+   */
   project(lnglat: maplibregl.LngLatLike) {
-    throw new Error("CesiumControlHost: project not implemented");
+    const C = this.Cesium;
+    const scene = this.scene();
+    const { lng, lat } = maplibregl.LngLat.convert(lnglat);
+    if (!C || !scene) return new maplibregl.Point(OFF_SCREEN_PX, OFF_SCREEN_PX);
+    const height = groundHeightAt(C, this.viewer, lng, lat);
+    const world = C.Cartesian3.fromDegrees(lng, lat, height);
+    const point = C.SceneTransforms.worldToWindowCoordinates(scene, world);
+    return point && Number.isFinite(point.x) && Number.isFinite(point.y)
+      ? new maplibregl.Point(point.x, point.y)
+      : new maplibregl.Point(OFF_SCREEN_PX, OFF_SCREEN_PX);
   }
+
+  /**
+   * The geographic position under a window coordinate — the terrain surface
+   * when terrain is loaded, else the ellipsoid, sharing `pickGlobeHit` with
+   * the cursor readout so both agree on where the ground is.
+   *
+   * A screen point that misses the globe entirely (space, past the horizon)
+   * has no ground coordinate at all. It answers the current view centre: a
+   * defined position inside the scene, which the callers — hit-testing a
+   * pointer that is over the canvas — can carry on with, where a throw would
+   * take down the control's event handler.
+   */
   unproject(point: maplibregl.PointLike) {
-    throw new Error("CesiumControlHost: unproject not implemented");
+    const C = this.Cesium;
+    const scene = this.scene();
+    const p = maplibregl.Point.convert(point);
+    if (!C || !scene) return this.getCenter();
+    const hit = pickGlobeHit(C, this.viewer, { x: p.x, y: p.y });
+    if (!hit) return this.getCenter();
+    const ellipsoid = scene.globe?.ellipsoid ?? C.Ellipsoid.WGS84;
+    const carto = ellipsoid.cartesianToCartographic(hit.position);
+    if (!carto) return this.getCenter();
+    const lng = C.Math.toDegrees(carto.longitude);
+    const lat = C.Math.toDegrees(carto.latitude);
+    return Number.isFinite(lng) && Number.isFinite(lat)
+      ? new maplibregl.LngLat(lng, lat)
+      : this.getCenter();
   }
   getCenter() {
     const view = useAppStore.getState().mapView;
@@ -112,8 +170,38 @@ class CesiumMapFacade extends maplibregl.Evented {
   getPitch() {
     return useAppStore.getState().mapView.pitch;
   }
+  /**
+   * The geographic extent the camera currently sees.
+   *
+   * `computeViewRectangle` has no answer when the globe does not fill enough
+   * of the frustum to bound — looking at space past the limb, or mid-morph
+   * between scene modes. Controls call `getBounds` to *narrow* something (a
+   * catalog search to the viewport, a fetch to the visible tiles), so the
+   * fallback is the whole world: a superset returns more than the view holds,
+   * where a guess or a throw would drop results the user can see.
+   */
   getBounds() {
-    throw new Error("CesiumControlHost: getBounds not implemented");
+    const C = this.Cesium;
+    const scene = this.scene();
+    const rectangle =
+      C && scene?.globe
+        ? this.viewer.camera.computeViewRectangle(scene.globe.ellipsoid)
+        : undefined;
+    if (!C || !rectangle) return new maplibregl.LngLatBounds([-180, -90], [180, 90]);
+    const degrees = C.Math.toDegrees;
+    const west = degrees(rectangle.west);
+    const east = degrees(rectangle.east);
+    // Cesium inverts the pair across the antimeridian; LngLatBounds unwraps it
+    // the way MapExtent does in CesiumEngine.getViewBounds.
+    return new maplibregl.LngLatBounds(
+      [west, degrees(rectangle.south)],
+      [east < west ? east + 360 : east, degrees(rectangle.north)],
+    );
+  }
+
+  /** The live scene, or null once the widget has been destroyed. */
+  private scene() {
+    return this.viewer.isDestroyed?.() ? null : (this.viewer.scene ?? null);
   }
 
   // Throw explicitly for style-spec mutations
@@ -134,9 +222,17 @@ export class CesiumControlHost {
   private controls = new Map<maplibregl.IControl, HTMLElement>();
   private facade: CesiumMapFacade;
 
+  /**
+   * @param viewer The globe this host mounts controls over.
+   * @param containerParent The element the corner containers are appended to.
+   * @param Cesium The engine namespace, for the facade's scene geometry
+   *   (`project` / `unproject` / `getBounds`). Omitting it leaves those
+   *   answering their documented fallbacks rather than throwing.
+   */
   constructor(
     public viewer: CesiumWidget,
     containerParent: HTMLElement,
+    Cesium: CesiumNs | null = null,
   ) {
     this.container = document.createElement("div");
     this.container.className = "maplibregl-control-container";
@@ -157,7 +253,7 @@ export class CesiumControlHost {
     }
 
     containerParent.appendChild(this.container);
-    this.facade = new CesiumMapFacade(this, viewer);
+    this.facade = new CesiumMapFacade(this, viewer, Cesium);
   }
 
   destroy() {

--- a/tests/cesium-control-host.test.ts
+++ b/tests/cesium-control-host.test.ts
@@ -37,6 +37,72 @@ function makeFakeViewer(document: Document) {
   };
 }
 
+const RADIANS = Math.PI / 180;
+
+/**
+ * A viewer with the scene surface the facade's geometry reads: a globe that
+ * reports a ground height, an ellipsoid that round-trips a cartesian, and a
+ * camera that picks and bounds. `hit` controls whether a screen point lands on
+ * the globe at all.
+ */
+function makeSceneViewer(document: Document, options: { hit?: boolean } = {}) {
+  const canvas = document.createElement("canvas");
+  const hit = options.hit ?? true;
+  const ellipsoid = {
+    // The fake Cartesian3 carries its own degrees, so the round trip is exact.
+    cartesianToCartographic: (position: { lng: number; lat: number }) => ({
+      longitude: position.lng * RADIANS,
+      latitude: position.lat * RADIANS,
+    }),
+  };
+  const scene = {
+    canvas,
+    globe: {
+      ellipsoid,
+      getHeight: () => 120,
+      // The picked cartesian is the fake's own lng/lat pair, so unproject
+      // round-trips it through cartesianToCartographic above.
+      pick: () => (hit ? { lng: 12.5, lat: -3.25 } : undefined),
+    },
+  };
+  return {
+    canvas,
+    scene,
+    camera: {
+      heading: 0,
+      pitch: -Math.PI / 2,
+      getPickRay: (point: { x: number; y: number }) => (hit ? { point } : undefined),
+      pickEllipsoid: () => undefined,
+      computeViewRectangle: () => ({
+        west: -10 * RADIANS,
+        south: -20 * RADIANS,
+        east: 30 * RADIANS,
+        north: 40 * RADIANS,
+      }),
+    },
+    isDestroyed: () => false,
+  };
+}
+
+/** Just enough of `@cesium/engine` for the facade's project/unproject/getBounds. */
+function makeFakeCesium(options: { project?: { x: number; y: number } | undefined } = {}) {
+  return {
+    Math: { toDegrees: (radians: number) => radians / RADIANS },
+    Cartographic: { fromDegrees: (lng: number, lat: number) => ({ lng, lat }) },
+    Cartesian3: {
+      fromDegrees: (lng: number, lat: number, height: number) => ({
+        lng,
+        lat,
+        height,
+      }),
+    },
+    Ellipsoid: { WGS84: {} },
+    SceneTransforms: {
+      worldToWindowCoordinates: () => ("project" in options ? options.project : { x: 400, y: 300 }),
+    },
+  };
+}
+
 describe("CesiumControlHost", () => {
   let doc: Document;
   let parent: HTMLElement;
@@ -288,7 +354,6 @@ describe("CesiumControlHost", () => {
     assert.throws(() => facade.setPaintProperty(), /setPaintProperty is not supported/);
     assert.throws(() => facade.setLayoutProperty(), /setLayoutProperty is not supported/);
     assert.throws(() => facade.getStyle(), /getStyle is not supported/);
-    assert.throws(() => facade.getBounds(), /getBounds not implemented/);
 
     // Source management works
     facade.addSource("test-src", { type: "geojson" });
@@ -296,6 +361,102 @@ describe("CesiumControlHost", () => {
     facade.removeSource("test-src");
     assert.equal(facade.getSource("test-src"), undefined);
 
+    host.destroy();
+  });
+
+  /** Mount a throwaway control just to capture the facade `onAdd` receives. */
+  function facadeOf(host: CesiumControlHost): any {
+    let facade: any = null;
+    host.addControl({
+      onAdd: (map) => {
+        facade = map;
+        return doc.createElement("div");
+      },
+      onRemove: () => {},
+    });
+    return facade;
+  }
+
+  it("projects and unprojects through the Cesium scene", () => {
+    const sceneViewer = makeSceneViewer(doc);
+    const host = new CesiumControlHost(sceneViewer as never, parent, makeFakeCesium() as never);
+    const facade = facadeOf(host);
+
+    const point = facade.project([-122.4, 37.7]);
+    assert.equal(point.x, 400);
+    assert.equal(point.y, 300);
+
+    const lngLat = facade.unproject([400, 300]);
+    assert.ok(Math.abs(lngLat.lng - 12.5) < 1e-9);
+    assert.ok(Math.abs(lngLat.lat - -3.25) < 1e-9);
+
+    host.destroy();
+  });
+
+  it("answers off-screen for a coordinate the scene cannot place", () => {
+    const sceneViewer = makeSceneViewer(doc);
+    const host = new CesiumControlHost(
+      sceneViewer as never,
+      parent,
+      makeFakeCesium({ project: undefined }) as never,
+    );
+    const facade = facadeOf(host);
+
+    const point = facade.project([-122.4, 37.7]);
+    assert.ok(point.x < 0 && point.y < 0, "a point behind the globe must read as off screen");
+    host.destroy();
+  });
+
+  it("unprojects a screen point that misses the globe to the view centre", () => {
+    const sceneViewer = makeSceneViewer(doc, { hit: false });
+    const host = new CesiumControlHost(sceneViewer as never, parent, makeFakeCesium() as never);
+    const facade = facadeOf(host);
+
+    const lngLat = facade.unproject([5, 5]);
+    assert.equal(lngLat.lng, -122.4);
+    assert.equal(lngLat.lat, 37.7);
+    host.destroy();
+  });
+
+  it("reads the camera's view rectangle as MapLibre bounds", () => {
+    const sceneViewer = makeSceneViewer(doc);
+    const host = new CesiumControlHost(sceneViewer as never, parent, makeFakeCesium() as never);
+    const bounds = facadeOf(host).getBounds();
+
+    assert.ok(Math.abs(bounds.getWest() - -10) < 1e-9);
+    assert.ok(Math.abs(bounds.getSouth() - -20) < 1e-9);
+    assert.ok(Math.abs(bounds.getEast() - 30) < 1e-9);
+    assert.ok(Math.abs(bounds.getNorth() - 40) < 1e-9);
+    host.destroy();
+  });
+
+  it("unwraps a view rectangle that crosses the antimeridian", () => {
+    const sceneViewer = makeSceneViewer(doc);
+    // Cesium reports west > east across the seam; MapLibre bounds must not.
+    sceneViewer.camera.computeViewRectangle = () => ({
+      west: (170 * Math.PI) / 180,
+      south: 0,
+      east: (-170 * Math.PI) / 180,
+      north: (10 * Math.PI) / 180,
+    });
+    const host = new CesiumControlHost(sceneViewer as never, parent, makeFakeCesium() as never);
+    const bounds = facadeOf(host).getBounds();
+
+    assert.ok(Math.abs(bounds.getWest() - 170) < 1e-9);
+    assert.ok(Math.abs(bounds.getEast() - 190) < 1e-9);
+    host.destroy();
+  });
+
+  it("falls back to the whole world when the camera cannot bound the globe", () => {
+    const sceneViewer = makeSceneViewer(doc);
+    sceneViewer.camera.computeViewRectangle = () => undefined as never;
+    const host = new CesiumControlHost(sceneViewer as never, parent, makeFakeCesium() as never);
+    const bounds = facadeOf(host).getBounds();
+
+    assert.equal(bounds.getWest(), -180);
+    assert.equal(bounds.getSouth(), -90);
+    assert.equal(bounds.getEast(), 180);
+    assert.equal(bounds.getNorth(), 90);
     host.destroy();
   });
 


### PR DESCRIPTION
Part of #2262 (tier 2 — DOM controls).

## Problem

`CesiumControlHost` hands `IControl.onAdd` a MapLibre-shaped facade over the Cesium scene. Three of the methods #2262 lists as "exact Cesium equivalents" were still placeholders that threw:

```ts
project(lnglat) { throw new Error("CesiumControlHost: project not implemented"); }
unproject(point) { throw new Error("CesiumControlHost: unproject not implemented"); }
getBounds() { throw new Error("CesiumControlHost: getBounds not implemented"); }
```

`addControl` catches a throw from `onAdd`, but nothing catches one from a control's own render loop or event handler afterwards — so a control that reads the viewport (a catalog search narrowed to the visible extent, a hit test on a pointer) crashed instead of degrading.

## Change

The host now takes the `@cesium/engine` namespace (`CesiumCanvas` already has it in scope where it builds the host) and implements the three against the live scene, reusing the helpers the engine already uses so the facade and the cursor readout agree on where the ground is:

- `project` — `groundHeightAt` to place the coordinate on terrain, then `SceneTransforms.worldToWindowCoordinates`. Projecting at ellipsoid zero would land visibly up- or downhill of its own ground with terrain on.
- `unproject` — `pickGlobeHit` (terrain first, then the ellipsoid), the same pick the pointer coordinates use.
- `getBounds` — `camera.computeViewRectangle`, unwrapped across the antimeridian the way `CesiumEngine.getViewBounds` unwraps `MapExtent`.

Each has a documented fallback at the edges, matching how MapLibre's own globe projection behaves rather than throwing at a caller mid-render:

| case | answer |
| --- | --- |
| coordinate behind the camera / far side of the globe | off-screen window coordinates |
| screen point that misses the globe (space, past the horizon) | the current view centre |
| camera with no bounded view rectangle (limb, mid-morph) | the whole world — a superset, so a viewport filter returns more than the view holds instead of dropping results |

The style-spec methods (`addLayer`, `setPaintProperty`, `setLayoutProperty`, `getStyle`) still throw. That boundary is the point of the facade; this only moves the read-only geometry to the supported side of it.

## Docs

`docs/plugin-api.md` gains a "What a MapLibre control gets on the globe" section listing what the facade answers, what throws, and why — the compatibility contract external plugin authors need alongside the `engines` field.

## Tests

`tests/cesium-control-host.test.ts`: a fake scene (globe with terrain height and pick, ellipsoid round trip, camera view rectangle) covering the happy path and every fallback, including an antimeridian-crossing rectangle. 18 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MapLibre controls running on the Cesium globe can now project and unproject coordinates and determine visible geographic bounds.
  * Controls receive more accurate scene-based map interactions, including globe-aware positioning and view information.
  * Controls that request unsupported styling operations now fail gracefully without interrupting plugin activation.

* **Documentation**
  * Added guidance for adapting MapLibre controls for Cesium, including supported functionality and recommended configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->