### PR TITLE
Fix desktop ArcGIS feature downloads through native HTTP

### DIFF
--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -38,7 +38,7 @@
       "allow": [{ "url": "http://*" }, { "url": "https://*" }]
     },
     {
-      "comment": "Hosts routed through the native HTTP client to bypass WebView network restrictions. The sidecar adapter routes only the GeoLibre sidecar port (lib/sidecar-fetch.ts). Geocoding, Share, and GeoLens use the remaining HTTPS hosts; keep those scopes in sync with their fetch adapters. ArcGIS REST services and portals are user-selected HTTP(S) URLs, including custom reverse-proxy paths, so their native downloads require the wildcard entries. GeoLens custom/self-hosted services still use browser fetch.",
+      "comment": "Hosts routed through the native HTTP client to bypass WebView network restrictions. The loopback scope is only the GeoLibre sidecar port (lib/sidecar-fetch.ts). Geocoding, Share, and GeoLens use the remaining HTTPS hosts; keep those scopes in sync with their fetch adapters. Any custom/self-hosted service falls back to browser fetch.",
       "identifier": "http:default",
       "allow": [
         { "url": "http://127.0.0.1:8765/*" },
@@ -49,9 +49,7 @@
         { "url": "https://maps.googleapis.com/*" },
         { "url": "https://www.cartociudad.es/*" },
         { "url": "https://share.geolibre.app/*" },
-        { "url": "https://datasets.geolibre.app/*" },
-        { "url": "http://*/*" },
-        { "url": "https://*/*" }
+        { "url": "https://datasets.geolibre.app/*" }
       ]
     }
   ]

--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -38,7 +38,7 @@
       "allow": [{ "url": "http://*" }, { "url": "https://*" }]
     },
     {
-      "comment": "Hosts routed through the native HTTP client to bypass WebView network restrictions. The loopback scope is only the GeoLibre sidecar port (lib/sidecar-fetch.ts). Geocoding, Share, and GeoLens use the remaining HTTPS hosts; keep those scopes in sync with their fetch adapters. Any custom/self-hosted service falls back to browser fetch.",
+      "comment": "Hosts routed through the native HTTP client to bypass WebView network restrictions. The sidecar adapter routes only the GeoLibre sidecar port (lib/sidecar-fetch.ts). Geocoding, Share, and GeoLens use the remaining HTTPS hosts; keep those scopes in sync with their fetch adapters. ArcGIS REST services and portals are user-selected HTTP(S) URLs, including custom reverse-proxy paths, so their native downloads require the wildcard entries. GeoLens custom/self-hosted services still use browser fetch.",
       "identifier": "http:default",
       "allow": [
         { "url": "http://127.0.0.1:8765/*" },
@@ -49,7 +49,9 @@
         { "url": "https://maps.googleapis.com/*" },
         { "url": "https://www.cartociudad.es/*" },
         { "url": "https://share.geolibre.app/*" },
-        { "url": "https://datasets.geolibre.app/*" }
+        { "url": "https://datasets.geolibre.app/*" },
+        { "url": "http://*/*" },
+        { "url": "https://*/*" }
       ]
     }
   ]

--- a/apps/geolibre-desktop/src-tauri/src/arcgis_http.rs
+++ b/apps/geolibre-desktop/src-tauri/src/arcgis_http.rs
@@ -1,0 +1,128 @@
+//! ArcGIS REST transport, separate from the host-scoped HTTP plugin.
+
+use std::time::Duration;
+
+use reqwest::{redirect::Policy, Url};
+use serde::Serialize;
+
+use super::{build_guarded_http_client_with_redirects, url_is_fetchable};
+
+#[derive(Serialize)]
+pub(crate) struct ArcGISResponse {
+    status: u16,
+    body: String,
+}
+
+fn has_token(url: &Url) -> bool {
+    url.query_pairs()
+        .any(|(key, value)| key == "token" && !value.is_empty())
+}
+
+fn validate_url(url: &Url) -> Result<(), String> {
+    if has_token(url) && url.scheme() != "https" {
+        return Err("ArcGIS access tokens require HTTPS.".into());
+    }
+    url_is_fetchable(url)
+}
+
+fn validate_redirect(previous: &[Url], target: &Url) -> Result<(), String> {
+    if let Some(authenticated) = previous.iter().find(|url| has_token(url)) {
+        if target.scheme() != "https" || target.origin() != authenticated.origin() {
+            return Err(
+                "Authenticated ArcGIS redirects must stay on the same HTTPS origin.".into(),
+            );
+        }
+    }
+    validate_url(target)
+}
+
+fn client() -> Result<reqwest::blocking::Client, String> {
+    static CLIENT: std::sync::OnceLock<Result<reqwest::blocking::Client, String>> =
+        std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            build_guarded_http_client_with_redirects(Policy::custom(|attempt| {
+                if attempt.previous().len() >= 10 {
+                    return attempt.error("Too many ArcGIS redirects.");
+                }
+                match validate_redirect(attempt.previous(), attempt.url()) {
+                    Ok(()) => attempt.follow(),
+                    Err(error) => attempt.error(error),
+                }
+            }))
+        })
+        .clone()
+}
+
+/// GET-only command with the existing native address/DNS and enterprise TLS guards.
+/// Returns HTTP status separately so ArcGIS retry and service-error handling survive IPC.
+#[tauri::command]
+pub(crate) async fn fetch_arcgis_response(url: String) -> Result<ArcGISResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let url = Url::parse(&url).map_err(|_| "Invalid ArcGIS URL.".to_string())?;
+        validate_url(&url)?;
+        let response = client()?
+            .get(url)
+            .timeout(Duration::from_secs(120))
+            .send()
+            // reqwest's display includes the URL, which may contain an access token.
+            .map_err(|error| format!("ArcGIS request failed: {}", error.without_url()))?;
+        let status = response.status().as_u16();
+        let body = response
+            .text()
+            .map_err(|error| format!("Could not read ArcGIS response: {}", error.without_url()))?;
+        Ok(ArcGISResponse { status, body })
+    })
+    .await
+    .map_err(|error| format!("ArcGIS request task failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_metadata_and_plaintext_tokens() {
+        assert!(
+            validate_url(&Url::parse("http://169.254.169.254/latest/meta-data").unwrap()).is_err()
+        );
+        assert!(validate_url(
+            &Url::parse("http://127.0.0.1/FeatureServer/0?token=secret").unwrap()
+        )
+        .is_err());
+        assert!(validate_url(&Url::parse("file:///etc/passwd").unwrap()).is_err());
+        assert!(validate_url(&Url::parse("http://127.0.0.1/FeatureServer/0").unwrap()).is_ok());
+    }
+
+    #[test]
+    fn allows_only_same_https_origin_for_authenticated_redirects() {
+        let previous = [Url::parse("https://127.0.0.1/old?token=secret").unwrap()];
+        assert!(validate_redirect(
+            &previous,
+            &Url::parse("https://127.0.0.1/new?token=secret").unwrap()
+        )
+        .is_ok());
+        for target in [
+            "http://127.0.0.1/new",
+            "https://127.0.0.2/new",
+            "https://127.0.0.1:444/new",
+        ] {
+            assert!(validate_redirect(&previous, &Url::parse(target).unwrap()).is_err());
+        }
+    }
+
+    #[test]
+    fn unauthenticated_redirects_still_enforce_address_guard() {
+        let previous = [Url::parse("http://127.0.0.1/FeatureServer/0").unwrap()];
+        assert!(validate_redirect(
+            &previous,
+            &Url::parse("http://169.254.169.254/latest/meta-data").unwrap()
+        )
+        .is_err());
+        assert!(validate_redirect(
+            &previous,
+            &Url::parse("http://127.0.0.2/FeatureServer/0").unwrap()
+        )
+        .is_ok());
+    }
+}

--- a/apps/geolibre-desktop/src-tauri/src/arcgis_http.rs
+++ b/apps/geolibre-desktop/src-tauri/src/arcgis_http.rs
@@ -1,11 +1,22 @@
 //! ArcGIS REST transport, separate from the host-scoped HTTP plugin.
 
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use reqwest::{redirect::Policy, Url};
 use serde::Serialize;
 
-use super::{build_guarded_http_client_with_redirects, url_is_fetchable};
+use super::{
+    client_identity, extra_ca_certificates, url_is_fetchable, ClientIdentity, GuardedDnsResolver,
+    MAX_HTTP_REDIRECTS,
+};
+
+const MAX_ARCGIS_BODY_BYTES: usize = 64 * 1024 * 1024;
+const BODY_TOO_LARGE: &str =
+    "ArcGIS response exceeds the 64 MiB limit. Reduce the records per request.";
 
 #[derive(Serialize)]
 pub(crate) struct ArcGISResponse {
@@ -36,45 +47,146 @@ fn validate_redirect(previous: &[Url], target: &Url) -> Result<(), String> {
     validate_url(target)
 }
 
-fn client() -> Result<reqwest::blocking::Client, String> {
-    static CLIENT: std::sync::OnceLock<Result<reqwest::blocking::Client, String>> =
+fn client() -> Result<reqwest::Client, String> {
+    static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> =
         std::sync::OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            build_guarded_http_client_with_redirects(Policy::custom(|attempt| {
-                if attempt.previous().len() >= 10 {
-                    return attempt.error("Too many ArcGIS redirects.");
+            let mut builder = reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(super::REMOTE_TILE_CONNECT_TIMEOUT_SECS))
+                .dns_resolver(Arc::new(GuardedDnsResolver))
+                .user_agent("GeoLibre Desktop")
+                .redirect(Policy::custom(|attempt| {
+                    if attempt.previous().len() >= MAX_HTTP_REDIRECTS {
+                        return attempt.error("Too many ArcGIS redirects.");
+                    }
+                    match validate_redirect(attempt.previous(), attempt.url()) {
+                        Ok(()) => attempt.follow(),
+                        Err(error) => attempt.error(error),
+                    }
+                }));
+            // Match the native download client's enterprise CA and mTLS settings.
+            for certificate in extra_ca_certificates()? {
+                builder = builder.add_root_certificate(certificate);
+            }
+            builder = match client_identity()? {
+                #[cfg(not(target_os = "android"))]
+                Some(ClientIdentity::Pkcs12(identity)) => {
+                    builder.use_native_tls().identity(identity)
                 }
-                match validate_redirect(attempt.previous(), attempt.url()) {
-                    Ok(()) => attempt.follow(),
-                    Err(error) => attempt.error(error),
-                }
-            }))
+                Some(ClientIdentity::Pem(identity)) => builder.use_rustls_tls().identity(identity),
+                None => builder.use_rustls_tls(),
+            };
+            builder
+                .build()
+                .map_err(|error| format!("Could not create ArcGIS HTTP client: {error}"))
         })
         .clone()
 }
 
-/// GET-only command with the existing native address/DNS and enterprise TLS guards.
-/// Returns HTTP status separately so ArcGIS retry and service-error handling survive IPC.
+type CancelRequest = Box<dyn Fn() + Send + Sync>;
+
+#[derive(Default, Clone)]
+pub(crate) struct ArcGISRequests(Arc<Mutex<HashMap<String, CancelRequest>>>);
+
+impl ArcGISRequests {
+    fn cancel(&self, id: &str) {
+        if let Some(cancel) = self.0.lock().unwrap().remove(id) {
+            cancel();
+        }
+    }
+}
+
+struct RequestGuard {
+    requests: ArcGISRequests,
+    id: String,
+}
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        self.requests.cancel(&self.id);
+    }
+}
+
 #[tauri::command]
-pub(crate) async fn fetch_arcgis_response(url: String) -> Result<ArcGISResponse, String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        let url = Url::parse(&url).map_err(|_| "Invalid ArcGIS URL.".to_string())?;
-        validate_url(&url)?;
-        let response = client()?
-            .get(url)
-            .timeout(Duration::from_secs(120))
-            .send()
-            // reqwest's display includes the URL, which may contain an access token.
-            .map_err(|error| format!("ArcGIS request failed: {}", error.without_url()))?;
-        let status = response.status().as_u16();
-        let body = response
-            .text()
-            .map_err(|error| format!("Could not read ArcGIS response: {}", error.without_url()))?;
-        Ok(ArcGISResponse { status, body })
+pub(crate) fn cancel_arcgis_request(
+    request_id: String,
+    requests: tauri::State<'_, ArcGISRequests>,
+) {
+    requests.cancel(&request_id);
+}
+
+async fn read_response(
+    mut response: reqwest::Response,
+    limit: usize,
+) -> Result<ArcGISResponse, String> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > limit as u64)
+    {
+        return Err(BODY_TOO_LARGE.into());
+    }
+    let status = response.status().as_u16();
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| format!("Could not read ArcGIS response: {}", error.without_url()))?
+    {
+        if chunk.len() > limit.saturating_sub(body.len()) {
+            return Err(BODY_TOO_LARGE.into());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    // ArcGIS JSON is UTF-8; match reqwest's replacement of malformed sequences.
+    Ok(ArcGISResponse {
+        status,
+        body: String::from_utf8_lossy(&body).into_owned(),
     })
-    .await
-    .map_err(|error| format!("ArcGIS request task failed: {error}"))?
+}
+
+async fn request(url: String) -> Result<ArcGISResponse, String> {
+    let url = Url::parse(&url).map_err(|_| "Invalid ArcGIS URL.".to_string())?;
+    let checked = url.clone();
+    tauri::async_runtime::spawn_blocking(move || validate_url(&checked))
+        .await
+        .map_err(|error| format!("ArcGIS validation failed: {error}"))??;
+    let response = client()?
+        .get(url)
+        .timeout(Duration::from_secs(120))
+        .send()
+        .await
+        .map_err(|error| format!("ArcGIS request failed: {}", error.without_url()))?;
+    read_response(response, MAX_ARCGIS_BODY_BYTES).await
+}
+
+/// Register cancellation before notifying the caller, so even an early abort
+/// stops the socket/body read. The guard also cleans up if the command is dropped.
+#[tauri::command]
+pub(crate) async fn fetch_arcgis_response(
+    url: String,
+    request_id: String,
+    ready: tauri::ipc::Channel<()>,
+    requests: tauri::State<'_, ArcGISRequests>,
+) -> Result<ArcGISResponse, String> {
+    let task = {
+        let mut active = requests.0.lock().unwrap();
+        if active.contains_key(&request_id) {
+            return Err("Duplicate ArcGIS request ID.".into());
+        }
+        let task = tauri::async_runtime::spawn(request(url));
+        let abort = task.inner().abort_handle();
+        active.insert(request_id.clone(), Box::new(move || abort.abort()));
+        task
+    };
+    let _guard = RequestGuard {
+        requests: requests.inner().clone(),
+        id: request_id,
+    };
+    ready
+        .send(())
+        .map_err(|_| "ArcGIS caller disconnected.".to_string())?;
+    task.await
+        .map_err(|_| "ArcGIS request cancelled.".to_string())?
 }
 
 #[cfg(test)]
@@ -124,5 +236,79 @@ mod tests {
             &Url::parse("http://127.0.0.2/FeatureServer/0").unwrap()
         )
         .is_ok());
+    }
+
+    fn serve(response: &'static [u8]) -> String {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/query", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 4096];
+            stream.read(&mut request).unwrap();
+            let _ = stream.write_all(response);
+        });
+        url
+    }
+
+    #[test]
+    fn bounds_advertised_and_chunked_bodies_before_decoding() {
+        tauri::async_runtime::block_on(async {
+            for response in [
+                b"HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\n".as_slice(),
+                b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n8\r\n12345678\r\n1\r\n9\r\n0\r\n\r\n".as_slice(),
+            ] {
+                let response = client().unwrap().get(serve(response)).send().await.unwrap();
+                assert!(matches!(read_response(response, 8).await, Err(error) if error == BODY_TOO_LARGE));
+            }
+            let response = client()
+                .unwrap()
+                .get(serve(
+                    b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 8\r\n\r\n12345678",
+                ))
+                .send()
+                .await
+                .unwrap();
+            let result = read_response(response, 8).await.unwrap();
+            assert_eq!(result.status, 503);
+            assert_eq!(result.body, "12345678");
+        });
+    }
+
+    #[test]
+    fn cancellation_closes_a_stalled_native_body_read() {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/query", listener.local_addr().unwrap());
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (closed_tx, closed_rx) = std::sync::mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut request = [0; 4096];
+            stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nx\r\n")
+                .unwrap();
+            started_tx.send(()).unwrap();
+            let result = stream.read(&mut request);
+            closed_tx.send(matches!(result, Ok(0)) || matches!(result, Err(ref error) if error.kind() == std::io::ErrorKind::ConnectionReset)).unwrap();
+        });
+        let task = tauri::async_runtime::spawn(request(url));
+        let abort = task.inner().abort_handle();
+        let requests = ArcGISRequests::default();
+        requests
+            .0
+            .lock()
+            .unwrap()
+            .insert("test".into(), Box::new(move || abort.abort()));
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        requests.cancel("test");
+        assert!(tauri::async_runtime::block_on(task).is_err());
+        assert!(closed_rx.recv_timeout(Duration::from_secs(5)).unwrap());
+        assert!(requests.0.lock().unwrap().is_empty());
+        server.join().unwrap();
     }
 }

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod arcgis_http;
 // Earth Engine sign-in uses Google's OAuth loopback-redirect flow, which binds
 // a listener on 127.0.0.1 to accept the browser's redirect. Accepting an
 // inbound connection requires the `com.apple.security.network.server`
@@ -414,6 +415,7 @@ pub fn run() {
             native_duckdb::count_native_vector_file_features,
             ensure_martin_binary,
             fetch_url_bytes,
+            arcgis_http::fetch_arcgis_response,
             install_external_plugin_archive,
             native_duckdb::load_native_vector_file,
             load_external_plugin_bundles,
@@ -1312,12 +1314,18 @@ fn guarded_http_client() -> Result<reqwest::blocking::Client, String> {
 }
 
 fn build_guarded_http_client() -> Result<reqwest::blocking::Client, String> {
+    build_guarded_http_client_with_redirects(guarded_redirect_policy())
+}
+
+fn build_guarded_http_client_with_redirects(
+    redirects: reqwest::redirect::Policy,
+) -> Result<reqwest::blocking::Client, String> {
     // The SSRF guard (GuardedDnsResolver + redirect re-validation) is applied
     // here, independent of the TLS backend chosen below, so it holds on both the
     // rustls and native-tls paths.
     let mut builder = reqwest::blocking::Client::builder()
         .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
-        .redirect(guarded_redirect_policy())
+        .redirect(redirects)
         .dns_resolver(std::sync::Arc::new(GuardedDnsResolver))
         .user_agent("GeoLibre Desktop");
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -196,6 +196,7 @@ const JUPYTER_HEALTH_ATTEMPTS: usize = 240;
 #[cfg(not(feature = "mas"))]
 const UV_INSTALL_BASE_URL: &str = "https://astral.sh/uv";
 const REMOTE_TILE_TIMEOUT_SECS: u64 = 8;
+const MAX_HTTP_REDIRECTS: usize = 10;
 const REMOTE_TILE_CONNECT_TIMEOUT_SECS: u64 = 4;
 const URL_RESOLVE_TIMEOUT_SECS: u64 = 15;
 /// Ceiling for a caller-supplied `fetch_url_bytes` budget. The default suits a
@@ -357,6 +358,7 @@ pub fn run() {
     let builder = builder
         .manage(pending_project_paths)
         .manage(SelectedImagePaths::default())
+        .manage(arcgis_http::ArcGISRequests::default())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         // Runs before persisted-scope's setup hook so legacy photo grants are
@@ -416,6 +418,7 @@ pub fn run() {
             ensure_martin_binary,
             fetch_url_bytes,
             arcgis_http::fetch_arcgis_response,
+            arcgis_http::cancel_arcgis_request,
             install_external_plugin_archive,
             native_duckdb::load_native_vector_file,
             load_external_plugin_bundles,
@@ -1099,7 +1102,7 @@ fn ensure_fetchable_url(url: &str) -> Result<(), String> {
 /// and must not be reported as one.
 fn guarded_redirect_policy() -> reqwest::redirect::Policy {
     reqwest::redirect::Policy::custom(|attempt| {
-        if attempt.previous().len() >= 10 {
+        if attempt.previous().len() >= MAX_HTTP_REDIRECTS {
             return attempt.stop();
         }
         match url_is_fetchable(attempt.url()) {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -15,6 +15,7 @@ import { ListTree, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createAppAPI } from "../../../../hooks/usePlugins";
+import { serviceRequestErrorMessage } from "../helpers";
 import { DEFAULT_ARCGIS_URLS } from "../constants";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import { serviceFieldString, type ServiceFields } from "../service-library";
@@ -267,6 +268,10 @@ export function ArcGISSource({ initialUrl = "" }: { initialUrl?: string }) {
         sublayers: arcgisSublayers.trim() || undefined,
         token: arcgisAccessToken.trim() || undefined,
         url: arcgisUrl.trim() || undefined,
+      });
+    } catch (error) {
+      throw new Error(serviceRequestErrorMessage(error, t, t("addData.shared.addError")), {
+        cause: error,
       });
     } finally {
       setProgress(null);

--- a/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
@@ -1,21 +1,30 @@
+import type { Channel, invoke as nativeInvoke } from "@tauri-apps/api/core";
+
 interface ArcGISResponse {
   status: number;
   body: string;
 }
 
-type ArcGISRequest = (url: string) => Promise<ArcGISResponse>;
+type ArcGISRequest = (url: string, signal?: AbortSignal | null) => Promise<ArcGISResponse>;
 
 /** Adapt the guarded GET-only Rust command to ArcGIS's fetch transport. */
 export function createNativeArcGISFetch(request: ArcGISRequest): typeof globalThis.fetch {
   return async (input, init) => {
+    const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    const body = init?.body ?? (input instanceof Request ? input.body : null);
+    if (method.toUpperCase() !== "GET" || body != null || [...headers].length > 0) {
+      throw new Error("Native ArcGIS fetch only supports GET without headers or a body.");
+    }
     const url = input instanceof Request ? input.url : input.toString();
     const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
     signal?.throwIfAborted();
     let onAbort: (() => void) | undefined;
     try {
-      // The blocking Rust request has a 120-second deadline. Cancellation ends
-      // the caller's wait immediately; late native results are discarded.
-      const pending = request(url);
+      // Reject promptly while the native cancellation acknowledgement is in flight.
+      const pending = request(url, signal);
       const result = signal
         ? await Promise.race([
             pending,
@@ -38,11 +47,39 @@ export function createNativeArcGISFetch(request: ArcGISRequest): typeof globalTh
   };
 }
 
+/** Coordinate native cancellation, including aborts before Rust registers the request. */
+export function createArcGISRequest(
+  invoke: typeof nativeInvoke,
+  createReady: () => Pick<Channel<void>, "onmessage">,
+): ArcGISRequest {
+  return async (url, signal) => {
+    signal?.throwIfAborted();
+    const requestId = crypto.randomUUID();
+    const ready = createReady();
+    let registered = false;
+    const onAbort = () => {
+      if (registered) {
+        void invoke("cancel_arcgis_request", { requestId }).catch((error: unknown) => {
+          console.error("[GeoLibre] Failed to cancel native ArcGIS request", error);
+        });
+      }
+    };
+    ready.onmessage = () => {
+      registered = true;
+      if (signal?.aborted) onAbort();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      return await invoke<ArcGISResponse>("fetch_arcgis_response", { url, requestId, ready });
+    } finally {
+      signal?.removeEventListener("abort", onAbort);
+    }
+  };
+}
+
 /** Install before project restoration so every ArcGIS REST request uses Rust. */
 export async function installNativeArcGISFetch(): Promise<void> {
   const { setArcGISFetch } = await import("@geolibre/plugins");
-  const { invoke } = await import("@tauri-apps/api/core");
-  setArcGISFetch(
-    createNativeArcGISFetch((url) => invoke<ArcGISResponse>("fetch_arcgis_response", { url })),
-  );
+  const { invoke, Channel } = await import("@tauri-apps/api/core");
+  setArcGISFetch(createNativeArcGISFetch(createArcGISRequest(invoke, () => new Channel<void>())));
 }

--- a/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
@@ -1,0 +1,7 @@
+import { setArcGISFetch } from "@geolibre/plugins";
+
+/** Route desktop ArcGIS REST downloads through Rust, outside WebView CORS. */
+export async function installNativeArcGISFetch(): Promise<void> {
+  const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+  setArcGISFetch(tauriFetch);
+}

--- a/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
@@ -1,7 +1,23 @@
-import { setArcGISFetch } from "@geolibre/plugins";
+import type { fetch as nativeFetch } from "@tauri-apps/plugin-http";
+
+/** Protect ArcGIS tokens from plaintext requests and automatic redirect downgrades. */
+export function createNativeArcGISFetch(fetchImpl: typeof nativeFetch): typeof globalThis.fetch {
+  return (input, init) => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    const authenticated = Boolean(url.searchParams.get("token"));
+    if (authenticated && url.protocol !== "https:") {
+      return Promise.reject(new Error("ArcGIS access tokens require HTTPS."));
+    }
+    // Tauri's native client can follow redirects outside the original URL's
+    // capability scope. Authenticated services must use their canonical URL so
+    // a redirect cannot disclose a token to plaintext HTTP or another host.
+    return fetchImpl(input, authenticated ? { ...init, maxRedirections: 0 } : init);
+  };
+}
 
 /** Route desktop ArcGIS REST downloads through Rust, outside WebView CORS. */
 export async function installNativeArcGISFetch(): Promise<void> {
+  const { setArcGISFetch } = await import("@geolibre/plugins");
   const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
-  setArcGISFetch(tauriFetch);
+  setArcGISFetch(createNativeArcGISFetch(tauriFetch));
 }

--- a/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/arcgis-fetch.ts
@@ -1,23 +1,48 @@
-import type { fetch as nativeFetch } from "@tauri-apps/plugin-http";
+interface ArcGISResponse {
+  status: number;
+  body: string;
+}
 
-/** Protect ArcGIS tokens from plaintext requests and automatic redirect downgrades. */
-export function createNativeArcGISFetch(fetchImpl: typeof nativeFetch): typeof globalThis.fetch {
-  return (input, init) => {
-    const url = new URL(input instanceof Request ? input.url : input.toString());
-    const authenticated = Boolean(url.searchParams.get("token"));
-    if (authenticated && url.protocol !== "https:") {
-      return Promise.reject(new Error("ArcGIS access tokens require HTTPS."));
+type ArcGISRequest = (url: string) => Promise<ArcGISResponse>;
+
+/** Adapt the guarded GET-only Rust command to ArcGIS's fetch transport. */
+export function createNativeArcGISFetch(request: ArcGISRequest): typeof globalThis.fetch {
+  return async (input, init) => {
+    const url = input instanceof Request ? input.url : input.toString();
+    const signal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+    signal?.throwIfAborted();
+    let onAbort: (() => void) | undefined;
+    try {
+      // The blocking Rust request has a 120-second deadline. Cancellation ends
+      // the caller's wait immediately; late native results are discarded.
+      const pending = request(url);
+      const result = signal
+        ? await Promise.race([
+            pending,
+            new Promise<never>((_, reject) => {
+              onAbort = () => reject(signal.reason);
+              signal.addEventListener("abort", onAbort, { once: true });
+              if (signal.aborted) onAbort();
+            }),
+          ])
+        : await pending;
+      return new Response([204, 205, 304].includes(result.status) ? null : result.body, {
+        status: result.status,
+      });
+    } catch (error) {
+      if (signal?.aborted) throw signal.reason;
+      throw error instanceof Error ? error : new Error(String(error));
+    } finally {
+      if (onAbort) signal?.removeEventListener("abort", onAbort);
     }
-    // Tauri's native client can follow redirects outside the original URL's
-    // capability scope. Authenticated services must use their canonical URL so
-    // a redirect cannot disclose a token to plaintext HTTP or another host.
-    return fetchImpl(input, authenticated ? { ...init, maxRedirections: 0 } : init);
   };
 }
 
-/** Route desktop ArcGIS REST downloads through Rust, outside WebView CORS. */
+/** Install before project restoration so every ArcGIS REST request uses Rust. */
 export async function installNativeArcGISFetch(): Promise<void> {
   const { setArcGISFetch } = await import("@geolibre/plugins");
-  const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
-  setArcGISFetch(createNativeArcGISFetch(tauriFetch));
+  const { invoke } = await import("@tauri-apps/api/core");
+  setArcGISFetch(
+    createNativeArcGISFetch((url) => invoke<ArcGISResponse>("fetch_arcgis_response", { url })),
+  );
 }

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -87,6 +87,7 @@ installDiagnosticsCapture();
 
 const nativeCoordinateOpenReady = initializeNativeCoordinateOpen();
 const nativeProjectOpenReady = initializeNativeProjectOpen();
+let nativeArcGISFetchReady: Promise<void> = Promise.resolve();
 let nativeSidecarFetchReady: Promise<void> = Promise.resolve();
 // In the desktop build, route geocoding (place search / reverse geocode)
 // through Tauri's native HTTP client so it bypasses WebView CORS: public
@@ -94,6 +95,11 @@ let nativeSidecarFetchReady: Promise<void> = Promise.resolve();
 // which the WebView rejects as "Search failed. Try again." Lazy + desktop-only
 // so the web/embedded bundles never import the Tauri HTTP plugin.
 if (isTauri()) {
+  nativeArcGISFetchReady = import("./lib/arcgis-fetch")
+    .then(({ installNativeArcGISFetch }) => installNativeArcGISFetch())
+    .catch((error: unknown) => {
+      console.error("[GeoLibre] Failed to install native ArcGIS fetch", error);
+    });
   // WebView2 can apply browser CORS and Local Network Access restrictions to
   // the loopback processing server. Route those requests through Tauri's
   // scoped native client so Windows uses the same reliable path as the shell
@@ -284,6 +290,8 @@ void Promise.all([
   // Sidecar-dependent panels can issue a request as soon as App mounts. On
   // Windows, wait until those requests have the native transport installed.
   nativeSidecarFetchReady,
+  // Restored ArcGIS layers can query immediately when App mounts.
+  nativeArcGISFetchReady,
   // Capture a file-association or command-line project path before App decides
   // whether to restore a configured startup project or the default workspace.
   nativeProjectOpenReady,

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -89,11 +89,8 @@ const nativeCoordinateOpenReady = initializeNativeCoordinateOpen();
 const nativeProjectOpenReady = initializeNativeProjectOpen();
 let nativeArcGISFetchReady: Promise<void> = Promise.resolve();
 let nativeSidecarFetchReady: Promise<void> = Promise.resolve();
-// In the desktop build, route geocoding (place search / reverse geocode)
-// through Tauri's native HTTP client so it bypasses WebView CORS: public
-// Nominatim's CDN intermittently omits the CORS header on cached responses,
-// which the WebView rejects as "Search failed. Try again." Lazy + desktop-only
-// so the web/embedded bundles never import the Tauri HTTP plugin.
+// Install desktop-only transports before requests can be issued. ArcGIS uses
+// a dedicated guarded Rust command; the other adapters use scoped HTTP hosts.
 if (isTauri()) {
   nativeArcGISFetchReady = import("./lib/arcgis-fetch")
     .then(({ installNativeArcGISFetch }) => installNativeArcGISFetch())

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -74,6 +74,7 @@ export {
 } from "./plugins/maplibre-basemap-control";
 export {
   addArcGISLayer,
+  setArcGISFetch,
   fetchArcGISImageServiceRasterFunctions,
   fetchArcGISMapServiceSublayers,
   ARCGIS_FEATURE_SOURCE_KIND,

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -6,6 +6,18 @@ import type { Feature, FeatureCollection, MultiPolygon, Position } from "geojson
 import type * as maplibregl from "maplibre-gl";
 import type { GeoLibreAppAPI } from "../types";
 
+let arcGISFetchOverride: typeof globalThis.fetch | null = null;
+
+/** Install the desktop HTTP transport for ArcGIS REST requests; null restores browser fetch. */
+export function setArcGISFetch(fetchImpl: typeof globalThis.fetch | null): void {
+  arcGISFetchOverride = fetchImpl;
+}
+
+/** Resolve at request time so restored layers and refreshes use the installed transport. */
+function arcGISFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return (arcGISFetchOverride ?? globalThis.fetch)(input, init);
+}
+
 export type ArcGISLayerType = "feature" | "vector-tile" | "map-service" | "image-service";
 export type ArcGISSourceType = "url" | "portal-item";
 
@@ -1517,7 +1529,7 @@ async function fetchArcGISFeatureCount(
   params: Record<string, string | undefined>,
 ): Promise<number | null> {
   try {
-    const response = await fetch(
+    const response = await arcGISFetch(
       appendArcGISParams(queryUrl, {
         ...params,
         f: "json",
@@ -1664,7 +1676,7 @@ async function fetchArcGISObjectIds(
   plan: ArcGISPagingPlan,
 ): Promise<{ field: string; objectIds: number[] } | null> {
   try {
-    const response = await fetch(
+    const response = await arcGISFetch(
       appendArcGISParams(plan.queryUrl, {
         ...plan.params,
         f: "json",
@@ -1808,7 +1820,7 @@ async function fetchArcGISGeoJson(
   url: string,
   signal?: AbortSignal,
 ): Promise<FeatureCollection & { exceededTransferLimit: boolean }> {
-  const response = await fetch(url, { signal });
+  const response = await arcGISFetch(url, { signal });
   if (!response.ok) {
     throw new ArcGISQueryError(`ArcGIS feature query failed with ${response.status}.`, {
       status: response.status,
@@ -2081,7 +2093,7 @@ async function fetchArcGISPortalItemInfo(
     f: "json",
     token: options.token?.trim(),
   });
-  const response = await fetch(itemUrl);
+  const response = await arcGISFetch(itemUrl);
   if (!response.ok) {
     throw new Error(`ArcGIS portal item request failed with ${response.status}.`, {
       cause,
@@ -2096,7 +2108,7 @@ async function fetchArcGISJson<T>(
   cause: unknown,
   signal?: AbortSignal,
 ): Promise<T> {
-  const response = await fetch(
+  const response = await arcGISFetch(
     appendArcGISParams(url, {
       f: "json",
       token: options.token?.trim(),

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -4,6 +4,7 @@ import { useAppStore } from "@geolibre/core";
 import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 import {
   addArcGISLayer,
+  setArcGISFetch,
   refreshArcGISFeatureLayer,
   reloadArcGISViewportLayer,
   restoreArcGISViewportLayers,
@@ -247,8 +248,42 @@ describe("addArcGISLayer (feature layer)", () => {
   });
 
   afterEach(() => {
+    setArcGISFetch(null);
     globalThis.fetch = originalFetch;
   });
+
+  for (const supportsPagination of [true, false]) {
+    it(`uses the installed transport for metadata, counts, paging, and refresh (pagination=${supportsPagination})`, async () => {
+      const service = fakeArcGISService({ total: 5, maxRecordCount: 2, supportsPagination });
+      const urls: string[] = [];
+      globalThis.fetch = async () => {
+        throw new TypeError("Browser fetch blocked by CORS");
+      };
+      setArcGISFetch(async (input, init) => {
+        urls.push(String(input));
+        return service.fetch(input, init);
+      });
+      const id = await addArcGISLayer(app, {
+        layerType: "feature",
+        sourceType: "url",
+        url: SERVICE_URL,
+        name: "Native cities",
+      });
+      const layer = useAppStore.getState().layers.find((entry) => entry.id === id)!;
+      assert.equal(layer.geojson?.features.length, 5);
+      assert.ok(urls.some((url) => url.includes("returnCountOnly=true")));
+      if (!supportsPagination) assert.ok(urls.some((url) => url.includes("returnIdsOnly=true")));
+      const refreshed = await refreshArcGISFeatureLayer({
+        queryUrl: String(layer.source.arcgisQueryUrl),
+      });
+      assert.equal(refreshed.features.length, 5);
+      setArcGISFetch(null);
+      await assert.rejects(
+        refreshArcGISFeatureLayer({ queryUrl: String(layer.source.arcgisQueryUrl) }),
+        /Browser fetch blocked/,
+      );
+    });
+  }
 
   it("loads a feature layer as a GeoJSON layer with its attributes intact", async () => {
     const id = await addArcGISLayer(app, {

--- a/tests/arcgis-fetch.test.ts
+++ b/tests/arcgis-fetch.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import { createNativeArcGISFetch } from "../apps/geolibre-desktop/src/lib/arcgis-fetch";
+
+it("rejects token-bearing HTTP requests before calling native HTTP", async () => {
+  let called = false;
+  const fetchImpl = createNativeArcGISFetch(async () => {
+    called = true;
+    return new Response();
+  });
+  await assert.rejects(
+    fetchImpl("http://example.com/FeatureServer/0?token=secret"),
+    /tokens require HTTPS/,
+  );
+  assert.equal(called, false);
+});
+
+it("disables native redirects for authenticated requests and preserves cancellation", async () => {
+  const controller = new AbortController();
+  const fetchImpl = createNativeArcGISFetch(async (input, init) => {
+    assert.equal(String(input), "https://example.com/FeatureServer/0?token=secret");
+    assert.equal(init?.maxRedirections, 0);
+    assert.equal(init?.signal, controller.signal);
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "http://example.com/FeatureServer/0?token=secret" },
+    });
+  });
+  const response = await fetchImpl("https://example.com/FeatureServer/0?token=secret", {
+    signal: controller.signal,
+  });
+  assert.equal(response.status, 302);
+});
+
+it("retains unauthenticated HTTP service support", async () => {
+  const fetchImpl = createNativeArcGISFetch(async (input, init) => {
+    assert.equal(String(input), "http://example.com/FeatureServer/0");
+    assert.equal(init?.maxRedirections, undefined);
+    return new Response("{}");
+  });
+  assert.equal((await fetchImpl("http://example.com/FeatureServer/0")).status, 200);
+});

--- a/tests/arcgis-fetch.test.ts
+++ b/tests/arcgis-fetch.test.ts
@@ -62,3 +62,53 @@ it("keeps wildcard hosts out of the shared native HTTP capability", () => {
     }
   }
 });
+
+it("rejects unsupported methods, headers, and bodies instead of silently changing the request", async () => {
+  const fetchImpl = createNativeArcGISFetch(async () => {
+    assert.fail("Rust must not be called");
+  });
+  for (const init of [
+    { method: "POST", body: "query" },
+    { headers: { Authorization: "Bearer secret" } },
+    { body: "query" },
+  ]) {
+    await assert.rejects(fetchImpl("https://example.com", init), /only supports GET/);
+  }
+  await assert.rejects(
+    fetchImpl(new Request("https://example.com", { method: "POST", body: "query" })),
+    /only supports GET/,
+  );
+});
+
+for (const abortBeforeReady of [true, false]) {
+  it(`cancels the native request when abort occurs ${abortBeforeReady ? "before" : "after"} registration`, async () => {
+    const { createArcGISRequest } = await import("../apps/geolibre-desktop/src/lib/arcgis-fetch");
+    const controller = new AbortController();
+    const ready = { onmessage: (_: void) => {} };
+    let requestId: unknown;
+    let cancelled: unknown;
+    let rejectFetch!: (error: unknown) => void;
+    const invoke = (async (command: string, args?: Record<string, unknown>) => {
+      if (command === "fetch_arcgis_response") {
+        requestId = args?.requestId;
+        return new Promise((_, reject) => {
+          rejectFetch = reject;
+        });
+      }
+      assert.equal(command, "cancel_arcgis_request");
+      cancelled = args?.requestId;
+      rejectFetch("ArcGIS request cancelled.");
+    }) as Parameters<typeof createArcGISRequest>[0];
+    const fetchImpl = createNativeArcGISFetch(createArcGISRequest(invoke, () => ready));
+    const pending = fetchImpl("https://example.com", { signal: controller.signal });
+    if (!abortBeforeReady) ready.onmessage();
+    controller.abort();
+    if (abortBeforeReady) {
+      assert.equal(cancelled, undefined);
+      ready.onmessage();
+    }
+    await assert.rejects(pending, { name: "AbortError" });
+    assert.equal(cancelled, requestId);
+    assert.equal(typeof cancelled, "string");
+  });
+}

--- a/tests/arcgis-fetch.test.ts
+++ b/tests/arcgis-fetch.test.ts
@@ -1,42 +1,64 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { it } from "node:test";
 import { createNativeArcGISFetch } from "../apps/geolibre-desktop/src/lib/arcgis-fetch";
 
-it("rejects token-bearing HTTP requests before calling native HTTP", async () => {
-  let called = false;
-  const fetchImpl = createNativeArcGISFetch(async () => {
-    called = true;
-    return new Response();
+it("preserves ArcGIS HTTP errors and bodies for retry and service-error handling", async () => {
+  const fetchImpl = createNativeArcGISFetch(async (url) => {
+    assert.equal(url, "https://example.com/FeatureServer/0");
+    return { status: 503, body: '{"error":{"message":"Busy"}}' };
   });
-  await assert.rejects(
-    fetchImpl("http://example.com/FeatureServer/0?token=secret"),
-    /tokens require HTTPS/,
-  );
-  assert.equal(called, false);
+  const response = await fetchImpl("https://example.com/FeatureServer/0");
+  assert.equal(response.ok, false);
+  assert.equal(response.status, 503);
+  assert.equal((await response.json()).error.message, "Busy");
 });
 
-it("disables native redirects for authenticated requests and preserves cancellation", async () => {
+it("cancels a pending native request and ignores a later rejection", async () => {
   const controller = new AbortController();
-  const fetchImpl = createNativeArcGISFetch(async (input, init) => {
-    assert.equal(String(input), "https://example.com/FeatureServer/0?token=secret");
-    assert.equal(init?.maxRedirections, 0);
-    assert.equal(init?.signal, controller.signal);
-    return new Response(null, {
-      status: 302,
-      headers: { Location: "http://example.com/FeatureServer/0?token=secret" },
-    });
-  });
-  const response = await fetchImpl("https://example.com/FeatureServer/0?token=secret", {
-    signal: controller.signal,
-  });
-  assert.equal(response.status, 302);
+  let rejectNative!: (error: Error) => void;
+  const fetchImpl = createNativeArcGISFetch(
+    () =>
+      new Promise((_, reject) => {
+        rejectNative = reject;
+      }),
+  );
+  const pending = fetchImpl("https://example.com/FeatureServer/0", { signal: controller.signal });
+  controller.abort();
+  await assert.rejects(pending, { name: "AbortError" });
+  rejectNative(new Error("Late native failure"));
 });
 
-it("retains unauthenticated HTTP service support", async () => {
-  const fetchImpl = createNativeArcGISFetch(async (input, init) => {
-    assert.equal(String(input), "http://example.com/FeatureServer/0");
-    assert.equal(init?.maxRedirections, undefined);
-    return new Response("{}");
+it("does not invoke Rust for a pre-aborted request", async () => {
+  const fetchImpl = createNativeArcGISFetch(async () => {
+    assert.fail("Native request must not start");
   });
-  assert.equal((await fetchImpl("http://example.com/FeatureServer/0")).status, 200);
+  await assert.rejects(fetchImpl("https://example.com", { signal: AbortSignal.abort() }), {
+    name: "AbortError",
+  });
+});
+
+it("normalizes IPC string errors", async () => {
+  const fetchImpl = createNativeArcGISFetch(async () => {
+    throw "Blocked address";
+  });
+  await assert.rejects(fetchImpl("https://example.com"), /Blocked address/);
+});
+
+it("keeps wildcard hosts out of the shared native HTTP capability", () => {
+  const capability = JSON.parse(
+    readFileSync(
+      new URL("../apps/geolibre-desktop/src-tauri/capabilities/default.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  for (const permission of capability.permissions) {
+    if (permission.identifier === "http:default") {
+      assert.ok(
+        permission.allow.every(
+          (entry: { url: string }) => !new URL(entry.url).hostname.includes("*"),
+        ),
+      );
+    }
+  }
 });


### PR DESCRIPTION
ArcGIS FeatureServer requests used WebView fetch on desktop, so public services without CORS headers failed just as they do in the browser. Install a native ArcGIS transport before the app mounts and use it for metadata, portal resolution, counts, object IDs, feature pages, viewport queries, and refresh. The Add ArcGIS dialog now uses the existing translated network/CORS guidance.

A dedicated GET-only Rust command preserves HTTP status and response bodies while reusing GeoLibre's existing guarded DNS resolution, address checks, enterprise certificate configuration, and connection pooling. The shared HTTP plugin's host allowlist remains unchanged. The address policy matches the existing native data-download commands: link-local/cloud-metadata, unspecified, and multicast addresses are blocked, while loopback/LAN data servers remain supported.

Token-bearing requests require HTTPS. Authenticated redirects can normalize paths within the same HTTPS origin, but cannot downgrade or change host/port. Redirect hops are revalidated and capped. Aborting a viewport request cancels the asynchronous native request and body read, including aborts before registration. Responses are capped at 64 MiB before decoding, with checks for both declared and chunked bodies; requests also have a 120-second deadline. Unsupported methods, headers, or bodies fail explicitly.

Validation:
- Reproduced the original browser CORS failure with Playwright CLI and verified the translated error guidance in both themes.
- Built and drove the actual Linux Tauri app in dark and light themes. Loaded the reported Hohenlohe parcel service with five-record pages and a 10-feature cap; inspected real polygon features and attributes in the store.
- Confirmed direct IPC requests to the cloud-metadata address are rejected.
- Rust regression tests cover metadata/plaintext-token rejection and safe/unsafe redirects. Frontend tests cover paging, refresh, HTTP status/body preservation, cancellation, and the shared capability allowlist.
- Full local CI passed: lint, production build, 8,055 frontend tests (one skipped), worker tests, 411 backend tests (28 skipped), coverage gates, and Rust check. The five focused Rust security/resource tests and scoped pre-commit checks also pass. Windows was not available for direct testing.

No upstream package release is required.

Fixes #2345


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ArcGIS support in the desktop app, including reliable loading and refreshing of feature layers.
  * ArcGIS requests can use a secure native connection for authenticated services.
  * Added support for routing ArcGIS requests through an alternative transport.

* **Bug Fixes**
  * Improved handling of ArcGIS request errors, cancellations, empty responses, and HTTP failures.
  * Added protections for redirects, unsafe ArcGIS addresses, and oversized responses.
  * ArcGIS submission errors now provide more consistent messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
