### PR TITLE
fix(raster): render LERC- and ZSTD-compressed COGs with the default engine

### DIFF
--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1206,6 +1206,13 @@ export default defineConfig({
       // pre-bundled via the deck.gl-geotiff static import.)
       "proj4",
       "geotiff-geokeys-to-proj4",
+      // cog-tiler-wasm's mask-aware LERC decoder (lerc-decoder.js) reaches
+      // these through dynamic import() the first time a LERC COG opens; they
+      // are geotiff's own codec packages, listed here for the same
+      // discover-and-reload reason as above. (`lerc` itself is excluded below:
+      // it locates its .wasm via import.meta.url.)
+      "pako",
+      "zstddec",
       // Cesium (the 3D-globe view). Pre-bundle it up front so esbuild applies
       // CJS→ESM interop to its CommonJS transitive deps (e.g. mersenne-twister,
       // which has no ESM entry): without this, the dev server serves those raw
@@ -1259,6 +1266,11 @@ export default defineConfig({
       // breaks that asset reference so the tiler stops rendering. Serve it
       // as-is. (Its plain-JS deps are pre-bundled via optimizeDeps.include.)
       "cog-tiler-wasm",
+      // lerc 4.x (cog-tiler-wasm's mask-aware LERC decoder) fetches
+      // lerc-wasm.wasm via `new URL(..., import.meta.url)`; pre-bundled, that
+      // resolves against the .vite/deps chunk and the request falls through to
+      // index.html ("expected magic word 00 61 73 6d, found 3c 21 64 6f").
+      "lerc",
       // h5wasm (local NetCDF/HDF5 reader) loads its libhdf5 .wasm via
       // `new URL(..., import.meta.url)`; esbuild pre-bundling mangles that
       // asset reference, so serve it as-is. Only reached through the lazy

--- a/package-lock.json
+++ b/package-lock.json
@@ -14682,6 +14682,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15345,15 +15346,29 @@
       }
     },
     "node_modules/cog-tiler-wasm": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.3.5.tgz",
-      "integrity": "sha512-0sirGQgqUaldNeQHlFZ9LibVmnThf0pgf/RtLpK7pS6FwANgr4l1fcEyqygCueBZf5hrA0zPCmuz70KIKHdZ9g==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.3.6.tgz",
+      "integrity": "sha512-1u94mAmqooKlmZ9SNx2BXhyfONSbRG+cVuIztE3yxotHngRwbh/tg1d9FLMiN9oQJTM3SOYLaZOXLM1y6VN9OA==",
       "license": "MIT",
       "peerDependencies": {
         "geotiff": "^2.1.0 || ^3.0.0",
         "geotiff-geokeys-to-proj4": "^2024.4.13 || ^2026.8.16",
+        "lerc": "^3.0.0 || ^4.0.0",
+        "pako": "^1.0.11 || ^2.0.4",
         "proj4": "^2.15.0",
-        "whitebox-wasm": "^0.4.1 || ^0.5.1"
+        "whitebox-wasm": "^0.4.1 || ^0.5.1",
+        "zstddec": "^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "lerc": {
+          "optional": true
+        },
+        "pako": {
+          "optional": true
+        },
+        "zstddec": {
+          "optional": true
+        }
       }
     },
     "node_modules/color-convert": {
@@ -27764,7 +27779,7 @@
         "@tauri-apps/plugin-opener": "^2.5.5",
         "@turf/union": "^7.4.0",
         "a5-js": "^0.10.0",
-        "cog-tiler-wasm": "^0.3.5",
+        "cog-tiler-wasm": "^0.3.6",
         "dggal": "^0.0.6",
         "geotiff": "^3.0.5",
         "geotiff-geokeys-to-proj4": "^2026.8.16",
@@ -27772,6 +27787,7 @@
         "h5wasm": "^0.10.3",
         "icechunk-js": "^0.6.0",
         "jspdf": "^4.2.1",
+        "lerc": "^4.2.0",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^6.7.0",
         "maplibre-gl-3d-tiles": "^0.5.6",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -49,6 +49,7 @@
     "h5wasm": "^0.10.3",
     "icechunk-js": "^0.6.0",
     "jspdf": "^4.2.1",
+    "lerc": "^4.2.0",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^6.7.0",
     "maplibre-gl-3d-tiles": "^0.5.6",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -41,7 +41,7 @@
     "@tauri-apps/plugin-opener": "^2.5.5",
     "@turf/union": "^7.4.0",
     "a5-js": "^0.10.0",
-    "cog-tiler-wasm": "^0.3.5",
+    "cog-tiler-wasm": "^0.3.6",
     "dggal": "^0.0.6",
     "geotiff": "^3.0.5",
     "geotiff-geokeys-to-proj4": "^2026.8.16",

--- a/packages/plugins/src/lerc-wasm-url.d.ts
+++ b/packages/plugins/src/lerc-wasm-url.d.ts
@@ -1,0 +1,7 @@
+// Vite resolves `?url` imports to the served/hashed asset URL. Declared here
+// because @geolibre/plugins does not pull in vite/client's ambient module
+// types; only this one asset is imported that way.
+declare module "lerc/lerc-wasm.wasm?url" {
+  const url: string;
+  export default url;
+}

--- a/packages/plugins/src/plugins/cog-compression.ts
+++ b/packages/plugins/src/plugins/cog-compression.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether a cog-tiler-wasm level's `compression` is baseline JPEG, the only
+ * codec whose tiles may omit their tables (TIFF tag 347) and so need the
+ * geotiff.js window read in maplibre-raster.ts. The string is whitebox-wasm's
+ * enum name, so match `Jpeg`/`OldJpeg` exactly: a looser `/jpeg/i` would also
+ * catch `JpegXl`, which the wasm decoder handles and geotiff.js cannot decode
+ * at all (#2339). Kept in a leaf module so it can be unit-tested without
+ * importing the whole raster plugin.
+ */
+export function isAbbreviatedJpegCompression(compression: string | undefined): boolean {
+  return /^(old)?jpeg$/i.test(compression ?? "");
+}

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -28,6 +28,7 @@ import {
   unwireRasterStoreSync,
   wireRasterStoreSync,
 } from "./raster-layer-sync";
+import { isAbbreviatedJpegCompression } from "./cog-compression";
 import {
   activateRasterClassification,
   disposeAllRasterClassification,
@@ -159,6 +160,8 @@ type RasterLayerManagerInternals = {
 };
 type CogTilerModule = {
   openCog: (source: unknown) => Promise<unknown>;
+  /** cog-tiler-wasm >= 0.3.6: where lerc's wasm is served from. */
+  configureLercDecoder?: (options: { wasmUrl?: string | null }) => void;
   [key: string]: unknown;
 };
 type GeoTiffImage = {
@@ -890,6 +893,7 @@ function patchCogTilerJpegTables(control: RasterControl): void {
   const loadCogTiler = deps.loadCogTiler;
   deps.loadCogTiler = async () => {
     const module = await loadCogTiler();
+    await configureLercWasmUrl(module);
     return {
       ...module,
       openCog: async (input: unknown) => patchJpegCogSource(await module.openCog(input)),
@@ -898,11 +902,34 @@ function patchCogTilerJpegTables(control: RasterControl): void {
   deps.geolibreJpegTablesPatched = true;
 }
 
+/**
+ * Point cog-tiler-wasm's mask-aware LERC decoder (#2339) at lerc's wasm.
+ *
+ * lerc locates `lerc-wasm.wasm` relative to its own module URL, which Vite's
+ * hashed build output and dev pre-bundling do not rewrite: the fetch lands on
+ * index.html and the wasm compile aborts. Vite's `?url` import resolves the
+ * served asset in both modes. It is a dynamic import so the Node test runner,
+ * which cannot resolve the `?url` suffix, never evaluates it; a resolution
+ * failure leaves lerc's own lookup in place rather than breaking the tiler.
+ */
+async function configureLercWasmUrl(module: CogTilerModule): Promise<void> {
+  if (typeof module.configureLercDecoder !== "function") return;
+  try {
+    const { default: wasmUrl } = await import("lerc/lerc-wasm.wasm?url");
+    module.configureLercDecoder({ wasmUrl });
+  } catch (error) {
+    console.warn(
+      "[GeoLibre] Could not resolve lerc's wasm URL; LERC nodata may decode as 0",
+      error,
+    );
+  }
+}
+
 function patchJpegCogSource(source: unknown): unknown {
   const cog = source as CogSourceInternals;
   if (
     cog.geolibreJpegTablesPatched ||
-    !/jpeg/i.test(cog.levels?.[0]?.compression ?? "") ||
+    !isAbbreviatedJpegCompression(cog.levels?.[0]?.compression) ||
     !cog.tiff ||
     !cog._tiffImage ||
     !cog._assembleWindow

--- a/tests/cog-compression.test.ts
+++ b/tests/cog-compression.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isAbbreviatedJpegCompression } from "../packages/plugins/src/plugins/cog-compression";
+
+describe("isAbbreviatedJpegCompression", () => {
+  it("matches whitebox-wasm's baseline JPEG variant names", () => {
+    assert.equal(isAbbreviatedJpegCompression("Jpeg"), true);
+    assert.equal(isAbbreviatedJpegCompression("OldJpeg"), true);
+    assert.equal(isAbbreviatedJpegCompression("JPEG"), true);
+  });
+
+  it("does not reroute JPEG-XL, which geotiff.js cannot decode (#2339)", () => {
+    assert.equal(isAbbreviatedJpegCompression("JpegXl"), false);
+  });
+
+  it("ignores every other codec, including the Other(code) form", () => {
+    for (const value of [
+      "Deflate",
+      "Lzw",
+      "WebP",
+      "PackBits",
+      "Other(34887)",
+      "Other(50000)",
+      "",
+      undefined,
+    ]) {
+      assert.equal(isAbbreviatedJpegCompression(value), false, String(value));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2339

LERC- and ZSTD-compressed COGs added through Add Data, Raster Layer listed a layer but painted nothing and raised no error. The default `cog-tiler-wasm` engine decodes tiles with whitebox-wasm, which has no codec for TIFF compression 34887 (LERC, all of `LERC` / `LERC_DEFLATE` / `LERC_ZSTD`) or 50000 (ZSTD); every tile decode threw inside the tiler and maplibre-gl-raster returns an empty tile on any render failure, so the map stayed blank. Only an `openCog` rejection reaches the panel as a visible layer error.

The decoding fix lives upstream in cog-tiler-wasm 0.3.6 (opengeos/cog-tiler-wasm#29):

- LERC and ZSTD levels are read through geotiff.js (the same path planar and big-endian COGs already used), including single-band EPSG:3857 rasters that previously never opened the geotiff.js handle. The decoder is chosen per overview level, since GDAL can compress overviews differently (`OVERVIEW_COMPRESS`).
- Codecs neither decoder can read (LZMA, JPEG 2000, CCITT, and the DNG 1.7 JPEG-XL code 52546 that GDAL 3.11+ writes) are rejected at open time with a named error, so the panel shows "Failed to load: Unsupported compression: LZMA (TIFF compression 34925). ..." instead of a silently empty map, as the issue asked.
- geotiff.js discards the LERC validity mask, so masked nodata pixels decoded as 0 and painted black. The tiler now registers a mask-aware LERC decoder (masked pixels take `GDAL_NODATA`, or NaN for floating-point rasters; all-nodata tiles are filled whole).

GeoLibre-side changes:

- Bump `cog-tiler-wasm` to `^0.3.6`.
- Hand the tiler the URL Vite resolves for lerc's wasm through a dynamic `?url` import. lerc locates `lerc-wasm.wasm` relative to its module URL, which neither the hashed build nor dev pre-bundling rewrites (the fetch landed on index.html and the wasm compile aborted). `lerc` is excluded from dev pre-bundling for the same reason; `pako` and `zstddec` are pre-bundled so their first dynamic import does not reload the page.
- Match the JPEGTables reroute on `Jpeg`/`OldJpeg` exactly. The old `/jpeg/i` sniff also matched `JpegXl`, which geotiff.js cannot decode. Extracted to `cog-compression.ts` with a unit test.

## Verification

COGs built with GDAL 3.12 from the Oregon DEM (EPSG:3857, Float64, NaN nodata) and the Athens DEM (EPSG:2100, Float32) with `-of COG -co COMPRESS=LERC|LERC_DEFLATE|LERC_ZSTD|ZSTD|DEFLATE|JXL|LZMA`, plus `COMPRESS=LERC -co OVERVIEW_COMPRESS=DEFLATE`, `COMPRESS=DEFLATE -co OVERVIEW_COMPRESS=ZSTD`, and `COMPRESS=LERC -co OVERVIEW_COMPRESS=LZMA`. Driven through the real app with Playwright, in both light and dark themes, in the dev server and the production build (`vite preview`), by file upload and by URL:

- LERC, LERC_DEFLATE, LERC_ZSTD, ZSTD: render on both the EPSG:3857 fast path and the warp path, nodata transparent, statistics and histogram populated, pixel Inspect returns real values, no console errors. Identical to the DEFLATE control.
- LZMA, and a LERC base with LZMA overviews: layer marked failed with the unsupported-compression message.
- Mixed base/overview codecs render at overview and base zooms.
- `npm run test:frontend`: 7979 passing. `npm run build` passes. Pre-commit passes.

## Follow-ups (not in this PR)

- whitebox-wasm does not map the DNG 1.7 JPEG-XL code 52546 that GDAL 3.11+ writes (it only knows 50002), so such COGs now fail with a named error rather than rendering.
- maplibre-gl-raster's own Inspect popup reads pixels with its own geotiff.js handle and still shows 0 for masked LERC pixels; the map render and cog-tiler's `point()` are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for LERC-compressed Cloud Optimized GeoTIFF imagery.
  - Improved compatibility with abbreviated JPEG-compressed raster tiles.

- **Bug Fixes**
  - Fixed WebAssembly asset loading for raster decoding in the desktop development environment.
  - Prevented JPEG XL data from being incorrectly handled as standard JPEG imagery.
  - Improved reliability when decoding compressed raster tiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->