### PR TITLE
fix(map): reduce a GeoJSON's 3D bbox before fitting the map to it

### DIFF
--- a/packages/map/src/geojson-loader.ts
+++ b/packages/map/src/geojson-loader.ts
@@ -39,12 +39,19 @@ export function detectGeometryProfile(fc: FeatureCollection): GeometryProfile {
 
 export function getLayerBounds(layer: GeoLibreLayer): [number, number, number, number] | null {
   if (layer.geojson?.features?.length) {
-    const box = bbox(layer.geojson);
+    // `bbox()` returns a collection's own `bbox` member untouched rather than
+    // recomputing it, and RFC 7946 §5 lets that member carry elevation — six
+    // values, [west, south, minAltitude, east, north, maxAltitude] — which the
+    // USGS earthquake feeds ship. Read as four, the altitude lands where a
+    // longitude belongs and the east edge where a latitude does, so MapLibre
+    // rejects the fit with "Invalid LngLat latitude value".
+    const raw = bbox(layer.geojson) as number[];
+    const box = raw.length === 6 ? [raw[0], raw[1], raw[3], raw[4]] : raw;
     // A collection whose features all carry a null geometry (e.g. a delimited
     // text file imported as an attribute table, or a non-spatial SQL result)
     // yields a degenerate ±Infinity box. Continue to the stored extent in
     // that case instead of flying to invalid coordinates.
-    if (box.every((value) => Number.isFinite(value))) {
+    if (box.length === 4 && box.every((value) => Number.isFinite(value))) {
       return box as [number, number, number, number];
     }
   }

--- a/tests/layer-bounds.test.ts
+++ b/tests/layer-bounds.test.ts
@@ -39,6 +39,33 @@ describe("getLayerBounds", () => {
     assert.deepEqual(bounds, [-78.638, 35.779, -70, 40]);
   });
 
+  it("reduces a six-element 3D bbox carried by the source data", () => {
+    // RFC 7946 §5 allows a `bbox` member to carry elevation, in which case it
+    // holds six values: [west, south, minAltitude, east, north, maxAltitude].
+    // The USGS earthquake feeds ship exactly that, and `bbox()` returns a
+    // collection's own member verbatim instead of recomputing it.
+    const bounds = getLayerBounds(
+      layerWith({
+        type: "FeatureCollection",
+        bbox: [-179.9224, -61.5305, -3.6, 179.7358, 66.921, 621.93],
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [-179.9224, -61.5305, 10] },
+            properties: {},
+          },
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [179.7358, 66.921, 621.93] },
+            properties: {},
+          },
+        ],
+      }),
+    );
+
+    assert.deepEqual(bounds, [-179.9224, -61.5305, 179.7358, 66.921]);
+  });
+
   it("returns null for a table layer whose features all have null geometry", () => {
     const bounds = getLayerBounds(
       layerWith({


### PR DESCRIPTION
## What

Loading any GeoJSON whose top-level `bbox` carries elevation crashes the app with
`Invalid LngLat latitude value: must be between -90 and 90`, and the error boundary replaces the
whole UI with *"Something went wrong"*.

Reproduce on a fresh instance — this is one of the most widely used public GeoJSON feeds there is:

```
/?data=https%3A%2F%2Fearthquake.usgs.gov%2Fearthquakes%2Ffeed%2Fv1.0%2Fsummary%2F2.5_day.geojson
```

## Why

`@turf/bbox` v7 returns a collection's **own** `bbox` member verbatim unless `recompute` is set:

```js
function bbox(geojson, options = {}) {
  if (geojson.bbox != null && true !== options.recompute) {
    return geojson.bbox;
  }
  …
```

and [RFC 7946 §5](https://datatracker.ietf.org/doc/html/rfc7946#section-5) allows that member to
carry elevation, in which case it holds **six** values —
`[west, south, minAltitude, east, north, maxAltitude]`. The USGS feeds ship exactly that.

`getLayerBounds` validated only that every value was finite (six finite values pass) and then
asserted the result was a 4-tuple with `as`, which is where the type system stopped looking.
`MapController.zoomToLayer` then builds its corner pair positionally:

```ts
const box = [
  [bounds[0], bounds[1]],
  [bounds[2], bounds[3]],
];
```

With six values that is `[[west, south], [minAltitude, east]]` — the altitude is read as a longitude
and the **east edge as a latitude**. For the USGS feed that latitude is `179.7358`, and MapLibre
rejects it.

## How

Reduce a six-element box to its horizontal extent (`[0], [1], [3], [4]`) before the finite check,
and require a length of 4 before returning. The fast path is untouched: a collection without its own
`bbox` member still gets the computed 2D box, and no extra pass over the coordinates is introduced.

Covered by a new case in `tests/layer-bounds.test.ts` that fails on `main` with the six values
returned verbatim.

## Note for reviewers

The same `bbox(…) as [number, number, number, number]` assertion appears at five other call sites,
so they share the latent defect — two of them also feed `fitBounds`:

- `packages/map/src/map-controller.ts:2016`
- `packages/processing/src/registry.ts:21` (the *Bounds* algorithm, calls `ctx.fitBounds`)
- `packages/processing/src/dggs-tools.ts:440` and `:659`
- `packages/processing/src/vector-tools.ts:2313` and `:2460`

I kept this change focused on the crash path, as CONTRIBUTING asks. Happy to extend it to the rest —
most likely as one shared 2D-normalising helper — if you would prefer that in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of GeoJSON collections with elevation-enabled bounding boxes.
  - Map layer bounds now correctly use the horizontal coordinates from six-value 3D bounding boxes, ensuring accurate layer positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->