### PR TITLE
fix: make URL load error banners dismissible

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -3060,10 +3060,16 @@ export function DesktopShell({
       ) : null}
       <div className="pointer-events-none absolute left-1/2 top-14 z-50 flex w-max max-w-[min(90vw,32rem)] -translate-x-1/2 flex-col gap-2">
         {projectUrlLoadState?.error ? (
-          <UrlLoadErrorBanner key={projectUrlLoadState.error} message={projectUrlLoadState.error} />
+          <UrlLoadErrorBanner
+            key={`project:${projectUrlLoadState.error}`}
+            message={projectUrlLoadState.error}
+          />
         ) : null}
         {dataUrlLoadState?.error ? (
-          <UrlLoadErrorBanner key={dataUrlLoadState.error} message={dataUrlLoadState.error} />
+          <UrlLoadErrorBanner
+            key={`data:${dataUrlLoadState.error}`}
+            message={dataUrlLoadState.error}
+          />
         ) : null}
       </div>
       {crsWarning ? (

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -68,6 +68,7 @@ import {
 import { createPortal } from "react-dom";
 import { BROWSER_PANEL_ID, useRegisterBrowserPanel } from "../../hooks/useRegisterBrowserPanel";
 import { COMMENTS_PANEL_ID, useRegisterCommentsPanel } from "../../hooks/useRegisterCommentsPanel";
+import { UrlLoadErrorBanner } from "./UrlLoadErrorBanner";
 import { CommentsPanel } from "../comments/CommentsPanel";
 import { CommentMapOverlay } from "../comments/CommentMapOverlay";
 import { useCommentTool } from "../comments/useCommentTool";
@@ -3057,26 +3058,14 @@ export function DesktopShell({
           </div>
         </div>
       ) : null}
-      {projectUrlLoadState?.error ? (
-        <div
-          aria-live="assertive"
-          className="pointer-events-none absolute left-1/2 top-14 z-50 max-w-[min(90vw,32rem)] -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-center text-sm text-destructive shadow-lg"
-        >
-          {projectUrlLoadState.error}
-        </div>
-      ) : null}
-      {dataUrlLoadState?.error ? (
-        // A link can carry both `url=` and `data=`, and both loaders can fail.
-        // Drop below the project banner so neither message is covered.
-        <div
-          aria-live="assertive"
-          className={`pointer-events-none absolute left-1/2 z-50 max-w-[min(90vw,32rem)] -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-center text-sm text-destructive shadow-lg ${
-            projectUrlLoadState?.error ? "top-28" : "top-14"
-          }`}
-        >
-          {dataUrlLoadState.error}
-        </div>
-      ) : null}
+      <div className="pointer-events-none absolute left-1/2 top-14 z-50 flex w-max max-w-[min(90vw,32rem)] -translate-x-1/2 flex-col gap-2">
+        {projectUrlLoadState?.error ? (
+          <UrlLoadErrorBanner key={projectUrlLoadState.error} message={projectUrlLoadState.error} />
+        ) : null}
+        {dataUrlLoadState?.error ? (
+          <UrlLoadErrorBanner key={dataUrlLoadState.error} message={dataUrlLoadState.error} />
+        ) : null}
+      </div>
       {crsWarning ? (
         <div
           data-testid="crs-warning"

--- a/apps/geolibre-desktop/src/components/layout/UrlLoadErrorBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/UrlLoadErrorBanner.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
+
+export function UrlLoadErrorBanner({ message }: { message: string }) {
+  const { t } = useTranslation();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      role="alert"
+      className="pointer-events-auto flex items-start gap-2 rounded-md border bg-background px-3 py-2 text-sm text-destructive shadow-lg"
+    >
+      <span className="min-w-0 flex-1 break-words">{message}</span>
+      <button
+        type="button"
+        aria-label={t("common.close")}
+        title={t("common.close")}
+        onClick={() => setDismissed(true)}
+        className="shrink-0 rounded-sm p-1 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/extensions/geolibre-chrome/manifest.json
+++ b/extensions/geolibre-chrome/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Open data in GeoLibre",
   "description": "Find geospatial datasets and services used by the current page and open them in GeoLibre.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage_url": "https://geolibre.app/",
   "minimum_chrome_version": "106",
   "permissions": ["activeTab", "scripting"],


### PR DESCRIPTION
Opening an unreachable data URL from the Chrome extension leaves an error banner with no way to close it. Add a translated, keyboard-accessible close button to both data and project URL error banners. Stack simultaneous errors by their actual height so long URLs cannot obscure another banner.

Bump the Chrome extension patch version from 0.3.0 to 0.3.1. The extension archive was built and its packaged manifest version verified.

Verified with Playwright against the reported ABS ZIP URL in light and dark themes, including mouse and keyboard dismissal, independent dismissal of simultaneous project/data errors, and importing us_cities.geojson afterward. Scoped pre-commit checks passed, including lint and the production build.

Fixes #2352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dismissible alerts for project and data URL loading errors.
  - Users can close each alert individually using a clear close button.
  - Multiple alerts now stack consistently in a shared layout without overlapping or requiring manual positioning.
  - Error messages remain visible until dismissed, making failed URL loads easier to identify and manage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
