### PR TITLE
fix(zarr): keep Zarr layers visible past zoom 12 on Mesa GPUs

### DIFF
--- a/patches/@carbonplan+zarr-layer+0.9.0.patch
+++ b/patches/@carbonplan+zarr-layer+0.9.0.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@carbonplan/zarr-layer/dist/index.js b/node_modules/@carbonplan/zarr-layer/dist/index.js
+index 9fc526c8..213a1f8b 100644
+--- a/node_modules/@carbonplan/zarr-layer/dist/index.js
++++ b/node_modules/@carbonplan/zarr-layer/dist/index.js
+@@ -2497,9 +2497,17 @@ function createShaderProgram(gl, options) {
+     scaleLoc: mustGetUniformLocation(gl, program, "scale"),
+     scaleXLoc: mustGetUniformLocation(gl, program, "scale_x"),
+     scaleYLoc: mustGetUniformLocation(gl, program, "scale_y"),
+-    shiftXLoc: mustGetUniformLocation(gl, program, "shift_x"),
+-    shiftYLoc: mustGetUniformLocation(gl, program, "shift_y"),
+-    worldXOffsetLoc: mustGetUniformLocation(gl, program, "u_worldXOffset"),
++    // In the source-projected flat (wgs84) shader gl_Position comes from
++    // u_anchor_clip + deltaClip, so shift_x/shift_y/u_worldXOffset only feed
++    // the v_mercatorPos varying, which the fragment shader never reads. Mesa
++    // (Intel/AMD/llvmpipe) eliminates that chain at link time and reports the
++    // uniforms inactive, which made mustGetUniformLocation throw on every
++    // frame from the moment the map left the globe transition, so the layer
++    // silently vanished at zoom >= 12 on those GPUs. A null location is a
++    // no-op for gl.uniform1f, so look these up without throwing.
++    shiftXLoc: gl.getUniformLocation(program, "shift_x"),
++    shiftYLoc: gl.getUniformLocation(program, "shift_y"),
++    worldXOffsetLoc: gl.getUniformLocation(program, "u_worldXOffset"),
+     // MapLibre modes use projectTile instead of matrix. The Mapbox flat
+     // source-projected (wgs84) shader uses u_eye_matrix, not matrix, so the
+     // compiler drops `matrix` there too — use the non-throwing lookup. All

--- a/scripts/apply-dependency-patches.mjs
+++ b/scripts/apply-dependency-patches.mjs
@@ -2,9 +2,10 @@ import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
 // Workspace-scoped production installs, such as the collaboration worker
-// image, do not install GeoLibre's raster dependencies. There is nothing to
-// patch in those trees, and asking patch-package to find @cogeotiff/core would
-// make an otherwise valid `npm ci --omit=dev` fail.
+// image, do not install the desktop app's dependencies (every patched package
+// is one of them). There is nothing to patch in those trees, and asking
+// patch-package to find @cogeotiff/core would make an otherwise valid
+// `npm ci --omit=dev` fail.
 if (!existsSync("node_modules/@cogeotiff/core/package.json")) {
   process.exit(0);
 }

--- a/tests/zarr-layer-patch.test.ts
+++ b/tests/zarr-layer-patch.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+// The patch in patches/@carbonplan+zarr-layer+0.9.0.patch (upstream:
+// carbonplan/zarr-layer#91) makes the renderer tolerate GPU drivers that
+// eliminate shift_x, shift_y and u_worldXOffset from the flat source-projected
+// shader. Mesa (Intel, AMD, llvmpipe) reports them inactive because they only
+// feed a varying the fragment shader never reads, and the unpatched
+// mustGetUniformLocation lookup threw on every frame once MapLibre left the
+// globe transition, so a Zarr layer vanished at zoom 12 and above (#2357).
+// The bundle keeps createShaderProgram private, so this pins the installed
+// source instead of exercising it.
+const bundle = readFileSync(fileURLToPath(import.meta.resolve("@carbonplan/zarr-layer")), "utf8");
+
+describe("@carbonplan/zarr-layer dependency patch", () => {
+  it("looks up the mercator-only uniforms without throwing", () => {
+    for (const name of ["shift_x", "shift_y", "u_worldXOffset"]) {
+      assert.ok(
+        bundle.includes(`gl.getUniformLocation(program, "${name}")`),
+        `${name} should use the non-throwing lookup`,
+      );
+      assert.ok(
+        !bundle.includes(`mustGetUniformLocation(gl, program, "${name}")`),
+        `${name} must not go through mustGetUniformLocation`,
+      );
+    }
+  });
+
+  it("still requires the uniforms every shader variant samples", () => {
+    assert.ok(bundle.includes('mustGetUniformLocation(gl, program, "opacity")'));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2357. A Zarr layer with a CRS disappeared on laptops with integrated graphics (Intel and AMD, Mesa drivers) as soon as the map left the globe transition: zoom 12 and above with the globe projection, and every zoom in plain Mercator. NVIDIA never showed it, which is why it did not reproduce until the run was forced onto Mesa.

## Root cause

`@carbonplan/zarr-layer` compiles its flat source-projected shader at that point. There `gl_Position` comes from `u_anchor_clip + deltaClip`, so `shift_x`, `shift_y` and `u_worldXOffset` only feed the `v_mercatorPos` varying, which the fragment shader never reads. Mesa eliminates that chain at link time and reports the three uniforms inactive; the renderer's strict `mustGetUniformLocation` then threw `Failed to get uniform location for shift_x` on every frame, the program was never cached, and MapLibre's frame loop swallowed the exception, so the layer silently stopped drawing with nothing in the UI. NVIDIA keeps the uniforms active.

Confirmed by dumping active uniforms in WebKitGTK on llvmpipe: the ECEF variant used below zoom 12 keeps all three, the flat variant compiled at zoom 12 loses them.

## Change

- Carry the upstream fix (carbonplan/zarr-layer#91) as a patch-package patch until a release ships it: look those three uniforms up with the non-throwing `gl.getUniformLocation`, as the renderer already does for `matrix` and `u_eye_matrix`. A null location is a no-op for `gl.uniform1f`.
- `tests/zarr-layer-patch.test.ts` pins the installed bundle so a dependency bump that silently drops the patch fails the suite (it fails against the pristine 0.9.0 bundle).
- Refresh the comment in `scripts/apply-dependency-patches.mjs` now that two app dependencies are patched.

Once the upstream release lands, bump `@carbonplan/zarr-layer` and delete the patch and the test.

## Verification

- Mesa llvmpipe in WebKitGTK (the Tauri engine), NOAA sample: before the patch the layer vanished at zoom 12.5 with `Failed to get uniform location for shift_x` thrown each frame; after it the layer renders at zoom 12.5 and 14 in globe and at 11.5 and 13 in Mercator with zero errors.
- NVIDIA GL in Chrome against the patched dev server: unchanged, renders at every zoom in both projections, also under mouse-wheel zoom at device scale factor 2.
- Dark theme (WebKit harness) and light theme (Chrome) covered by the two runs above.
- `npm run build`, the new test, and `pre-commit run --files` on the changed files pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for flat, source-projected rendering on GPU drivers that omit certain inactive shader uniforms.
  - Prevented shader initialization failures in affected rendering scenarios, helping layers display reliably across more hardware configurations.
  - Preserved required uniform handling for opacity and other active rendering properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->