### PR TITLE
fix(bounds): reduce 3D bboxes through one shared helper at every call site

### DIFF
--- a/packages/core/src/geojson-z.ts
+++ b/packages/core/src/geojson-z.ts
@@ -20,8 +20,9 @@ import type { Feature, FeatureCollection, GeoJSON, Geometry, Position } from "ge
  * feed reached MapLibre as an out-of-range latitude (#2358).
  *
  * Returns null when there is no usable horizontal extent: a box of any other
- * length, or one carrying a non-finite value — an empty collection, or one
- * whose features all have a null geometry, bboxes to ±Infinity.
+ * length, or one carrying a non-finite value anywhere — an empty collection, or
+ * one whose features all have a null geometry, bboxes to ±Infinity, and a box
+ * whose altitudes are not finite is not one to trust the rest of.
  *
  * @param box - A GeoJSON or Turf bounding box, of four or six values.
  */
@@ -29,14 +30,9 @@ export function horizontalBbox(
   box: readonly number[] | null | undefined,
 ): [number, number, number, number] | null {
   if (!box) return null;
-  const horizontal =
-    box.length === 4
-      ? [box[0], box[1], box[2], box[3]]
-      : box.length === 6
-        ? [box[0], box[1], box[3], box[4]]
-        : null;
-  if (!horizontal?.every((value) => Number.isFinite(value))) return null;
-  return horizontal as [number, number, number, number];
+  if (box.length !== 4 && box.length !== 6) return null;
+  if (!box.every((value) => Number.isFinite(value))) return null;
+  return box.length === 6 ? [box[0], box[1], box[3], box[4]] : [box[0], box[1], box[2], box[3]];
 }
 
 // Proving the *negative* (no Z anywhere) walks every coordinate, so cache the

--- a/packages/core/src/geojson-z.ts
+++ b/packages/core/src/geojson-z.ts
@@ -5,8 +5,39 @@ import type { Feature, FeatureCollection, GeoJSON, Geometry, Position } from "ge
  * GPX tracks with `<ele>` readings or LineStringZ/PointZ geometries. MapLibre's
  * 2D style layers ignore the third coordinate, so layers that want to render
  * their Z values use these helpers to detect and rescale elevations before
- * handing the data to a deck.gl overlay.
+ * handing the data to a deck.gl overlay. The same data can carry its elevation
+ * in a `bbox` member too, which `horizontalBbox` trims back to two dimensions.
  */
+
+/**
+ * Reduces a bounding box to its horizontal extent, `[west, south, east, north]`.
+ *
+ * RFC 7946 §5 lets a `bbox` member carry elevation, in which case it holds six
+ * values — `[west, south, minAltitude, east, north, maxAltitude]` — and
+ * `@turf/bbox` returns a collection's own member verbatim rather than
+ * recomputing it. A consumer reading such a box as four values takes the
+ * altitude for a longitude and the east edge for a latitude; that is how a 3D
+ * feed reached MapLibre as an out-of-range latitude (#2358).
+ *
+ * Returns null when there is no usable horizontal extent: a box of any other
+ * length, or one carrying a non-finite value — an empty collection, or one
+ * whose features all have a null geometry, bboxes to ±Infinity.
+ *
+ * @param box - A GeoJSON or Turf bounding box, of four or six values.
+ */
+export function horizontalBbox(
+  box: readonly number[] | null | undefined,
+): [number, number, number, number] | null {
+  if (!box) return null;
+  const horizontal =
+    box.length === 4
+      ? [box[0], box[1], box[2], box[3]]
+      : box.length === 6
+        ? [box[0], box[1], box[3], box[4]]
+        : null;
+  if (!horizontal?.every((value) => Number.isFinite(value))) return null;
+  return horizontal as [number, number, number, number];
+}
 
 // Proving the *negative* (no Z anywhere) walks every coordinate, so cache the
 // verdict per GeoJSON object — the map sync, the deck overlay, and the Style

--- a/packages/map/src/derived-geometry.ts
+++ b/packages/map/src/derived-geometry.ts
@@ -6,7 +6,12 @@ import convex from "@turf/convex";
 import mask from "@turf/mask";
 import type { Feature, FeatureCollection, MultiPolygon, Polygon } from "geojson";
 import type { GeometryGeneratorType, LayerStyle } from "@geolibre/core";
-import { bodyLengthToEarth, getActiveBodyRadiusRatio, styleValue } from "@geolibre/core";
+import {
+  bodyLengthToEarth,
+  getActiveBodyRadiusRatio,
+  horizontalBbox,
+  styleValue,
+} from "@geolibre/core";
 
 /**
  * Derived feature collections for the symbology pack (#1323): the inverted
@@ -203,15 +208,10 @@ function deriveFeature(
       case "centroid":
         return centroid(feature);
       case "bounding-box": {
-        const box = bbox(feature);
-        if (!box.every((value) => Number.isFinite(value))) return null;
-        // bbox() returns 6 elements [minX,minY,minZ,maxX,maxY,maxZ] when any
-        // coordinate carries a Z value; normalize to the 2D corners so the
-        // degenerate check and bboxPolygon() see [minX,minY,maxX,maxY].
-        const box2d: [number, number, number, number] =
-          box.length === 6
-            ? [box[0], box[1], box[3], box[4]]
-            : (box as [number, number, number, number]);
+        // A six-element box carries elevation, so reduce it to the 2D corners
+        // the degenerate check and bboxPolygon() expect.
+        const box2d = horizontalBbox(bbox(feature));
+        if (!box2d) return null;
         // A point's bbox is degenerate (zero area) and would render nothing.
         if (box2d[0] === box2d[2] && box2d[1] === box2d[3]) return null;
         return bboxPolygon(box2d);

--- a/packages/map/src/geojson-loader.ts
+++ b/packages/map/src/geojson-loader.ts
@@ -1,6 +1,6 @@
 import bbox from "@turf/bbox";
 import type { FeatureCollection } from "geojson";
-import type { GeoLibreLayer } from "@geolibre/core";
+import { type GeoLibreLayer, horizontalBbox } from "@geolibre/core";
 
 export type GeometryKind = "point" | "line" | "polygon";
 
@@ -39,21 +39,14 @@ export function detectGeometryProfile(fc: FeatureCollection): GeometryProfile {
 
 export function getLayerBounds(layer: GeoLibreLayer): [number, number, number, number] | null {
   if (layer.geojson?.features?.length) {
-    // `bbox()` returns a collection's own `bbox` member untouched rather than
-    // recomputing it, and RFC 7946 §5 lets that member carry elevation — six
-    // values, [west, south, minAltitude, east, north, maxAltitude] — which the
-    // USGS earthquake feeds ship. Read as four, the altitude lands where a
-    // longitude belongs and the east edge where a latitude does, so MapLibre
-    // rejects the fit with "Invalid LngLat latitude value".
-    const raw = bbox(layer.geojson) as number[];
-    const box = raw.length === 6 ? [raw[0], raw[1], raw[3], raw[4]] : raw;
     // A collection whose features all carry a null geometry (e.g. a delimited
     // text file imported as an attribute table, or a non-spatial SQL result)
-    // yields a degenerate ±Infinity box. Continue to the stored extent in
-    // that case instead of flying to invalid coordinates.
-    if (box.length === 4 && box.every((value) => Number.isFinite(value))) {
-      return box as [number, number, number, number];
-    }
+    // yields a degenerate ±Infinity box, and one that carries its own 3D `bbox`
+    // member yields six values. `horizontalBbox` answers null to the first and
+    // trims the second; either way, continue to the stored extent rather than
+    // flying to invalid coordinates.
+    const box = horizontalBbox(bbox(layer.geojson));
+    if (box) return box;
   }
   for (const value of [layer.source.bounds, layer.metadata.bounds]) {
     if (

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROJECT_PREFERENCES,
   getPlanetaryBasemapByStyleUrl,
   getRegionalBasemapByStyleUrl,
+  horizontalBbox,
   isRegionalBasemapSentinel,
   PLANETARY_BASEMAP_SENTINEL_PREFIX,
   scaleAltitudeToActiveBody,
@@ -2013,9 +2014,9 @@ export class MapController implements MapEngine {
 
   private fitFeature(featureCollection: FeatureCollection): void {
     if (!this.map || featureCollection.features.length === 0) return;
-    const box = bbox(featureCollection) as [number, number, number, number];
+    const box = horizontalBbox(bbox(featureCollection));
     // fitBounds validates the box and handles point-sized boxes.
-    this.fitBounds(box);
+    if (box) this.fitBounds(box);
   }
 
   private syncHighlight(featureCollection: FeatureCollection): void {

--- a/packages/processing/src/dggs-tools.ts
+++ b/packages/processing/src/dggs-tools.ts
@@ -1,6 +1,6 @@
 import type { FeatureCollection } from "geojson";
 import bbox from "@turf/bbox";
-import type { GeoLibreLayer } from "@geolibre/core";
+import { type GeoLibreLayer, horizontalBbox } from "@geolibre/core";
 import type {
   DuckDbCapability,
   DuckDbGeoJsonSource,
@@ -437,7 +437,12 @@ export const createDggsGridTool: ProcessingAlgorithm = {
         }
       }
       inputGeojson = layer.geojson;
-      const bb = normalizeLonLatBbox(bbox(layer.geojson) as [number, number, number, number]);
+      const layerBox = horizontalBbox(bbox(layer.geojson));
+      if (!layerBox) {
+        ctx.log('Error: parameter "layer" has no usable extent');
+        return;
+      }
+      const bb = normalizeLonLatBbox(layerBox);
       areaKm2 = bboxAreaKm2(bb);
       if (source === "extent") areaBbox = bb;
       // A5 `geometry_to_cells` returns [] for a ±180° world ring; use the bbox
@@ -656,7 +661,11 @@ export const dggsBinPointsTool: ProcessingAlgorithm = {
       return;
     }
 
-    const bb = bbox(layer.geojson) as [number, number, number, number];
+    const bb = horizontalBbox(bbox(layer.geojson));
+    if (!bb) {
+      ctx.log('Error: parameter "layer" has no usable extent');
+      return;
+    }
     const dggridType = resolveDggridGridType(ctx.parameters.dggridType);
     const dggalType = resolveDggalGridType(ctx.parameters.dggalType);
     const res = resolveResolution(ctx, type, bboxAreaKm2(bb), dggridType, dggalType);

--- a/packages/processing/src/registry.ts
+++ b/packages/processing/src/registry.ts
@@ -1,5 +1,5 @@
 import bbox from "@turf/bbox";
-import type { GeoLibreLayer } from "@geolibre/core";
+import { type GeoLibreLayer, horizontalBbox } from "@geolibre/core";
 import type { ProcessingAlgorithm, ProcessingContext } from "./types";
 
 function getLayer(ctx: ProcessingContext, paramId = "layer"): GeoLibreLayer | undefined {
@@ -18,7 +18,11 @@ export const calculateBoundsAlgorithm: ProcessingAlgorithm = {
       ctx.log("Error: layer has no GeoJSON data");
       return;
     }
-    const bounds = bbox(layer.geojson) as [number, number, number, number];
+    const bounds = horizontalBbox(bbox(layer.geojson));
+    if (!bounds) {
+      ctx.log("Error: layer has no usable extent");
+      return;
+    }
     ctx.log(`Bounds: [${bounds.map((n) => n.toFixed(6)).join(", ")}]`);
     ctx.fitBounds?.(bounds);
   },

--- a/packages/processing/src/statistics-tools.ts
+++ b/packages/processing/src/statistics-tools.ts
@@ -4,7 +4,7 @@ import centroid from "@turf/centroid";
 import { featureCollection, polygon as turfPolygon } from "@turf/helpers";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { GeoLibreLayer } from "@geolibre/core";
-import { earthAreaToBody, getActiveMeanRadiusMeters } from "@geolibre/core";
+import { earthAreaToBody, getActiveMeanRadiusMeters, horizontalBbox } from "@geolibre/core";
 import type {
   FieldDirection,
   FieldNormalization,
@@ -590,7 +590,12 @@ export const averageNearestNeighborTool: ProcessingAlgorithm = {
     const observedMean = sumNn / n;
 
     // Study area = bounding-box area (m²) of the input extent.
-    const [west, south, east, north] = bbox(layer.geojson);
+    const extentBox = horizontalBbox(bbox(layer.geojson));
+    if (!extentBox) {
+      ctx.log("Error: the layer has no usable extent.");
+      return;
+    }
+    const [west, south, east, north] = extentBox;
     const extent = turfPolygon([
       [
         [west, south],
@@ -710,7 +715,12 @@ export const kernelDensityTool: ProcessingAlgorithm = {
 
     // Build a grid over the point extent, padded by one bandwidth so the
     // kernel tails near the edges are represented.
-    const [west, south, east, north] = bbox(layer.geojson);
+    const extentBox = horizontalBbox(bbox(layer.geojson));
+    if (!extentBox) {
+      ctx.log("Error: the layer has no usable extent.");
+      return;
+    }
+    const [west, south, east, north] = extentBox;
     const midLat = (south + north) / 2;
     const kmPerDegLat = 111.32;
     const kmPerDegLon = 111.32 * Math.cos((midLat * Math.PI) / 180) || 1e-6;

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -40,6 +40,7 @@ import {
   earthLengthToBody,
   encodePolyline,
   getActiveBodyRadiusRatio,
+  horizontalBbox,
   layerJoinKey,
   type GeoLibreLayer,
 } from "@geolibre/core";
@@ -2310,7 +2311,12 @@ export const gridTool: ProcessingAlgorithm = {
         ctx.log('Error: parameter "layer" has no GeoJSON features');
         return;
       }
-      bounds = bbox(layer.geojson) as [number, number, number, number];
+      const layerBounds = horizontalBbox(bbox(layer.geojson));
+      if (!layerBounds) {
+        ctx.log('Error: parameter "layer" has no usable extent');
+        return;
+      }
+      bounds = layerBounds;
       // Guard the layer path like the viewport/bbox paths: a zero-area extent
       // (e.g. a single-point layer, west === east) or an antimeridian-spanning
       // one (west > east) would otherwise make cols/rows zero or negative,
@@ -2457,13 +2463,14 @@ export const voronoiTool: ProcessingAlgorithm = {
     // Both diagrams are undefined for collinear/coincident points (a zero-area
     // bounding box). Turf's tin/voronoi would throw or return nothing; bail with
     // a clear message instead. Mirrors the backend guard.
-    const [minX, minY, maxX, maxY] = bbox(pointsFc) as [number, number, number, number];
-    if (minX === maxX || minY === maxY) {
+    const pointsBox = horizontalBbox(bbox(pointsFc));
+    if (!pointsBox || pointsBox[0] === pointsBox[2] || pointsBox[1] === pointsBox[3]) {
       ctx.log(
         "Error: the points are collinear or coincident; Voronoi / Delaunay needs points that span an area",
       );
       return;
     }
+    const [minX, minY, maxX, maxY] = pointsBox;
     if (kind === "delaunay") {
       const result = tin(pointsFc);
       // The bbox guard above catches axis-aligned collinearity; diagonally

--- a/tests/horizontal-bbox.test.ts
+++ b/tests/horizontal-bbox.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { horizontalBbox } from "@geolibre/core";
+
+describe("horizontalBbox", () => {
+  it("passes a two-dimensional box through", () => {
+    assert.deepEqual(horizontalBbox([-78, 35, -77, 36]), [-78, 35, -77, 36]);
+  });
+
+  it("drops the altitude pair from a six-element box", () => {
+    // RFC 7946 §5: [west, south, minAltitude, east, north, maxAltitude].
+    assert.deepEqual(
+      horizontalBbox([-179.9224, -61.5305, -3.6, 179.7358, 66.921, 621.93]),
+      [-179.9224, -61.5305, 179.7358, 66.921],
+    );
+  });
+
+  it("returns null for a box carrying a non-finite value", () => {
+    // What an empty collection, or one whose features all have a null
+    // geometry, bboxes to.
+    assert.equal(
+      horizontalBbox([
+        Number.POSITIVE_INFINITY,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+      ]),
+      null,
+    );
+    assert.equal(horizontalBbox([-78, Number.NaN, -77, 36]), null);
+  });
+
+  it("returns null for a box of any other length", () => {
+    assert.equal(horizontalBbox([-78, 35, -77]), null);
+    assert.equal(horizontalBbox([]), null);
+  });
+
+  it("returns null for a missing box", () => {
+    assert.equal(horizontalBbox(null), null);
+    assert.equal(horizontalBbox(undefined), null);
+  });
+});

--- a/tests/horizontal-bbox.test.ts
+++ b/tests/horizontal-bbox.test.ts
@@ -30,6 +30,12 @@ describe("horizontalBbox", () => {
     assert.equal(horizontalBbox([-78, Number.NaN, -77, 36]), null);
   });
 
+  it("returns null when only the altitudes are non-finite", () => {
+    // The horizontal values alone would pass, but a box whose altitudes are
+    // not finite is not one to trust the rest of.
+    assert.equal(horizontalBbox([-78, 35, Number.NaN, -77, 36, Number.POSITIVE_INFINITY]), null);
+  });
+
   it("returns null for a box of any other length", () => {
     assert.equal(horizontalBbox([-78, 35, -77]), null);
     assert.equal(horizontalBbox([]), null);

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -1396,4 +1396,29 @@ describe("processing registry", () => {
     assert.deepEqual(messages, ["Bounds: [-78.000000, 35.000000, -77.000000, 36.000000]"]);
     assert.deepEqual(fittedBounds, [-78, 35, -77, 36]);
   });
+
+  it("fits the horizontal extent of a layer whose bbox carries elevation", () => {
+    // A collection's own `bbox` member is returned verbatim, and RFC 7946 §5
+    // lets it hold six values. Read as four, the altitude would stand in for a
+    // longitude and the east edge for a latitude.
+    const messages: string[] = [];
+    let fittedBounds: [number, number, number, number] | null = null;
+
+    calculateBoundsAlgorithm.run({
+      layers: [
+        {
+          ...layer,
+          geojson: { ...(layer.geojson as FeatureCollection), bbox: [-78, 35, 0, -77, 36, 1200] },
+        },
+      ],
+      parameters: { layer: "layer-a" },
+      log: (message) => messages.push(message),
+      fitBounds: (bounds) => {
+        fittedBounds = bounds;
+      },
+    });
+
+    assert.deepEqual(messages, ["Bounds: [-78.000000, 35.000000, -77.000000, 36.000000]"]);
+    assert.deepEqual(fittedBounds, [-78, 35, -77, 36]);
+  });
 });

--- a/tests/statistics-tools.test.ts
+++ b/tests/statistics-tools.test.ts
@@ -240,6 +240,30 @@ describe("average nearest neighbor", () => {
     const { messages } = run(averageNearestNeighborTool, pointLayer([[0, 0, {}]]), {});
     assert.ok(messages.some((m) => m.includes("at least 2")));
   });
+
+  it("ignores an elevation-carrying bbox when measuring the study area", () => {
+    // A collection's own `bbox` member is taken verbatim, and RFC 7946 §5 lets
+    // it hold six values. Read as four, the study area would be measured over
+    // [west, south, minAltitude, east], so the same points would report a
+    // different ratio depending on whether the file declared its elevation.
+    const points: Array<[number, number, Record<string, unknown>]> = [];
+    for (let r = 0; r < 4; r++) {
+      for (let c = 0; c < 4; c++) points.push([c * 0.01, r * 0.01, {}]);
+    }
+    const flat = pointLayer(points);
+    const withElevation: GeoLibreLayer = {
+      ...flat,
+      geojson: {
+        ...(flat.geojson as FeatureCollection),
+        bbox: [0, 0, 120, 0.03, 0.03, 940],
+      },
+    };
+
+    assert.equal(
+      loggedNumber(run(averageNearestNeighborTool, withElevation, {}).messages, "NN ratio:"),
+      loggedNumber(run(averageNearestNeighborTool, flat, {}).messages, "NN ratio:"),
+    );
+  });
 });
 
 describe("kernel density", () => {


### PR DESCRIPTION
## What

Follow-up to #2358, as offered there. The same defect was latent at every other place that reads a
`bbox()` result as four values. This routes all of them — plus the inline reduction #2358 added, and
one the codebase had already written by hand — through a single shared helper.

## Why

`@turf/bbox` returns a collection's own `bbox` member verbatim rather than recomputing it, and
[RFC 7946 §5](https://datatracker.ietf.org/doc/html/rfc7946#section-5) lets that member carry
elevation, in which case it holds six values: `[west, south, minAltitude, east, north, maxAltitude]`.
Read as four, the altitude stands in for a longitude and the east edge for a latitude.

| Site | Consequence of a six-element box |
| --- | --- |
| `processing/registry.ts` — *Calculate layer bounds* | logs six numbers, then `fitBounds` throws, as in #2358 |
| `map/map-controller.ts` — `fitFeature` | same, for a collection carrying its own bbox |
| `processing/dggs-tools.ts` ×2 | the altitude becomes the east edge, so the DGGS cell area and the grid extent are computed over a nonsense box |
| `processing/vector-tools.ts` — grid generation | the `west >= east` guard compares a longitude against an altitude, so an invalid extent slips through |
| `processing/vector-tools.ts` — Voronoi / Delaunay | same, for the collinear-points guard |
| `processing/statistics-tools.ts` — average nearest neighbor | the study area is measured over `[west, south, minAltitude, east]`, so the NN ratio silently changes with the file's elevation |
| `processing/statistics-tools.ts` — kernel density | the KDE grid is built over that same box |

The last two destructure the result into four names without a type assertion, which is how they
escaped the first pass — thanks to the reviewer who spotted them.

## How

`horizontalBbox(box)` in `@geolibre/core` (next to the other Z-value helpers) validates the box —
four or six values, all finite — and returns `[west, south, east, north]`, or `null` when there is no
usable horizontal extent. An empty collection, or one whose features all have a null geometry,
bboxes to ±Infinity and so answers `null` too.

That check order is not new: the `bounding-box` branch of `map/derived-geometry.ts` already
validated every value before reducing to 2D, with a comment explaining why. It was the only place in
the repo that knew. It now calls the helper, so the knowledge lives in one place rather than two.

The `null` folds into each site's existing guard rather than adding new control flow: the processing
algorithms log their usual `Error: …` line and return, `fitFeature` skips the fit, and
`getLayerBounds` continues to the stored extent exactly as before. No call site keeps a type
assertion, and `bbox()` now has no consumer that reads its result positionally without going through
the helper.

## Tests

- `tests/horizontal-bbox.test.ts` covers the helper: 2D passthrough, the 3D reduction, non-finite
  horizontal values, non-finite *altitudes*, wrong lengths, and a missing box.
- `tests/processing.test.ts` — *Calculate layer bounds* on a layer whose collection carries
  `bbox: [-78, 35, 0, -77, 36, 1200]` logs and fits the horizontal extent. Fails on `main`.
- `tests/statistics-tools.test.ts` — *Average nearest neighbor* reports the same ratio for the same
  points with and without a 3D `bbox` member. Fails without this change.
- `tests/layer-bounds.test.ts` and `tests/derived-geometry.test.ts` are unchanged and still pass, so
  both behaviors that already existed survive the refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent handling of horizontal map extents across mapping and geospatial processing tools.
  - Three-dimensional GeoJSON bounding boxes now correctly ignore elevation when calculating map bounds.
  - Invalid or unusable extents are safely detected before map fitting, grid generation, and spatial analysis.

- **Bug Fixes**
  - Improved map fitting and processing for GeoJSON data containing elevation coordinates.
  - Prevented invalid, infinite, or malformed bounding boxes from producing incorrect results.

- **Tests**
  - Added coverage for valid, three-dimensional, missing, malformed, and non-finite bounding boxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->