### PR TITLE
fix(storymap): fade companion symbology and diagrams with their layer, and let the legend follow the chapters

### DIFF
--- a/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
+++ b/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
@@ -12,6 +12,7 @@
  */
 import {
   normalizeHexColor,
+  storyVisibleLayers,
   useAppStore,
   type LegendConfig,
   type LegendCustomEntry,
@@ -178,7 +179,16 @@ export function MapLegendPanel({
   mapReadyGeneration: number;
 }) {
   const { t, i18n } = useTranslation();
-  const layers = useAppStore((state) => state.layers);
+  const storeLayers = useAppStore((state) => state.layers);
+  const storyPresenting = useAppStore((state) => state.ui.storymapPresenting);
+  const storyOpacity = useAppStore((state) => state.ui.storymapLayerOpacity);
+  // During a story presentation the legend follows the chapters: a layer the
+  // current chapter has faded fully out drops from the legend as well, so
+  // the reader sees only the symbology on screen (discussion #2326).
+  const layers = useMemo(
+    () => storyVisibleLayers(storeLayers, storyPresenting, storyOpacity),
+    [storeLayers, storyPresenting, storyOpacity],
+  );
   const legend = useAppStore((state) => state.legend);
   const setLegend = useAppStore((state) => state.setLegend);
   const [editing, setEditing] = useState(false);

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -333,9 +333,18 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         .addTo(insetMap);
     }
 
-    const applyEffects = (changes: StoryChapter["onChapterEnter"]) => {
+    // Apply a chapter's layer fades to the map and collect them into `pending`,
+    // which enterChapter commits to the store in one write once the replay is
+    // done (see `ui.storymapLayerOpacity`): deck.gl diagrams and the on-map
+    // Legend follow the fades from there, while MapLibre layers take them
+    // directly from the controller.
+    const applyEffects = (
+      changes: StoryChapter["onChapterEnter"],
+      pending: Record<string, number>,
+    ) => {
       for (const change of changes) {
         controller.setStoryLayerOpacity(change.layerId, change.opacity, change.duration);
+        pending[change.layerId] = change.opacity;
       }
     };
 
@@ -382,17 +391,19 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       // enter never ran. `previous` is -1 before the first chapter (e.g. jumping
       // straight from the start slide to chapter N), which replays 0..N-1 so the
       // skipped chapters' fades still run.
+      const pending: Record<string, number> = {};
       if (previous !== index) {
         // Chapter indices are always >= 0: a `previous` of -1 means "before
         // chapter 0", so the loop starts at i = 0 and only moves toward `index`.
         const dir = previous < index ? 1 : -1;
-        if (previous >= 0) applyEffects(chapters[previous]?.onChapterExit ?? []);
+        if (previous >= 0) applyEffects(chapters[previous]?.onChapterExit ?? [], pending);
         for (let i = previous + dir; i !== index; i += dir) {
-          applyEffects(chapters[i]?.onChapterEnter ?? []);
-          applyEffects(chapters[i]?.onChapterExit ?? []);
+          applyEffects(chapters[i]?.onChapterEnter ?? [], pending);
+          applyEffects(chapters[i]?.onChapterExit ?? [], pending);
         }
       }
-      applyEffects(chapter.onChapterEnter);
+      applyEffects(chapter.onChapterEnter, pending);
+      useAppStore.getState().setStorymapLayerOpacity(pending);
     };
 
     const enterSlide = (step: Extract<PresenterStep, { kind: "slide" }>) => {
@@ -482,14 +493,23 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     };
   }, [hasChapters, mapControllerRef]);
 
-  // Allow Escape to exit the presentation.
+  // Allow Escape to exit the presentation. The presenter owns the key while it
+  // is up: it listens in the capture phase and stops propagation, so on-map
+  // panels that also close on Escape (the Legend panel, for one) do not close
+  // themselves as a side effect of leaving the story (discussion #2326). An
+  // Escape aimed at an open dialog or menu is left alone so it still dismisses
+  // that surface first.
   useEffect(() => {
     if (!presenting) return;
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") exitPresentation();
+      if (event.key !== "Escape") return;
+      const target = event.target instanceof Element ? event.target : null;
+      if (target?.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) return;
+      event.stopPropagation();
+      exitPresentation();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [presenting, exitPresentation]);
 
   // A presentation with no chapters has nothing to show; close it (routing

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -497,14 +497,21 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   // is up: it listens in the capture phase and stops propagation, so on-map
   // panels that also close on Escape (the Legend panel, for one) do not close
   // themselves as a side effect of leaving the story (discussion #2326). An
-  // Escape aimed at an open dialog or menu is left alone so it still dismisses
-  // that surface first.
+  // Escape aimed at an open dialog, menu, or an editable control (the Legend
+  // panel's inline rename and dictionary textarea handle Escape locally) is
+  // left alone so it still dismisses or reverts that surface first.
   useEffect(() => {
     if (!presenting) return;
     const onKey = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       const target = event.target instanceof Element ? event.target : null;
-      if (target?.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) return;
+      if (
+        target?.closest(
+          '[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"], [role="combobox"], input, textarea, select, [contenteditable="true"]',
+        )
+      ) {
+        return;
+      }
       event.stopPropagation();
       exitPresentation();
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,12 @@ export * from "./pixel-format";
 export * from "./print-layout-config";
 export { createSampleStoryMap } from "./storymap-sample";
 export {
+  applyStoryLayerOpacity,
+  isStoryHiddenLayer,
+  storyLayerOpacityFactor,
+  storyVisibleLayers,
+} from "./storymap-playback";
+export {
   scrubWidgetsForRemovedLayers,
   scrubCommentsForRemovedLayers,
   scrubLegendForRemovedLayers,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1538,9 +1538,11 @@ export const useAppStore = create<AppState>()(
             next[layerId] = clamped;
             changed = true;
           }
-          // Skip the write when nothing moved: a chapter re-entering the same
-          // opacities would otherwise rebuild every store subscriber's view.
-          return changed ? { ui: { ...s.ui, storymapLayerOpacity: next } } : {};
+          // Return the current state untouched when nothing moved: Zustand only
+          // skips the listener broadcast for the same state reference, and a
+          // chapter re-entering the same opacities would otherwise rebuild
+          // every store subscriber's view.
+          return changed ? { ui: { ...s.ui, storymapLayerOpacity: next } } : s;
         }),
       setStorymapComposing: (chapterId) =>
         set((s) => ({ ui: { ...s.ui, storymapComposingId: chapterId } })),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -386,6 +386,15 @@ export interface AppState {
     // it reopens the Story Map editor instead of dropping to the bare map
     // (#918). Auto-presented projects (opened for viewing) leave this false.
     storymapReturnToEditor: boolean;
+    /**
+     * Layer opacities the active story presentation has applied so far, keyed
+     * by store layer id. Playback fades layers by writing MapLibre paint
+     * properties directly (never the persisted `layers[].opacity`), so this is
+     * how renderers outside MapLibre's paint model (deck.gl diagrams, 3D
+     * Z-value geometry) and the on-map Legend follow a chapter's fades. Empty
+     * while not presenting; never saved with the project.
+     */
+    storymapLayerOpacity: Record<string, number>;
     // Id of the chapter currently being composed on the live map. When set, the
     // Story Map dialog is hidden so the user can pan/zoom/tilt the real map and
     // save the resulting camera back into this chapter (issue #775).
@@ -523,6 +532,11 @@ export interface AppState {
   setDashboardOpen: (open: boolean) => void;
   setStorymapPanelOpen: (open: boolean) => void;
   setStorymapPresenting: (presenting: boolean, returnToEditor?: boolean) => void;
+  /**
+   * Record the layer opacities a story chapter applied, merging into the
+   * presentation's running map (see `ui.storymapLayerOpacity`).
+   */
+  setStorymapLayerOpacity: (changes: Record<string, number>) => void;
   setStorymapComposing: (chapterId: string | null) => void;
   setBatchToolsOpen: (open: boolean) => void;
   setModelBuilderOpen: (open: boolean) => void;
@@ -1167,6 +1181,7 @@ export const useAppStore = create<AppState>()(
         storymapPanelOpen: false,
         storymapPresenting: false,
         storymapReturnToEditor: false,
+        storymapLayerOpacity: {},
         storymapComposingId: null,
         batchToolsOpen: false,
         modelBuilderOpen: false,
@@ -1508,8 +1523,25 @@ export const useAppStore = create<AppState>()(
             // Track whether exiting should reopen the editor; only meaningful
             // while presenting, so it clears once the presentation ends (#918).
             storymapReturnToEditor: presenting ? returnToEditor : false,
+            // A presentation starts from (and leaves behind) a clean slate; the
+            // fades it applies are replayed from chapter 0 on the next run.
+            storymapLayerOpacity: {},
           },
         })),
+      setStorymapLayerOpacity: (changes) =>
+        set((s) => {
+          const next = { ...s.ui.storymapLayerOpacity };
+          let changed = false;
+          for (const [layerId, opacity] of Object.entries(changes)) {
+            const clamped = Math.min(1, Math.max(0, opacity));
+            if (next[layerId] === clamped) continue;
+            next[layerId] = clamped;
+            changed = true;
+          }
+          // Skip the write when nothing moved: a chapter re-entering the same
+          // opacities would otherwise rebuild every store subscriber's view.
+          return changed ? { ui: { ...s.ui, storymapLayerOpacity: next } } : {};
+        }),
       setStorymapComposing: (chapterId) =>
         set((s) => ({ ui: { ...s.ui, storymapComposingId: chapterId } })),
       setBatchToolsOpen: (open) => set((s) => ({ ui: { ...s.ui, batchToolsOpen: open } })),
@@ -2347,6 +2379,7 @@ export const useAppStore = create<AppState>()(
             ...s.ui,
             storymapPresenting: false,
             storymapReturnToEditor: false,
+            storymapLayerOpacity: {},
             storymapPanelOpen: false,
             storymapComposingId: null,
             // An open selection dialog (and its preselected layer id) belongs
@@ -2410,6 +2443,7 @@ export const useAppStore = create<AppState>()(
             // A bundled story auto-presents for viewing, so exiting it should
             // not pop open the editor (#918).
             storymapReturnToEditor: false,
+            storymapLayerOpacity: {},
             storymapPanelOpen: false,
             storymapComposingId: null,
             // An open selection dialog (and its preselected layer id) belongs

--- a/packages/core/src/storymap-playback.ts
+++ b/packages/core/src/storymap-playback.ts
@@ -11,8 +11,18 @@
  */
 import type { GeoLibreLayer } from "./types";
 
+/** The clamped opacity recorded for a layer, or undefined when untouched. */
+function recordedStoryOpacity(
+  opacities: Record<string, number> | undefined,
+  layerId: string,
+): number | undefined {
+  const value = opacities?.[layerId];
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.min(1, Math.max(0, value));
+}
+
 /**
- * The opacity factor a story presentation has applied to a layer.
+ * The opacity a story presentation has applied to a layer.
  *
  * @param opacities The store's `ui.storymapLayerOpacity` record.
  * @param layerId Store layer id.
@@ -23,16 +33,21 @@ export function storyLayerOpacityFactor(
   opacities: Record<string, number> | undefined,
   layerId: string,
 ): number {
-  const value = opacities?.[layerId];
-  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
-  return Math.min(1, Math.max(0, value));
+  return recordedStoryOpacity(opacities, layerId) ?? 1;
 }
 
 /**
- * A layer whose effective opacity folds in the story presentation's fade.
+ * A layer whose opacity reflects the story presentation's fade.
  *
- * Returns the same object when the presentation has not touched the layer, so
- * identity-keyed caches downstream keep hitting.
+ * A chapter's opacity *replaces* the layer's own opacity rather than scaling
+ * it, matching `MapController.setStoryLayerOpacity`, which writes the chapter
+ * value as the absolute paint opacity; otherwise a layer set to 0.7 in the
+ * Layers panel and faded to 0.4 by a chapter would draw its diagrams at 0.28
+ * while its MapLibre layers draw at 0.4.
+ *
+ * Returns the same object when the presentation has not touched the layer (or
+ * recorded the opacity it already has), so identity-keyed caches downstream
+ * keep hitting.
  *
  * @param layer Store layer.
  * @param opacities The store's `ui.storymapLayerOpacity` record.
@@ -41,9 +56,9 @@ export function applyStoryLayerOpacity(
   layer: GeoLibreLayer,
   opacities: Record<string, number> | undefined,
 ): GeoLibreLayer {
-  const factor = storyLayerOpacityFactor(opacities, layer.id);
-  if (factor === 1) return layer;
-  return { ...layer, opacity: layer.opacity * factor };
+  const opacity = recordedStoryOpacity(opacities, layer.id);
+  if (opacity === undefined || opacity === layer.opacity) return layer;
+  return { ...layer, opacity };
 }
 
 /**

--- a/packages/core/src/storymap-playback.ts
+++ b/packages/core/src/storymap-playback.ts
@@ -1,0 +1,79 @@
+/**
+ * Helpers for following a story-map presentation's layer fades outside the
+ * MapLibre paint model.
+ *
+ * Story playback fades layers by writing MapLibre paint properties directly
+ * (see `MapController.setStoryLayerOpacity`) and records the applied values in
+ * `ui.storymapLayerOpacity`. Anything that renders a layer some other way, such
+ * as deck.gl feature diagrams and 3D Z-value geometry, or that lists layers
+ * for the reader, such as the on-map Legend, reads that record through these
+ * helpers so a faded-out layer disappears everywhere at once.
+ */
+import type { GeoLibreLayer } from "./types";
+
+/**
+ * The opacity factor a story presentation has applied to a layer.
+ *
+ * @param opacities The store's `ui.storymapLayerOpacity` record.
+ * @param layerId Store layer id.
+ * @returns The recorded opacity in `[0, 1]`, or `1` when the presentation has
+ *   not touched the layer (or nothing is presenting).
+ */
+export function storyLayerOpacityFactor(
+  opacities: Record<string, number> | undefined,
+  layerId: string,
+): number {
+  const value = opacities?.[layerId];
+  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * A layer whose effective opacity folds in the story presentation's fade.
+ *
+ * Returns the same object when the presentation has not touched the layer, so
+ * identity-keyed caches downstream keep hitting.
+ *
+ * @param layer Store layer.
+ * @param opacities The store's `ui.storymapLayerOpacity` record.
+ */
+export function applyStoryLayerOpacity(
+  layer: GeoLibreLayer,
+  opacities: Record<string, number> | undefined,
+): GeoLibreLayer {
+  const factor = storyLayerOpacityFactor(opacities, layer.id);
+  if (factor === 1) return layer;
+  return { ...layer, opacity: layer.opacity * factor };
+}
+
+/**
+ * Whether a story presentation has faded a layer fully out.
+ *
+ * @param opacities The store's `ui.storymapLayerOpacity` record.
+ * @param layerId Store layer id.
+ */
+export function isStoryHiddenLayer(
+  opacities: Record<string, number> | undefined,
+  layerId: string,
+): boolean {
+  return storyLayerOpacityFactor(opacities, layerId) === 0;
+}
+
+/**
+ * The layers a reader can currently see during a story presentation: the
+ * input minus those the active chapter has faded fully out. Outside a
+ * presentation the input is returned as-is (same array identity).
+ *
+ * @param layers Store layers in panel order.
+ * @param presenting The store's `ui.storymapPresenting` flag.
+ * @param opacities The store's `ui.storymapLayerOpacity` record.
+ */
+export function storyVisibleLayers(
+  layers: GeoLibreLayer[],
+  presenting: boolean,
+  opacities: Record<string, number> | undefined,
+): GeoLibreLayer[] {
+  if (!presenting) return layers;
+  if (!layers.some((layer) => isStoryHiddenLayer(opacities, layer.id))) return layers;
+  return layers.filter((layer) => !isStoryHiddenLayer(opacities, layer.id));
+}

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -6,9 +6,10 @@ import {
   getRegionalBasemapByStyleUrl,
   isRegionalBasemapSentinel,
   PLANETARY_BASEMAP_SENTINEL_PREFIX,
-  type RegionalBasemap,
   scaleAltitudeToActiveBody,
+  styleValue,
   useAppStore,
+  type RegionalBasemap,
 } from "@geolibre/core";
 import type {
   GeoLibreLayer,
@@ -159,12 +160,8 @@ function storyPaintOpacity(
     (nativeId === generatorFillLayerId(layer.id) && prop === "fill-opacity") ||
     (nativeId === generatorCircleLayerId(layer.id) && prop === "circle-opacity");
   if (!isGeneratorFill) return opacity;
-  const generatorOpacity = layer.style.geometryGeneratorOpacity;
-  const factor =
-    typeof generatorOpacity === "number" && Number.isFinite(generatorOpacity)
-      ? Math.min(1, Math.max(0, generatorOpacity))
-      : 1;
-  return opacity * factor;
+  const generatorOpacity = styleValue(layer.style, "geometryGeneratorOpacity");
+  return opacity * Math.min(1, Math.max(0, generatorOpacity));
 }
 const TERRAIN_SOURCE_ID = "geolibre-terrain-dem";
 const DEFAULT_TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -31,13 +31,18 @@ import {
   clusterLayerId,
   fillExtrusionLayerId,
   fillLayerId,
+  generatorCircleLayerId,
+  generatorFillLayerId,
+  generatorLineLayerId,
   getLayerBounds,
   heatmapLayerId,
   highlightCircleLayerId,
   highlightFillLayerId,
   highlightLineLayerId,
   highlightSourceId,
+  invertedFillLayerId,
   labelLayerId,
+  lineDecorationLayerId,
   lineLayerId,
   markerLayerId,
   sourceId,
@@ -135,6 +140,32 @@ const OPACITY_PAINT_PROPERTIES: Record<string, string[]> = {
   raster: ["raster-opacity"],
   symbol: ["icon-opacity", "text-opacity"],
 };
+
+/**
+ * The paint value a story fade writes for one property of one style layer.
+ *
+ * Fades write absolute opacities, but the geometry generator's fill/circle
+ * opacity is the product of the layer opacity and the style's own
+ * `geometryGeneratorOpacity` (see `applyGeometryGeneratorLayers`), so a fade
+ * back to 1 must not promote a translucent buffer to solid.
+ */
+function storyPaintOpacity(
+  layer: GeoLibreLayer,
+  nativeId: string,
+  prop: string,
+  opacity: number,
+): number {
+  const isGeneratorFill =
+    (nativeId === generatorFillLayerId(layer.id) && prop === "fill-opacity") ||
+    (nativeId === generatorCircleLayerId(layer.id) && prop === "circle-opacity");
+  if (!isGeneratorFill) return opacity;
+  const generatorOpacity = layer.style.geometryGeneratorOpacity;
+  const factor =
+    typeof generatorOpacity === "number" && Number.isFinite(generatorOpacity)
+      ? Math.min(1, Math.max(0, generatorOpacity))
+      : 1;
+  return opacity * factor;
+}
 const TERRAIN_SOURCE_ID = "geolibre-terrain-dem";
 const DEFAULT_TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   type: "raster-dem",
@@ -782,8 +813,10 @@ export class MapController implements MapEngine {
    */
   setStoryLayerOpacity(layerId: string, opacity: number, durationMs?: number): void {
     if (!this.map) return;
+    const layer = this.syncedLayers.find((item) => item.id === layerId);
+    if (!layer) return;
     const clamped = Math.min(1, Math.max(0, opacity));
-    for (const nativeId of this.getNativeLayerIdsByLayerId(layerId)) {
+    for (const nativeId of this.getStoryStyleLayerIds(layer)) {
       const styleLayer = this.map.getLayer(nativeId);
       if (!styleLayer) continue;
       const props = OPACITY_PAINT_PROPERTIES[styleLayer.type] ?? [];
@@ -793,9 +826,39 @@ export class MapController implements MapEngine {
             duration: durationMs,
           });
         }
-        setDynamicPaintProperty(this.map, nativeId, prop, clamped);
+        setDynamicPaintProperty(
+          this.map,
+          nativeId,
+          prop,
+          storyPaintOpacity(layer, nativeId, prop, clamped),
+        );
       }
     }
+  }
+
+  /**
+   * Every MapLibre style layer a story fade must reach for a project layer:
+   * its primary render layers plus the companion symbology `syncLayers` draws
+   * beside them (inverted fill, line decorations, geometry-generator output).
+   * The companions are internal (`geolibre:internal`) and so deliberately
+   * absent from {@link getCandidateStyleLayers}, which feeds identify and the
+   * layer control; without them a chapter that fades a layer out leaves its
+   * centroids or buffers on screen (discussion #2326).
+   */
+  private getStoryStyleLayerIds(layer: GeoLibreLayer): string[] {
+    const ids = this.getNativeLayerIds(layer);
+    if (layer.type !== "geojson") return ids;
+    const seen = new Set(ids);
+    for (const id of [
+      invertedFillLayerId(layer.id),
+      lineDecorationLayerId(layer.id),
+      generatorFillLayerId(layer.id),
+      generatorLineLayerId(layer.id),
+      generatorCircleLayerId(layer.id),
+    ]) {
+      if (!seen.has(id) && this.map?.getLayer(id)) ids.push(id);
+    }
+    return ids;
   }
 
   /**
@@ -815,7 +878,7 @@ export class MapController implements MapEngine {
     // restored values animate back in (potentially over a multi-second fade).
     if (this.map) {
       for (const layer of this.syncedLayers) {
-        for (const nativeId of this.getNativeLayerIdsByLayerId(layer.id)) {
+        for (const nativeId of this.getStoryStyleLayerIds(layer)) {
           const styleLayer = this.map.getLayer(nativeId);
           if (!styleLayer) continue;
           for (const prop of OPACITY_PAINT_PROPERTIES[styleLayer.type] ?? []) {

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -1,4 +1,9 @@
-import { type GeoLibreLayer, styleValue, useAppStore } from "@geolibre/core";
+import {
+  applyStoryLayerOpacity,
+  type GeoLibreLayer,
+  styleValue,
+  useAppStore,
+} from "@geolibre/core";
 import type { Layer } from "@deck.gl/core";
 import type { GeoLibreAppAPI, GeoLibreDeckGL } from "../../types";
 import { ensureMercatorProjection } from "../map-projection-utils";
@@ -86,7 +91,14 @@ async function runEnsureDeckVizOverlay(app: GeoLibreAppAPI): Promise<void> {
   // supplies the "deckviz" layer list.
   await ensureSharedDeckOverlay(app);
   storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
-    if (state.layers !== previous.layers) renderDeckVizLayers();
+    // Story playback fades layers outside the store's `layers` (see
+    // `ui.storymapLayerOpacity`), so those fades rebuild the overlay too.
+    if (
+      state.layers !== previous.layers ||
+      state.ui.storymapLayerOpacity !== previous.ui.storymapLayerOpacity
+    ) {
+      renderDeckVizLayers();
+    }
   });
   renderDeckVizLayers();
 }
@@ -129,7 +141,14 @@ function syncViewListeners(target: ViewListenerMap | null): void {
 function renderDeckVizLayers(): void {
   if (!deckGL || !appRef) return;
 
-  const storeLayers = useAppStore.getState().layers;
+  const state = useAppStore.getState();
+  // Fold the active story presentation's fades into each layer's opacity so
+  // diagrams and 3D geometry follow a chapter like the MapLibre layers do
+  // (discussion #2326). Untouched layers keep their identity, so the
+  // FeatureCollection-keyed atlas/elevation caches still hit.
+  const storeLayers = state.layers.map((layer) =>
+    applyStoryLayerOpacity(layer, state.ui.storymapLayerOpacity),
+  );
   const vizLayers = storeLayers.filter(isDeckVizLayer);
   const diagramLayers = storeLayers.filter((layer) => layer.visible && isDiagramLayer(layer));
   const hasRenderableLayers =
@@ -177,7 +196,9 @@ function renderDeckVizLayers(): void {
   // them.
   const deckLayers: Layer[] = [];
   for (const layer of storeLayers) {
-    if (!layer.visible) continue;
+    // A layer a chapter has faded fully out has nothing to draw; skipping it
+    // also spares the diagram declutter pass for the hidden layer.
+    if (!layer.visible || layer.opacity <= 0) continue;
     const entry = contextById.get(layer.id);
     try {
       // Diagrams go first so the final reverse() puts them on top of the same

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -145,14 +145,22 @@ function renderDeckVizLayers(): void {
   // Fold the active story presentation's fades into each layer's opacity so
   // diagrams and 3D geometry follow a chapter like the MapLibre layers do
   // (discussion #2326). Untouched layers keep their identity, so the
-  // FeatureCollection-keyed atlas/elevation caches still hit.
-  const storeLayers = state.layers.map((layer) =>
-    applyStoryLayerOpacity(layer, state.ui.storymapLayerOpacity),
-  );
-  const vizLayers = storeLayers.filter(isDeckVizLayer);
-  const diagramLayers = storeLayers.filter((layer) => layer.visible && isDiagramLayer(layer));
+  // FeatureCollection-keyed atlas/elevation caches still hit; with no fades
+  // recorded (the common case, including every animation frame outside a
+  // presentation) the store array is used as-is rather than copied.
+  const storyOpacity = state.ui.storymapLayerOpacity;
+  const storeLayers =
+    Object.keys(storyOpacity).length === 0
+      ? state.layers
+      : state.layers.map((layer) => applyStoryLayerOpacity(layer, storyOpacity));
+  // A hidden or fully faded layer has nothing to draw, so it is left out of
+  // every decision below: it must not keep the animation loop, the Mercator
+  // projection, or the diagram view listeners alive on its own.
+  const renderableLayers = storeLayers.filter((layer) => layer.visible && layer.opacity > 0);
+  const vizLayers = renderableLayers.filter(isDeckVizLayer);
+  const diagramLayers = renderableLayers.filter(isDiagramLayer);
   const hasRenderableLayers =
-    vizLayers.length > 0 || diagramLayers.length > 0 || storeLayers.some(isElevation3dLayer);
+    vizLayers.length > 0 || diagramLayers.length > 0 || renderableLayers.some(isElevation3dLayer);
 
   if (!hasRenderableLayers) {
     setSharedDeckLayers("deckviz", []);
@@ -167,7 +175,6 @@ function renderDeckVizLayers(): void {
   ensureMercatorProjection(appRef.getMap?.());
 
   const contexts = vizLayers
-    .filter((layer) => layer.visible)
     .map((layer) => buildContext(layer))
     .filter((entry): entry is RenderEntry => entry !== null);
 
@@ -195,10 +202,7 @@ function renderDeckVizLayers(): void {
   // layers, and feature diagrams interleave exactly as the Layers panel shows
   // them.
   const deckLayers: Layer[] = [];
-  for (const layer of storeLayers) {
-    // A layer a chapter has faded fully out has nothing to draw; skipping it
-    // also spares the diagram declutter pass for the hidden layer.
-    if (!layer.visible || layer.opacity <= 0) continue;
+  for (const layer of renderableLayers) {
     const entry = contextById.get(layer.id);
     try {
       // Diagrams go first so the final reverse() puts them on top of the same

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1716,6 +1716,92 @@ describe("MapController story-map layer helpers", () => {
     assert.equal(paint["raster-opacity"], 0.4);
     assert.equal(paint["raster-opacity-transition"], undefined);
   });
+
+  // A polygon layer whose style draws centroids through the geometry
+  // generator: the companion circle layer is internal (not a candidate style
+  // layer) yet must still follow story fades (discussion #2326).
+  function centroidPolygonLayer(id: string, style: Partial<LayerStyle> = {}): GeoLibreLayer {
+    return pointLayer(
+      id,
+      {
+        geojson: {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              properties: {},
+              geometry: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [0, 0],
+                    [1, 0],
+                    [1, 1],
+                    [0, 1],
+                    [0, 0],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      },
+      { geometryGenerator: "centroid", geometryGeneratorOpacity: 0.5, ...style },
+    );
+  }
+
+  it("setStoryLayerOpacity fades geometry-generator companion layers with the layer", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    controller.syncLayers([centroidPolygonLayer("a")]);
+    assert.ok(fake.layers.get("layer-a-generator-circle"), "centroid layer synced");
+
+    controller.setStoryLayerOpacity("a", 0, 400);
+
+    const paint = fake.layers.get("layer-a-generator-circle")?.paint as Record<string, unknown>;
+    assert.equal(paint["circle-opacity"], 0);
+    assert.equal(paint["circle-stroke-opacity"], 0);
+    assert.deepEqual(paint["circle-opacity-transition"], { duration: 400 });
+    // The primary fill still fades too.
+    const fill = fake.layers.get("layer-a-fill")?.paint as Record<string, unknown>;
+    assert.equal(fill["fill-opacity"], 0);
+  });
+
+  it("setStoryLayerOpacity keeps the generator's own translucency when fading back in", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    controller.syncLayers([centroidPolygonLayer("a")]);
+
+    controller.setStoryLayerOpacity("a", 1);
+
+    const paint = fake.layers.get("layer-a-generator-circle")?.paint as Record<string, unknown>;
+    // circle-opacity = story opacity x geometryGeneratorOpacity; the stroke
+    // follows the plain layer opacity, as in applyGeometryGeneratorLayers.
+    assert.equal(paint["circle-opacity"], 0.5);
+    assert.equal(paint["circle-stroke-opacity"], 1);
+  });
+
+  it("restoreLayerStyles clears companion-layer transitions before re-syncing", () => {
+    const { map, fake } = makeFakeMap();
+    // restoreLayerStyles halts any in-flight story camera move first.
+    (map as unknown as { stop: () => void }).stop = () => {};
+    const controller = controllerWith(map);
+    controller.syncLayers([centroidPolygonLayer("a")]);
+    controller.setStoryLayerOpacity("a", 0, 3000);
+
+    controller.restoreLayerStyles();
+
+    const transition = fake.calls.find(
+      (c) =>
+        c.method === "setPaintProperty" &&
+        c.args[0] === "layer-a-generator-circle" &&
+        c.args[1] === "circle-opacity-transition" &&
+        JSON.stringify(c.args[2]) === JSON.stringify({ duration: 0 }),
+    );
+    assert.ok(transition, "companion transition reset to 0 so the restore does not animate");
+    const paint = fake.layers.get("layer-a-generator-circle")?.paint as Record<string, unknown>;
+    assert.equal(paint["circle-opacity"], 0.5);
+  });
 });
 
 // A DOM stub just rich enough for TerrainControl.onAdd, which the fake map's

--- a/tests/storymap-playback.test.ts
+++ b/tests/storymap-playback.test.ts
@@ -79,13 +79,24 @@ describe("store storymapLayerOpacity", () => {
     assert.deepEqual(useAppStore.getState().ui.storymapLayerOpacity, { a: 0, b: 0.5, c: 0 });
   });
 
-  it("keeps the record identity when a write changes nothing", () => {
+  it("keeps the record identity and stays silent when a write changes nothing", () => {
     const store = useAppStore.getState();
     store.setStorymapLayerOpacity({ a: 0.5 });
     const before = useAppStore.getState().ui.storymapLayerOpacity;
-    store.setStorymapLayerOpacity({ a: 0.5 });
-    store.setStorymapLayerOpacity({});
+    let notifications = 0;
+    const unsubscribe = useAppStore.subscribe(() => {
+      notifications += 1;
+    });
+    try {
+      store.setStorymapLayerOpacity({ a: 0.5 });
+      store.setStorymapLayerOpacity({});
+    } finally {
+      unsubscribe();
+    }
     assert.equal(useAppStore.getState().ui.storymapLayerOpacity, before);
+    // Subscribers (the deck overlay, the Legend panel) must not rebuild for a
+    // no-op write.
+    assert.equal(notifications, 0);
   });
 
   it("resets when a presentation starts or ends", () => {

--- a/tests/storymap-playback.test.ts
+++ b/tests/storymap-playback.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  applyStoryLayerOpacity,
+  createEmptyProject,
+  DEFAULT_LAYER_STYLE,
+  isStoryHiddenLayer,
+  parseProject,
+  serializeProject,
+  storyLayerOpacityFactor,
+  storyVisibleLayers,
+  useAppStore,
+  type GeoLibreLayer,
+} from "../packages/core/src/index";
+
+function layer(id: string, opacity = 1): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: { type: "FeatureCollection", features: [] },
+  };
+}
+
+describe("storymap playback helpers", () => {
+  it("storyLayerOpacityFactor defaults to 1 and clamps recorded values", () => {
+    assert.equal(storyLayerOpacityFactor(undefined, "a"), 1);
+    assert.equal(storyLayerOpacityFactor({}, "a"), 1);
+    assert.equal(storyLayerOpacityFactor({ a: 0.25 }, "a"), 0.25);
+    assert.equal(storyLayerOpacityFactor({ a: 4 }, "a"), 1);
+    assert.equal(storyLayerOpacityFactor({ a: -1 }, "a"), 0);
+    assert.equal(storyLayerOpacityFactor({ a: Number.NaN }, "a"), 1);
+  });
+
+  it("applyStoryLayerOpacity multiplies the store opacity and keeps identity when untouched", () => {
+    const base = layer("a", 0.8);
+    assert.equal(applyStoryLayerOpacity(base, {}), base);
+    assert.equal(applyStoryLayerOpacity(base, { b: 0 }), base);
+    const faded = applyStoryLayerOpacity(base, { a: 0.5 });
+    assert.notEqual(faded, base);
+    assert.equal(faded.opacity, 0.4);
+    // The feature collection is shared, so FeatureCollection-keyed caches hit.
+    assert.equal(faded.geojson, base.geojson);
+  });
+
+  it("isStoryHiddenLayer is true only for a full fade-out", () => {
+    assert.equal(isStoryHiddenLayer({ a: 0 }, "a"), true);
+    assert.equal(isStoryHiddenLayer({ a: 0.01 }, "a"), false);
+    assert.equal(isStoryHiddenLayer({}, "a"), false);
+  });
+
+  it("storyVisibleLayers drops faded-out layers only while presenting", () => {
+    const layers = [layer("a"), layer("b"), layer("c")];
+    const opacities = { a: 0, b: 0.3 };
+    assert.equal(storyVisibleLayers(layers, false, opacities), layers);
+    assert.equal(storyVisibleLayers(layers, true, {}), layers);
+    assert.deepEqual(
+      storyVisibleLayers(layers, true, opacities).map((item) => item.id),
+      ["b", "c"],
+    );
+  });
+});
+
+describe("store storymapLayerOpacity", () => {
+  beforeEach(() => {
+    useAppStore.getState().setStorymapPresenting(false);
+  });
+
+  it("merges chapter fades and clamps them", () => {
+    const store = useAppStore.getState();
+    store.setStorymapPresenting(true);
+    store.setStorymapLayerOpacity({ a: 0, b: 2 });
+    store.setStorymapLayerOpacity({ b: 0.5, c: -1 });
+    assert.deepEqual(useAppStore.getState().ui.storymapLayerOpacity, { a: 0, b: 0.5, c: 0 });
+  });
+
+  it("keeps the record identity when a write changes nothing", () => {
+    const store = useAppStore.getState();
+    store.setStorymapLayerOpacity({ a: 0.5 });
+    const before = useAppStore.getState().ui.storymapLayerOpacity;
+    store.setStorymapLayerOpacity({ a: 0.5 });
+    store.setStorymapLayerOpacity({});
+    assert.equal(useAppStore.getState().ui.storymapLayerOpacity, before);
+  });
+
+  it("resets when a presentation starts or ends", () => {
+    const store = useAppStore.getState();
+    store.setStorymapLayerOpacity({ a: 0 });
+    store.setStorymapPresenting(true);
+    assert.deepEqual(useAppStore.getState().ui.storymapLayerOpacity, {});
+    store.setStorymapLayerOpacity({ a: 0 });
+    store.setStorymapPresenting(false);
+    assert.deepEqual(useAppStore.getState().ui.storymapLayerOpacity, {});
+  });
+
+  it("does not carry fades into a newly loaded project", () => {
+    const store = useAppStore.getState();
+    store.setStorymapLayerOpacity({ a: 0 });
+    useAppStore.getState().loadProject(parseProject(serializeProject(createEmptyProject("Plain"))));
+    assert.deepEqual(useAppStore.getState().ui.storymapLayerOpacity, {});
+  });
+});

--- a/tests/storymap-playback.test.ts
+++ b/tests/storymap-playback.test.ts
@@ -37,13 +37,18 @@ describe("storymap playback helpers", () => {
     assert.equal(storyLayerOpacityFactor({ a: Number.NaN }, "a"), 1);
   });
 
-  it("applyStoryLayerOpacity multiplies the store opacity and keeps identity when untouched", () => {
+  it("applyStoryLayerOpacity replaces the store opacity and keeps identity when untouched", () => {
     const base = layer("a", 0.8);
     assert.equal(applyStoryLayerOpacity(base, {}), base);
     assert.equal(applyStoryLayerOpacity(base, { b: 0 }), base);
+    // Same value as the layer already has: no copy needed.
+    assert.equal(applyStoryLayerOpacity(base, { a: 0.8 }), base);
     const faded = applyStoryLayerOpacity(base, { a: 0.5 });
     assert.notEqual(faded, base);
-    assert.equal(faded.opacity, 0.4);
+    // Absolute, like the MapLibre paint path, not 0.8 x 0.5.
+    assert.equal(faded.opacity, 0.5);
+    // A chapter fading back to 1 also overrides a translucent base opacity.
+    assert.equal(applyStoryLayerOpacity(base, { a: 1 }).opacity, 1);
     // The feature collection is shared, so FeatureCollection-keyed caches hit.
     assert.equal(faded.geojson, base.geojson);
   });


### PR DESCRIPTION
## Summary

Addresses the three points raised in discussion #2326 about story maps.

**Companion symbology and diagrams stayed on screen after a chapter faded a layer out.** `setStoryLayerOpacity` walked the candidate style layers only, which deliberately exclude the internal companion layers (`geolibre:internal`), so geometry-generator output (centroids, buffers, hulls, bounding boxes), the inverted fill, and line decorations kept rendering. Feature diagrams (pie, donut, bar) are a deck.gl overlay that reads opacity from the store, which playback never touches, so they never faded at all.

**The legend now follows the chapters.** Layers the current chapter has faded fully out drop from the on-map Legend panel while presenting, so the reader only sees the symbology that is on screen.

**Pressing Escape to leave a presentation closed the Legend panel.** The presenter listened for Escape on `window` in the bubble phase, after the Legend panel's own document-level Escape-to-close handler had already run. The presenter now owns Escape in the capture phase while presenting (an Escape aimed at an open dialog or menu is left alone).

## Changes

- `MapController`: story fades and the exit-time transition reset reach the companion style layers; the generator fill/circle opacity is scaled by `geometryGeneratorOpacity` so fading back to 1 does not promote a translucent buffer to solid.
- Store: transient `ui.storymapLayerOpacity` (never saved with the project) records the fades a presentation has applied; cleared when a presentation starts or ends and on project load. The presenter commits each chapter's replayed effects in one write.
- `@geolibre/core`: small `storymap-playback` helpers (`applyStoryLayerOpacity`, `storyVisibleLayers`, ...) shared by the deck overlay and the Legend panel.
- Deck overlay: folds the record into layer opacity so diagrams and 3D Z-value geometry follow the chapter; a fully faded layer is skipped.
- Legend panel: filters presenting layers through `storyVisibleLayers`.
- Presenter: capture-phase Escape handling.

## Verification

- New tests: `tests/storymap-playback.test.ts` (helpers + store action), plus three `MapController` cases covering the generator companion fade, the generator opacity scaling, and the exit-time transition reset. Full frontend suite green, `npm run build` green.
- Manually in the real web app with a 176-country polygon layer styled with pie diagrams and centroid generators, a three-chapter story (visible, faded out, visible again) and the Legend panel open, in both light and dark themes:
  - Before: chapter 2 hid the fills but the pies and centroid dots stayed; Escape exited the story and also closed the Legend.
  - After: chapter 2 hides pies, centroids, and the layer's legend entry; chapter 3 brings them all back; Escape exits and the Legend stays open.

## Not in this PR

Story fades write absolute paint opacities for the primary layers, so a fade back to 1 renders a translucent fill (e.g. `fillOpacity: 0.3`) as solid until the presentation exits. That predates this change and is worth its own fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story presentations now smoothly fade map layers and associated symbology, including generated geometry and decorations.
  * Fully faded layers are hidden from the map legend and visualizations during presentations.
  * Layer opacity is preserved and restored correctly when navigating between story chapters.

* **Bug Fixes**
  * Escape no longer interrupts presentations when pressed inside dialogs, menus, listboxes, comboboxes, or editable fields.
  * Opacity changes now update map overlays consistently and retain intended transparency after fades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->