### PR TITLE
fix(swipe): bump maplibre-gl-swipe to 0.11.3 so panel checkboxes stay clickable

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -94,7 +94,7 @@
     "maplibre-gl-raster": "^0.14.11",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.11.2",
+    "maplibre-gl-swipe": "^0.11.3",
     "maplibre-gl-time-slider": "^1.8.7",
     "maplibre-gl-usgs-lidar": "^0.11.5",
     "maplibre-gl-vector": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "maplibre-gl-raster": "^0.14.11",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.11.2",
+        "maplibre-gl-swipe": "^0.11.3",
         "maplibre-gl-time-slider": "^1.8.7",
         "maplibre-gl-usgs-lidar": "^0.11.5",
         "maplibre-gl-vector": "^0.11.0",
@@ -21047,9 +21047,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.11.2.tgz",
-      "integrity": "sha512-QjbQsQnz+FPjHmYiieuWmp0aD40lKaZXZL4pocd09nbnmqtbuzpQqQeu4jknui6xdIsWfvO2KUgTrdATpKWQbw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.11.3.tgz",
+      "integrity": "sha512-qiwT+ARG69qVu1ZYohimlqeuJR9M2EtIzY+VM2dEx9L7U1++Ea6CmcJsJrjZzMRS22kEpocfs4VbVzXNaoDXSw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -27808,7 +27808,7 @@
         "maplibre-gl-raster": "^0.14.11",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.11.2",
+        "maplibre-gl-swipe": "^0.11.3",
         "maplibre-gl-time-slider": "^1.8.7",
         "maplibre-gl-usgs-lidar": "^0.11.5",
         "maplibre-gl-vector": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -70,7 +70,7 @@
     "maplibre-gl-raster": "^0.14.11",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.11.2",
+    "maplibre-gl-swipe": "^0.11.3",
     "maplibre-gl-time-slider": "^1.8.7",
     "maplibre-gl-usgs-lidar": "^0.11.5",
     "maplibre-gl-vector": "^0.11.0",


### PR DESCRIPTION
The Layer Swipe panel's layer checkboxes stopped responding once a deck.gl COG
raster was on the map: clicking a row did nothing, and after the first toggle
the whole panel froze.

The cause was upstream. SwipeControl._refreshLayerList() re-appended every
layer row on each refresh, and appendChild on an already-attached node moves
it. A node moved between mousedown and mouseup never receives a click, and
GeoLibre's map fires styledata continuously while a raster overlay is
rendering (measured ~18 refreshes/sec), so nearly every click was swallowed.

maplibre-gl-swipe 0.11.3 reorders the rows in place instead, touching the DOM
only for rows that are actually out of position. No GeoLibre-side change is
needed beyond the version bump.

Fixes #2347


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the map swipe component dependency to version 0.11.3 across the desktop application and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->